### PR TITLE
Allow multiple ODataRoutePrefix attributes

### DIFF
--- a/OData/src/System.Web.OData/OData/Routing/Conventions/AttributeRoutingConvention.cs
+++ b/OData/src/System.Web.OData/OData/Routing/Conventions/AttributeRoutingConvention.cs
@@ -207,7 +207,7 @@ namespace System.Web.OData.Routing.Conventions
                     ILookup<string, HttpActionDescriptor> actionMapping = actionSelector.GetActionMapping(controller);
                     HttpActionDescriptor[] actions = actionMapping.SelectMany(a => a).ToArray();
  
-                    foreach (string prefix in AttributeRoutingConvention.GetODataRoutePrefixes(controller))
+                    foreach (string prefix in GetODataRoutePrefixes(controller))
                     {
                         foreach (HttpActionDescriptor action in actions)
                         {

--- a/OData/src/System.Web.OData/OData/Routing/Conventions/AttributeRoutingConvention.cs
+++ b/OData/src/System.Web.OData/OData/Routing/Conventions/AttributeRoutingConvention.cs
@@ -205,15 +205,17 @@ namespace System.Web.OData.Routing.Conventions
                 {
                     IHttpActionSelector actionSelector = controller.Configuration.Services.GetActionSelector();
                     ILookup<string, HttpActionDescriptor> actionMapping = actionSelector.GetActionMapping(controller);
-                    IEnumerable<HttpActionDescriptor> actions = actionMapping.SelectMany(a => a);
-                    string prefix = GetODataRoutePrefix(controller);
-
-                    foreach (HttpActionDescriptor action in actions)
+                    HttpActionDescriptor[] actions = actionMapping.SelectMany(a => a).ToArray();
+ 
+                    foreach (string prefix in AttributeRoutingConvention.GetODataRoutePrefixes(controller))
                     {
-                        IEnumerable<ODataPathTemplate> pathTemplates = GetODataPathTemplates(prefix, action);
-                        foreach (ODataPathTemplate pathTemplate in pathTemplates)
+                        foreach (HttpActionDescriptor action in actions)
                         {
-                            attributeMappings.Add(pathTemplate, action);
+                            IEnumerable<ODataPathTemplate> pathTemplates = GetODataPathTemplates(prefix, action);
+                            foreach (ODataPathTemplate pathTemplate in pathTemplates)
+                            {
+                                attributeMappings.Add(pathTemplate, action);
+                            }
                         }
                     }
                 }
@@ -227,25 +229,34 @@ namespace System.Web.OData.Routing.Conventions
             return typeof(ODataController).IsAssignableFrom(controller.ControllerType);
         }
 
-        private static string GetODataRoutePrefix(HttpControllerDescriptor controllerDescriptor)
+        private static IEnumerable<string> GetODataRoutePrefixes(HttpControllerDescriptor controllerDescriptor)
         {
             Contract.Assert(controllerDescriptor != null);
 
-            string prefix = controllerDescriptor.GetCustomAttributes<ODataRoutePrefixAttribute>(inherit: false)
-                .Select(prefixAttribute => prefixAttribute.Prefix)
-                .SingleOrDefault();
-
-            if (prefix != null && prefix.StartsWith("/", StringComparison.Ordinal))
+            var prefixAttributes = controllerDescriptor.GetCustomAttributes<ODataRoutePrefixAttribute>(inherit: false);
+            if (prefixAttributes.Count == 0)
             {
-                throw Error.InvalidOperation(SRResources.RoutePrefixStartsWithSlash, prefix, controllerDescriptor.ControllerType.FullName);
+                yield return null;
             }
-
-            if (prefix != null && prefix.EndsWith("/", StringComparison.Ordinal))
+            else
             {
-                prefix = prefix.TrimEnd('/');
-            }
+                foreach (ODataRoutePrefixAttribute prefixAttribute in prefixAttributes)
+                {
+                    string prefix = prefixAttribute.Prefix;
 
-            return prefix;
+                    if (prefix != null && prefix.StartsWith("/", StringComparison.Ordinal))
+                    {
+                        throw Error.InvalidOperation(SRResources.RoutePrefixStartsWithSlash, prefix, controllerDescriptor.ControllerType.FullName);
+                    }
+
+                    if (prefix != null && prefix.EndsWith("/", StringComparison.Ordinal))
+                    {
+                        prefix = prefix.TrimEnd('/');
+                    }
+
+                    yield return prefix;
+                }
+            }
         }
 
         private IEnumerable<ODataPathTemplate> GetODataPathTemplates(string prefix, HttpActionDescriptor action)

--- a/OData/src/System.Web.OData/OData/Routing/ODataRoutePrefixAttribute.cs
+++ b/OData/src/System.Web.OData/OData/Routing/ODataRoutePrefixAttribute.cs
@@ -8,7 +8,7 @@ namespace System.Web.OData.Routing
     /// Represents an attribute that can be placed on an OData controller to specify
     /// the prefix that will be used for all actions of that controller.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public sealed class ODataRoutePrefixAttribute : Attribute
     {
         /// <summary>

--- a/OData/test/System.Web.OData.Test/OData/Routing/Conventions/AttributeRoutingConventionTest.cs
+++ b/OData/test/System.Web.OData.Test/OData/Routing/Conventions/AttributeRoutingConventionTest.cs
@@ -161,6 +161,10 @@ namespace System.Web.OData.Routing.Conventions
         [InlineData(typeof(SingletonTestControllerWithPrefix), "VipCustomer", "GetVipCustomerWithPrefix")] // Singleton
         [InlineData(typeof(SingletonTestControllerWithPrefix), "VipCustomer/Name", "GetVipCustomerNameWithPrefix")] // Singleton/property
         [InlineData(typeof(SingletonTestControllerWithPrefix), "VipCustomer/Orders", "GetVipCustomerOrdersWithPrefix")] // Singleton/Navigation
+        [InlineData(typeof(TestODataControllerWithMultiplePrefixes), "Customers({key})", "GetCustomer")]
+        [InlineData(typeof(TestODataControllerWithMultiplePrefixes), "Customers({key})/Orders", "GetOrdersOfACustomer")]
+        [InlineData(typeof(TestODataControllerWithMultiplePrefixes), "VipCustomer", "GetCustomer")]
+        [InlineData(typeof(TestODataControllerWithMultiplePrefixes), "VipCustomer/Orders", "GetOrdersOfACustomer")]
         public void AttributeMappingsIsInitialized_WithRightActionAndTemplate(Type controllerType,
             string expectedPathTemplate, string expectedActionName)
         {
@@ -292,6 +296,21 @@ namespace System.Web.OData.Routing.Conventions
 
             [ODataRoute("/Customers")]
             public void GetCustomers()
+            {
+            }
+        }
+
+        [ODataRoutePrefix("Customers({key})")]
+        [ODataRoutePrefix("VipCustomer")]
+        public class TestODataControllerWithMultiplePrefixes : ODataController
+        {
+            [ODataRoute("Orders")]
+            public void GetOrdersOfACustomer()
+            {
+            }
+
+            [ODataRoute("")]
+            public void GetCustomer()
             {
             }
         }


### PR DESCRIPTION
OneDrive has scenarios where it exposes objects of the same type at different points in the model. Since the actions that can be performed on the objects are the same irrespective of location we're currently decorating the action methods with a number of almost identical ODataRoute attributes, where the only real difference is prefix. Instead we'd like to define all the applicable prefixes at the controller level, and just decorate the actions with a single ODataRoute that identifies when the action should trigger for the object represented by the controller.