### PR TITLE
Issue #231: DeleteRef fails if navigation property is derived type and there is no corresponding entity set 

### DIFF
--- a/OData/src/System.Web.OData/OData/Routing/DefaultODataPathHandler.cs
+++ b/OData/src/System.Web.OData/OData/Routing/DefaultODataPathHandler.cs
@@ -193,7 +193,9 @@ namespace System.Web.OData.Routing
 
                     if (exceptionThrown ||
                         (entityIdSegment != null &&
-                            (id == null || !id.EdmType.IsOrInheritsFrom(lastSegmentEdmType.ElementType.Definition))))
+                            (id == null ||
+                                !(id.EdmType.IsOrInheritsFrom(lastSegmentEdmType.ElementType.Definition) ||
+                                  lastSegmentEdmType.ElementType.Definition.IsOrInheritsFrom(id.EdmType)))))
                     {
                         throw new ODataException(Error.Format(SRResources.InvalidDollarId, queryString.Get("$id")));
                     }

--- a/OData/test/System.Web.OData.Test/OData/Routing/ODataRoutingModel.cs
+++ b/OData/test/System.Web.OData.Test/OData/Routing/ODataRoutingModel.cs
@@ -23,7 +23,6 @@ namespace System.Web.OData.Routing
             ODataConventionModelBuilder builder = new ODataConventionModelBuilder(configuration);
             builder.EntitySet<RoutingCustomer>("RoutingCustomers");
             builder.EntitySet<Product>("Products");
-            builder.EntitySet<SpecialProduct>("SpecialProducts");
             builder.EntitySet<SalesPerson>("SalesPeople");
             builder.EntitySet<EmailAddress>("EmailAddresses");
             builder.EntitySet<üCategory>("üCategories");
@@ -31,6 +30,7 @@ namespace System.Web.OData.Routing
             builder.Singleton<RoutingCustomer>("VipCustomer");
             builder.Singleton<Product>("MyProduct");
             builder.EntitySet<DateTimeOffsetKeyCustomer>("DateTimeOffsetKeyCustomers");
+            builder.EntitySet<Destination>("Destinations");
             builder.ComplexType<Dog>();
             builder.ComplexType<Cat>();
 
@@ -189,11 +189,11 @@ namespace System.Web.OData.Routing
             overloadUnboundFunction.Parameter<int>("P2");
             overloadUnboundFunction.Parameter<string>("P3");
 
-            var functionWithComplexTypeParameter =
+            var functionWithComplexTypeParameter = 
                 builder.EntityType<RoutingCustomer>().Function("CanMoveToAddress").Returns<bool>();
             functionWithComplexTypeParameter.Parameter<Address>("address");
 
-            var functionWithCollectionOfComplexTypeParameter =
+            var functionWithCollectionOfComplexTypeParameter = 
                 builder.EntityType<RoutingCustomer>().Function("MoveToAddresses").Returns<bool>();
             functionWithCollectionOfComplexTypeParameter.CollectionParameter<Address>("addresses");
 
@@ -237,6 +237,7 @@ namespace System.Web.OData.Routing
             public int ID { get; set; }
             public string Name { get; set; }
             public virtual List<Product> Products { get; set; }
+            public virtual List<SpecialProduct> SpecialProducts { get; set; }
             public Address Address { get; set; }
             public Pet Pet { get; set; }
         }
@@ -323,6 +324,18 @@ namespace System.Web.OData.Routing
         public class DateTimeOffsetKeyCustomer
         {
             public DateTimeOffset ID { get; set; }
+        }
+
+        public class Destination
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public virtual List<DestinationGroup> Parents { get; set; }
+        }
+
+        public class DestinationGroup : Destination
+        {
+            public virtual List<Destination> Children { get; set; }
         }
     }
 }

--- a/OData/test/System.Web.OData.Test/OData/Routing/ODataRoutingModel.cs
+++ b/OData/test/System.Web.OData.Test/OData/Routing/ODataRoutingModel.cs
@@ -189,11 +189,11 @@ namespace System.Web.OData.Routing
             overloadUnboundFunction.Parameter<int>("P2");
             overloadUnboundFunction.Parameter<string>("P3");
 
-            var functionWithComplexTypeParameter = 
+            var functionWithComplexTypeParameter =
                 builder.EntityType<RoutingCustomer>().Function("CanMoveToAddress").Returns<bool>();
             functionWithComplexTypeParameter.Parameter<Address>("address");
 
-            var functionWithCollectionOfComplexTypeParameter = 
+            var functionWithCollectionOfComplexTypeParameter =
                 builder.EntityType<RoutingCustomer>().Function("MoveToAddresses").Returns<bool>();
             functionWithCollectionOfComplexTypeParameter.CollectionParameter<Address>("addresses");
 

--- a/OData/test/System.Web.OData.Test/OData/Routing/ODataRoutingTest.cs
+++ b/OData/test/System.Web.OData.Test/OData/Routing/ODataRoutingTest.cs
@@ -293,7 +293,8 @@ namespace System.Web.OData.Routing
         }
 
         [Theory]
-        [InlineData("DELETE", "RoutingCustomers(1)/Products/$ref?$id=http://localhost/MyRoot/odata/SpecialProducts(5)")]
+        [InlineData("DELETE", "RoutingCustomers(1)/SpecialProducts/$ref?$id=http://localhost/MyRoot/odata/Products(5)")]
+        [InlineData("DELETE", "Destinations(1)/Parents/$ref?$id=http://localhost/MyRoot/odata/Destinations(5)")]
         public async Task RoutesCorrectly_DeleteRefWithDerivedNavigationProperty(string httpMethod, string uri)
         {
             // Arrange & Act
@@ -360,7 +361,8 @@ namespace System.Web.OData.Routing
                 typeof(MetadataController),
                 typeof(RoutingCustomersController),
                 typeof(ProductsController),
-                typeof(EnumCustomersController)
+                typeof(EnumCustomersController),
+                typeof(DestinationsController)
             };
 
             TestAssemblyResolver resolver = new TestAssemblyResolver(new MockAssembly(controllers));
@@ -479,7 +481,11 @@ namespace System.Web.OData.Routing
         {
             return "GetProducts";
         }
-
+        [AcceptVerbs("POST")]
+        public string GetSpecialProducts()
+        {
+            return "GetSpecialProducts";
+        }
         [AcceptVerbs("POST")]
         public string GetMostProfitableOnCollectionOfVIP()
         {
@@ -621,6 +627,30 @@ namespace System.Web.OData.Routing
         public string TopProductOfAllByCityAndModel(string city, int model)
         {
             return String.Format(CultureInfo.InvariantCulture, "TopProductOfAllByCityAndModel({0}, {1})", city, model);
+        }
+    }
+
+    public class DestinationsController : ODataController
+    {
+        public string Get(int key)
+        {
+            return String.Format(CultureInfo.InvariantCulture, "Get({0})", key);
+        }
+
+        [AcceptVerbs("POST", "PUT")]
+        public string CreateRef(int key, string navigationProperty)
+        {
+            return String.Format(CultureInfo.InvariantCulture, "CreateRef({0})({1})", key, navigationProperty);
+        }
+
+        public string DeleteRef(int key, string navigationProperty)
+        {
+            return String.Format(CultureInfo.InvariantCulture, "DeleteRef({0})({1})", key, navigationProperty);
+        }
+
+        public string DeleteRef(int key, int relatedKey, string navigationProperty)
+        {
+            return String.Format(CultureInfo.InvariantCulture, "DeleteRef({0})({1})({2})", key, relatedKey, navigationProperty);
         }
     }
 

--- a/OData/test/System.Web.OData.Test/OData/Routing/ODataRoutingTest.cs
+++ b/OData/test/System.Web.OData.Test/OData/Routing/ODataRoutingTest.cs
@@ -481,6 +481,7 @@ namespace System.Web.OData.Routing
         {
             return "GetProducts";
         }
+
         [AcceptVerbs("POST")]
         public string GetSpecialProducts()
         {


### PR DESCRIPTION
DELETE RoutingCustomers(1)/SpecialProducts/$ref?$id=http://localhost/Products(5) will work after this fix
Modify the original test case to cover those two sittuations