### PR TITLE
Allow null dynamic property values in serialized open types

### DIFF
--- a/OData/test/System.Web.OData.Test/OData/Formatter/Serialization/ODataComplexTypeSerializerTests.cs
+++ b/OData/test/System.Web.OData.Test/OData/Formatter/Serialization/ODataComplexTypeSerializerTests.cs
@@ -203,6 +203,7 @@ namespace System.Web.OData.Formatter.Serialization
             address.Properties.Add("GuidProperty", new Guid("181D3A20-B41A-489F-9F15-F91F0F6C9ECA"));
             address.Properties.Add("DoubleProperty", 99.109);
             address.Properties.Add("DateTimeProperty", new DateTime(2014, 10, 27));
+            address.Properties.Add("NullableProperty", null);
 
             // Act
             var odataValue = serializer.CreateODataComplexValue(address, addressTypeRef, context);
@@ -211,7 +212,7 @@ namespace System.Web.OData.Formatter.Serialization
             ODataComplexValue complexValue = Assert.IsType<ODataComplexValue>(odataValue);
 
             Assert.Equal(complexValue.TypeName, "Default.Address");
-            Assert.Equal(6, complexValue.Properties.Count());
+            Assert.Equal(7, complexValue.Properties.Count());
 
             // Verify the declared properties
             ODataProperty street = Assert.Single(complexValue.Properties.Where(p => p.Name == "Street"));
@@ -231,6 +232,9 @@ namespace System.Web.OData.Formatter.Serialization
 
             ODataProperty doubleProperty = Assert.Single(complexValue.Properties.Where(p => p.Name == "DoubleProperty"));
             Assert.Equal(99.109, doubleProperty.Value);
+
+            ODataProperty nullableProperty = Assert.Single(complexValue.Properties.Where(p => p.Name == "NullableProperty"));
+            Assert.Null(nullableProperty.Value);
 
             ODataProperty dateTimeProperty =
                 Assert.Single(complexValue.Properties.Where(p => p.Name == "DateTimeProperty"));

--- a/OData/test/System.Web.OData.Test/OData/Formatter/Serialization/ODataEntityTypeSerializerTests.cs
+++ b/OData/test/System.Web.OData.Test/OData/Formatter/Serialization/ODataEntityTypeSerializerTests.cs
@@ -832,6 +832,7 @@ namespace System.Web.OData.Formatter.Serialization
             customer.CustomerProperties.Add("GuidProperty", new Guid("181D3A20-B41A-489F-9F15-F91F0F6C9ECA"));
             customer.CustomerProperties.Add("ListProperty", new List<int>{5,4,3,2,1});
             customer.CustomerProperties.Add("DateTimeProperty", new DateTime(2014, 10, 24));
+            customer.CustomerProperties.Add("NullableProperty", null);
 
             EntityInstanceContext entityInstanceContext = new EntityInstanceContext(writeContext,
                 customerType.ToEdmTypeReference(false) as IEdmEntityTypeReference, customer);
@@ -841,7 +842,7 @@ namespace System.Web.OData.Formatter.Serialization
 
             // Assert
             Assert.Equal(entry.TypeName, "Default.Customer");
-            Assert.Equal(7, entry.Properties.Count());
+            Assert.Equal(8, entry.Properties.Count());
 
             // Verify the declared properties
             ODataProperty street = Assert.Single(entry.Properties.Where(p => p.Name == "CustomerId"));
@@ -876,6 +877,9 @@ namespace System.Web.OData.Formatter.Serialization
 
             ODataProperty dateTimeProperty = Assert.Single(entry.Properties.Where(p => p.Name == "DateTimeProperty"));
             Assert.Equal(new DateTimeOffset(new DateTime(2014, 10, 24)), dateTimeProperty.Value);
+
+            ODataProperty nullableProperty = Assert.Single(entry.Properties.Where(p => p.Name == "NullableProperty"));
+            Assert.Null(nullableProperty.Value);
         }
 
         [Fact]


### PR DESCRIPTION
Description: there is currently no way to serialize an open propery with a null value ("MyNullProperty" : null). There can be semantic differences between absent properties and null-valued properties, and it should be possible to represent both. This changeset serializes null values as ODataNullValue instances.

Issue: https://github.com/OData/WebApi/issues/312

