### PR TITLE
Write nextpagelink/count if they can be retrieved from the current reque...

### DIFF
--- a/OData/src/System.Web.Http.OData/OData/Formatter/Serialization/ODataCollectionSerializer.cs
+++ b/OData/src/System.Web.Http.OData/OData/Formatter/Serialization/ODataCollectionSerializer.cs
@@ -10,6 +10,8 @@ using Microsoft.Data.OData;
 
 namespace System.Web.Http.OData.Formatter.Serialization
 {
+    using Extensions;
+
     /// <summary>
     /// ODataSerializer for serializing collection of Entities or Complex types or primitives.
     /// </summary>
@@ -85,10 +87,20 @@ namespace System.Web.Http.OData.Formatter.Serialization
                 throw Error.ArgumentNull("writer");
             }
 
+            ODataCollectionStart collectionStart = new ODataCollectionStart { Name = writeContext.RootElementName };
+            if (writeContext.Request.ODataProperties().NextLink != null)
+            {
+                collectionStart.NextPageLink = writeContext.Request.ODataProperties().NextLink;
+            }
+
+            if (writeContext.Request.ODataProperties().TotalCount.HasValue)
+            {
+                collectionStart.Count = writeContext.Request.ODataProperties().TotalCount;
+            }
+
+            writer.WriteStart(collectionStart);
+
             ODataCollectionValue collectionValue = CreateODataValue(graph, collectionType, writeContext) as ODataCollectionValue;
-
-            writer.WriteStart(new ODataCollectionStart { Name = writeContext.RootElementName });
-
             if (collectionValue != null)
             {
                 foreach (object item in collectionValue.Items)


### PR DESCRIPTION
This change is the second part to fix the issue (https://github.com/OData/odata.net/issues/140). In this change, the ODataCollectionSerializer will construct the ODataCollectionStart object by assigning the nextPageLink and count retrieved from the Request.ODataProperties().

After that, write.WriteStart() method will trigger the underlying writer to have those properties properly written to response. 

This pull request has a dependency on the other request (https://github.com/OData/odata.net/pull/166). The checkin can only happen after pull request #166 gets submitted and new OData core library becomes available.
