### PR TITLE
Add E2E tests for unqualified name call support on ODataRoute.

### DIFF
--- a/OData/test/E2ETest/WebStack.QA.Test.OData/Routing/UnqualifiedNameCallRoutingTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/Routing/UnqualifiedNameCallRoutingTests.cs
@@ -1,0 +1,82 @@
+﻿using System.Net.Http;
+using System.Web.Http;
+using System.Web.Http.Dispatcher;
+using System.Web.OData;
+using System.Web.OData.Builder;
+using System.Web.OData.Extensions;
+using System.Web.OData.Routing;
+using Microsoft.OData.Edm;
+using Newtonsoft.Json.Linq;
+using Nuwa;
+using WebStack.QA.Test.OData.Common;
+using Xunit;
+using Xunit.Extensions;
+
+namespace WebStack.QA.Test.OData.Routing
+{
+    [NuwaFramework]
+    [NwHost(HostType.KatanaSelf)]
+    public class UnqualifiedNameCallRoutingTests
+    {
+        [NuwaBaseAddress]
+        public string BaseAddress { get; set; }
+
+        [NuwaHttpClient]
+        public HttpClient Client { get; set; }
+
+        [NuwaConfiguration]
+        public static void UpdateConfiguration(HttpConfiguration config)
+        {
+            var controllers = new[] { typeof(UnqualifiedCarsController) };
+            TestAssemblyResolver resolver = new TestAssemblyResolver(new TypesInjectionAssembly(controllers));
+
+            config.Services.Replace(typeof(IAssembliesResolver), resolver);
+            config.Routes.Clear();
+            config.EnableUnqualifiedNameCall(true);
+            config.MapODataServiceRoute("odata", "odata", GetModel());
+             config.EnsureInitialized();
+        }
+
+        private static IEdmModel GetModel()
+        {
+            ODataModelBuilder builder = new ODataConventionModelBuilder();
+            EntitySetConfiguration<UnqualifiedCar> cars = builder.EntitySet<UnqualifiedCar>("UnqualifiedCars");
+            cars.EntityType.Action("Wash").Returns<string>();
+            cars.EntityType.Collection.Action("Wash").Returns<string>();
+            return builder.GetEdmModel();
+        }
+
+        [Theory]
+        [InlineData("/odata/UnqualifiedCars(5)/Wash", "WashSingle5")]
+        [InlineData("/odata/UnqualifiedCars/Wash", "WashCollection")]
+        public void CanCallActionWithUnqualifiedRouteName(string url, string expectedResult)
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, BaseAddress + url);
+            HttpResponseMessage response = Client.SendAsync(request).Result;
+            Assert.NotNull(response);
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.NotNull(response.Content);
+            Assert.Equal(expectedResult, (string)response.Content.ReadAsAsync<JObject>().Result["value"]);
+        }
+    }
+
+    public class UnqualifiedCarsController : ODataController
+    {
+        [ODataRoute("UnqualifiedCars({key})/Wash")]
+        public IHttpActionResult WashSingle([FromODataUri]int key)
+        {
+            return Ok("WashSingle" + key);
+        }
+
+        [ODataRoute("UnqualifiedCars/Wash")]
+        public IHttpActionResult WashOnCollection()
+        {
+            return Ok("WashCollection");
+        }
+    }
+
+    public class UnqualifiedCar
+    {
+        public int Id { get; set; }
+    }
+}

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
@@ -859,6 +859,7 @@
     <Compile Include="Routing\RefRoutingConventionTests.cs" />
     <Compile Include="Routing\ODataRouteTests.cs" />
     <Compile Include="Routing\ODataValueProviderTests.cs" />
+    <Compile Include="Routing\UnqualifiedNameCallRoutingTests.cs" />
     <Compile Include="BoundOperation\BoundOperationController.cs" />
     <Compile Include="BoundOperation\BoundOperationDataModel.cs" />
     <Compile Include="BoundOperation\BoundOperationEdmModel.cs" />


### PR DESCRIPTION
E2E tests for https://github.com/OData/WebApi/commit/68c56e30e5a1e839eec343d60d7b5f58088335c1