### PR TITLE
Navigation link generation for contained navigations

### DIFF
--- a/OData/src/System.Web.OData/OData/Builder/LinkGenerationHelpers.cs
+++ b/OData/src/System.Web.OData/OData/Builder/LinkGenerationHelpers.cs
@@ -223,6 +223,8 @@ namespace System.Web.OData.Builder
                             currentNavigationSource = navigationPathSegment.GetNavigationSource(previousNavigationSource);
                         }
 
+                        odataPath.Add(pathSegment);
+
                         // If we've found our target navigation in the path that means we've correctly populated the
                         // segments up to the navigation and we can ignore the remaining segments.
                         if (currentNavigationSource != null)
@@ -234,26 +236,10 @@ namespace System.Web.OData.Builder
                                 break;
                             }
                         }
-
-                        odataPath.Add(pathSegment);
                     }
                 }
 
-                if (segmentFound)
-                {
-                    if (odataPath.Count == 0)
-                    {
-                        // If we found our desired navigation source right at the beginning we need to make sure it
-                        // manifests as an EntitySetSegment.
-                        odataPath.Add(new EntitySetPathSegment((IEdmEntitySetBase)entityContext.NavigationSource));
-                    }
-                    else
-                    {
-                        // Otherwise add it as a NavigationPathSegment.
-                        odataPath.Add(new NavigationPathSegment(entityContext.NavigationSource.Name));
-                    }
-                }
-                else
+                if (!segmentFound)
                 {
                     // If the target navigation was not found in the current path that means we lack any context that
                     // would suggest a scenario other than directly accessing an entity set, so we must assume that's

--- a/OData/src/System.Web.OData/OData/Builder/LinkGenerationHelpers.cs
+++ b/OData/src/System.Web.OData/OData/Builder/LinkGenerationHelpers.cs
@@ -195,11 +195,73 @@ namespace System.Web.OData.Builder
 
             if (entityContext.NavigationSource.NavigationSourceKind() == EdmNavigationSourceKind.Singleton)
             {
+                // Per the OData V4 specification, a singleton is expected to be a child of the entity container, and
+                // as a result we can make the assumption that it is the only segment in the generated path.
                 odataPath.Add(new SingletonPathSegment((IEdmSingleton)entityContext.NavigationSource));
             }
             else
             {
-                odataPath.Add(new EntitySetPathSegment((IEdmEntitySetBase)entityContext.NavigationSource));
+                // If the navigation is not a singleton we need to walk all of the path segments to generate a
+                // contextually accurate URI.
+                bool segmentFound = false;
+                if (entityContext.SerializerContext.Path != null)
+                {
+                    IEdmNavigationSource previousNavigationSource = null;
+                    foreach (ODataPathSegment pathSegment in entityContext.SerializerContext.Path.Segments)
+                    {
+                        IEdmNavigationSource currentNavigationSource = null;
+
+                        var entitySetPathSegment = pathSegment as EntitySetPathSegment;
+                        if (entitySetPathSegment != null)
+                        {
+                            currentNavigationSource = entitySetPathSegment.EntitySetBase;
+                        }
+
+                        var navigationPathSegment = pathSegment as NavigationPathSegment;
+                        if (navigationPathSegment != null)
+                        {
+                            currentNavigationSource = navigationPathSegment.GetNavigationSource(previousNavigationSource);
+                        }
+
+                        // If we've found our target navigation in the path that means we've correctly populated the
+                        // segments up to the navigation and we can ignore the remaining segments.
+                        if (currentNavigationSource != null)
+                        {
+                            previousNavigationSource = currentNavigationSource;
+                            if (currentNavigationSource == entityContext.NavigationSource)
+                            {
+                                segmentFound = true;
+                                break;
+                            }
+                        }
+
+                        odataPath.Add(pathSegment);
+                    }
+                }
+
+                if (segmentFound)
+                {
+                    if (odataPath.Count == 0)
+                    {
+                        // If we found our desired navigation source right at the beginning we need to make sure it
+                        // manifests as an EntitySetSegment.
+                        odataPath.Add(new EntitySetPathSegment((IEdmEntitySetBase)entityContext.NavigationSource));
+                    }
+                    else
+                    {
+                        // Otherwise add it as a NavigationPathSegment.
+                        odataPath.Add(new NavigationPathSegment(entityContext.NavigationSource.Name));
+                    }
+                }
+                else
+                {
+                    // If the target navigation was not found in the current path that means we lack any context that
+                    // would suggest a scenario other than directly accessing an entity set, so we must assume that's
+                    // the case.
+                    odataPath.Clear();
+                    odataPath.Add(new EntitySetPathSegment((IEdmEntitySetBase)entityContext.NavigationSource));
+                }
+
                 odataPath.Add(new KeyValuePathSegment(ConventionsHelpers.GetEntityKeyValue(entityContext)));
             }
 


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/OData/WebApi/issues/195 whereby the current code assumes all navigations are for entity sets. The change proposes to use the provided path to give a contextually accurate URI, and to fall back to the old behavior if no relevant context is found.