### PR TITLE
Making ODataQueryOptions.GetNextPageLink public.

### DIFF
--- a/OData/src/System.Web.OData/OData/Query/ODataQueryOptions.cs
+++ b/OData/src/System.Web.OData/OData/Query/ODataQueryOptions.cs
@@ -516,11 +516,19 @@ namespace System.Web.OData.Query
         /// <returns>A next page link.</returns>
         public static Uri GetNextPageLink(HttpRequestMessage request, int pageSize)
         {
-            Contract.Assert(request != null);
-            Contract.Assert(request.RequestUri != null);
-            Contract.Assert(request.RequestUri.IsAbsoluteUri);
+            if (request == null || request.RequestUri == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
 
-            return GetNextPageLink(request.RequestUri, request.GetQueryNameValuePairs(), pageSize);
+            Uri requestUri = request.RequestUri;
+
+            if (!requestUri.IsAbsoluteUri)
+            {
+                throw Error.ArgumentUriNotAbsolute("request", requestUri);
+            }
+
+            return GetNextPageLink(requestUri, request.GetQueryNameValuePairs(), pageSize);
         }
 
         internal static Uri GetNextPageLink(Uri requestUri, int pageSize)

--- a/OData/src/System.Web.OData/OData/Query/ODataQueryOptions.cs
+++ b/OData/src/System.Web.OData/OData/Query/ODataQueryOptions.cs
@@ -508,7 +508,13 @@ namespace System.Web.OData.Query
             return truncatedCollection.AsQueryable();
         }
 
-        internal static Uri GetNextPageLink(HttpRequestMessage request, int pageSize)
+        /// <summary>
+        /// Creates a link for the next page of results; To be used as the value of @odata.nextLink.
+        /// </summary>
+        /// <param name="request">The request on which to base the next page link.</param>
+        /// <param name="pageSize">The number of results allowed per page.</param>
+        /// <returns>A next page link.</returns>
+        public static Uri GetNextPageLink(HttpRequestMessage request, int pageSize)
         {
             Contract.Assert(request != null);
             Contract.Assert(request.RequestUri != null);

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/ODataQueryOptionTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/ODataQueryOptionTest.cs
@@ -748,6 +748,24 @@ namespace System.Web.OData.Query
         }
 
         [Fact]
+        public void GetNextPageLink_WithNullRequestOrUri_Throws()
+        {
+            HttpRequestMessage nullRequest = null;
+            Assert.Throws<ArgumentNullException>(() => { ODataQueryOptions.GetNextPageLink(nullRequest, 10); });
+
+            HttpRequestMessage requestWithNullUri = new HttpRequestMessage() { RequestUri = null };
+            Assert.Throws<ArgumentNullException>(() => { ODataQueryOptions.GetNextPageLink(requestWithNullUri, 10); });
+        }
+
+        [Fact]
+        public void GetNextPageLink_WithRelativeUri_Throws()
+        {
+            Uri relativeUri = new Uri("/test", UriKind.Relative);
+            HttpRequestMessage requestWithRelativeUri = new HttpRequestMessage() { RequestUri = relativeUri };
+            Assert.Throws<ArgumentException>(() => { ODataQueryOptions.GetNextPageLink(requestWithRelativeUri, 10); });
+        }
+
+        [Fact]
         public void CanTurnOffAllValidation()
         {
             // Arrange


### PR DESCRIPTION
This will be useful for anyone processing OData query options directly (i.e. -- not using LINQ and ApplyTo()).