### PR TITLE
Checking propetry for null changed from Or to OrElse

### DIFF
--- a/OData/src/System.Web.Http.OData/OData/Query/Expressions/FilterBinder.cs
+++ b/OData/src/System.Web.Http.OData/OData/Query/Expressions/FilterBinder.cs
@@ -1250,7 +1250,7 @@ namespace System.Web.Http.OData.Query.Expressions
             if (arguments.Any())
             {
                 return arguments
-                    .Aggregate((left, right) => Expression.Or(left, right));
+                    .Aggregate((left, right) => Expression.OrElse(left, right));
             }
             else
             {

--- a/OData/src/System.Web.OData/OData/Query/Expressions/FilterBinder.cs
+++ b/OData/src/System.Web.OData/OData/Query/Expressions/FilterBinder.cs
@@ -1779,7 +1779,7 @@ namespace System.Web.OData.Query.Expressions
             if (arguments.Any())
             {
                 return arguments
-                    .Aggregate((left, right) => Expression.Or(left, right));
+                    .Aggregate((left, right) => Expression.OrElse(left, right));
             }
             else
             {

--- a/OData/test/UnitTest/System.Web.Http.OData.Test/OData/Query/Expressions/FilterBinderTests.cs
+++ b/OData/test/UnitTest/System.Web.Http.OData.Test/OData/Query/Expressions/FilterBinderTests.cs
@@ -408,6 +408,18 @@ namespace System.Web.Http.OData.Query.Expressions
                 new Product { UnitsInStock = ToNullable<short>(unitsInStock) },
                 new { WithNullPropagation = withNullPropagation, WithoutNullPropagation = withoutNullPropagation });
         }
+
+
+        [Theory]
+        [InlineData("Abcd", true, true)]
+        public void NullHandling_StringFunctionWithStringParameret(string productName, bool withNullPropagation, object withoutNullPropagation)
+        {
+            var filters = VerifyQueryDeserialization(
+                "startswith(ProductName, 'Abc')",
+                NotTesting,
+                "$it => (IIF((($it.ProductName == null) OrElse (\"Abc\" == null)), null, Convert($it.ProductName.StartsWith(\"Abc\"))) == True)");
+        }
+
         #endregion
 
         [Theory]

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/FilterBinderTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/FilterBinderTests.cs
@@ -408,6 +408,16 @@ namespace System.Web.OData.Query.Expressions
                 new Product { UnitsInStock = ToNullable<short>(unitsInStock) },
                 new { WithNullPropagation = withNullPropagation, WithoutNullPropagation = withoutNullPropagation });
         }
+
+        [Theory]
+        [InlineData("Abcd", true, true)]
+        public void NullHandling_StringFunctionWithStringParameret(string productName, bool withNullPropagation, object withoutNullPropagation)
+        {
+            var filters = VerifyQueryDeserialization(
+                "startswith(ProductName, 'Abc')",
+                NotTesting,
+                "$it => (IIF((($it.ProductName == null) OrElse (\"Abc\" == null)), null, Convert($it.ProductName.StartsWith(\"Abc\"))) == True)");
+        }
         #endregion
 
         [Theory]


### PR DESCRIPTION
Checking propetry for null chanaged from "($it.Property == null) | false" (bitwise OR) to "($it.Property == null) || false" (logical OR).