### PR TITLE
Manually using ODataQueryOptions.Validate and setting SelectExpandQue…

### DIFF
--- a/OData/src/System.Web.OData/OData/EnableQueryAttribute.cs
+++ b/OData/src/System.Web.OData/OData/EnableQueryAttribute.cs
@@ -545,11 +545,6 @@ namespace System.Web.OData
                 request.ODataProperties().Path);
             ODataQueryOptions queryOptions = new ODataQueryOptions(queryContext, request);
 
-            if (queryOptions.SelectExpand != null)
-            {
-                queryOptions.SelectExpand.LevelsMaxLiteralExpansionDepth = _validationSettings.MaxExpansionDepth;
-            }
-
             ValidateQuery(request, queryOptions);
 
             // apply the query

--- a/OData/src/System.Web.OData/OData/Query/SelectExpandQueryOption.cs
+++ b/OData/src/System.Web.OData/OData/Query/SelectExpandQueryOption.cs
@@ -23,7 +23,10 @@ namespace System.Web.OData.Query
         private static readonly IAssembliesResolver _defaultAssembliesResolver = new DefaultAssembliesResolver();
         private SelectExpandClause _selectExpandClause;
         private ODataQueryOptionParser _queryOptionParser;
-        private int _levelsMaxLiteralExpansionDepth = ODataValidationSettings.DefaultMaxExpansionDepth;
+        // Give _levelsMaxLiteralExpansionDepth a negative value meaning it is uninitialized, and it will be set to:
+        // 1. LevelsMaxLiteralExpansionDepth or
+        // 2. ODataValidationSettings.MaxExpansionDepth
+        private int _levelsMaxLiteralExpansionDepth = -1;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SelectExpandQueryOption"/> class.
@@ -278,7 +281,10 @@ namespace System.Web.OData.Query
         {
             bool levelsEncountered;
             bool isMaxLevel;
-            return ProcessLevels(SelectExpandClause, LevelsMaxLiteralExpansionDepth, out levelsEncountered, out isMaxLevel);
+            return ProcessLevels(SelectExpandClause, 
+                LevelsMaxLiteralExpansionDepth < 0 ? ODataValidationSettings.DefaultMaxExpansionDepth : LevelsMaxLiteralExpansionDepth, 
+                out levelsEncountered, 
+                out isMaxLevel);
         }
 
         // Process $levels in SelectExpandClause.

--- a/OData/src/System.Web.OData/OData/Query/Validators/SelectExpandQueryValidator.cs
+++ b/OData/src/System.Web.OData/OData/Query/Validators/SelectExpandQueryValidator.cs
@@ -39,7 +39,11 @@ namespace System.Web.OData.Query.Validators
 
             if (validationSettings.MaxExpansionDepth > 0)
             {
-                if (selectExpandQueryOption.LevelsMaxLiteralExpansionDepth > validationSettings.MaxExpansionDepth)
+                if (selectExpandQueryOption.LevelsMaxLiteralExpansionDepth < 0)
+                {
+                    selectExpandQueryOption.LevelsMaxLiteralExpansionDepth = validationSettings.MaxExpansionDepth;
+                }
+                else if (selectExpandQueryOption.LevelsMaxLiteralExpansionDepth > validationSettings.MaxExpansionDepth)
                 {
                     throw new ODataException(Error.Format(
                         SRResources.InvalidExpansionDepthValue,

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DollarLevels/DollarLevelsController.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DollarLevels/DollarLevelsController.cs
@@ -35,7 +35,7 @@ namespace WebStack.QA.Test.OData.DollarLevels
                             Name = "Name" + i,
                         }).ToList();
 
-            for (int i = 1; i < 9; i++)
+            for (int i = 0; i < 9; i++)
             {
                 _DLManagers[i].Manager = _DLManagers[i + 1];
                 _DLManagers[i + 1].DirectReports = new List<DLManager> { _DLManagers[i] };
@@ -97,7 +97,7 @@ namespace WebStack.QA.Test.OData.DollarLevels
                             ID = i,
                         }).ToList();
 
-            for (int i = 1; i < 4; i++)
+            for (int i = 0; i < 4; i++)
             {
                 _DLEmployees[i].Friend = _DLEmployees[i + 1];
             }
@@ -149,7 +149,6 @@ namespace WebStack.QA.Test.OData.DollarLevels
             var employee = _DLEmployees.Single(e=>e.ID == key);
             var appliedEmployee = queryOptions.ApplyTo(employee, new ODataQuerySettings());
             return Ok(appliedEmployee, appliedEmployee.GetType());
-
         }
 
         private IHttpActionResult Ok(object content, Type type)

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DollarLevels/DollarLevelsController.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DollarLevels/DollarLevelsController.cs
@@ -1,13 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Web.Http;
+using System.Web.Http.Results;
 using System.Web.OData;
+using System.Web.OData.Query;
+using Microsoft.OData.Core;
 
 namespace WebStack.QA.Test.OData.DollarLevels
 {
     public class DLManagersController : ODataController
     {
-         public DLManagersController()
+        public DLManagersController()
         {
             if (null == _DLManagers)
             {
@@ -36,16 +42,120 @@ namespace WebStack.QA.Test.OData.DollarLevels
             }
         }
 
-        [EnableQuery(MaxExpansionDepth = 3)]
-        public IHttpActionResult Get()
+        public IHttpActionResult Get(ODataQueryOptions<DLManager> queryOptions)
         {
-            return Ok(_DLManagers.AsQueryable());
+            ODataValidationSettings settings = new ODataValidationSettings();
+            settings.MaxExpansionDepth = 1;
+
+            try
+            {
+                queryOptions.Validate(settings);
+            }
+            catch (ODataException e)
+            {
+                var responseMessage = new HttpResponseMessage(HttpStatusCode.BadRequest);
+                responseMessage.Content = new StringContent(
+                    String.Format("The query specified in the URI is not valid. {0}", e.Message));
+                return ResponseMessage(responseMessage);
+            }
+
+            var managers = queryOptions.ApplyTo(_DLManagers.AsQueryable()).AsQueryable();
+            return Ok(managers, managers.GetType());
         }
 
         [EnableQuery(MaxExpansionDepth = 4)]
         public IHttpActionResult Get(int key)
         {
             return Ok(_DLManagers.Single(e => e.ID == key));
+
+        }
+
+        private IHttpActionResult Ok(object content, Type type)
+        {
+            var resultType = typeof(OkNegotiatedContentResult<>).MakeGenericType(type);
+            return Activator.CreateInstance(resultType, content, this) as IHttpActionResult;
+        }
+    }
+
+    public class DLEmployeesController : ODataController
+    {
+        public DLEmployeesController()
+        {
+            if (null == _DLEmployees)
+            {
+                InitDLEmployees();
+            }
+        }
+
+        private static List<DLEmployee> _DLEmployees = null;
+
+        private static void InitDLEmployees()
+        {
+            _DLEmployees = Enumerable.Range(1, 5).Select(i =>
+                        new DLEmployee
+                        {
+                            ID = i,
+                        }).ToList();
+
+            for (int i = 1; i < 4; i++)
+            {
+                _DLEmployees[i].Friend = _DLEmployees[i + 1];
+            }
+        }
+
+        public IHttpActionResult Get(ODataQueryOptions<DLEmployee> queryOptions)
+        {
+            if (queryOptions.SelectExpand != null)
+            {
+                queryOptions.SelectExpand.LevelsMaxLiteralExpansionDepth = 2;
+            }
+
+            ODataValidationSettings settings = new ODataValidationSettings();
+            settings.MaxExpansionDepth = 4;
+
+            try
+            {
+                queryOptions.Validate(settings);
+            }
+            catch (ODataException e)
+            {
+                var responseMessage = new HttpResponseMessage(HttpStatusCode.BadRequest);
+                responseMessage.Content = new StringContent(
+                    String.Format("The query specified in the URI is not valid. {0}", e.Message));
+                return ResponseMessage(responseMessage);
+            }
+
+            var employees = queryOptions.ApplyTo(_DLEmployees.AsQueryable()).AsQueryable();
+            return Ok(employees, employees.GetType());
+        }
+
+        public IHttpActionResult Get(int key, ODataQueryOptions<DLEmployee> queryOptions)
+        {
+            ODataValidationSettings settings = new ODataValidationSettings();
+            settings.MaxExpansionDepth = 3;
+
+            try
+            {
+                queryOptions.Validate(settings);
+            }
+            catch (ODataException e)
+            {
+                var responseMessage = new HttpResponseMessage(HttpStatusCode.BadRequest);
+                responseMessage.Content = new StringContent(
+                    String.Format("The query specified in the URI is not valid. {0}", e.Message));
+                return ResponseMessage(responseMessage);
+            }
+
+            var employee = _DLEmployees.Single(e=>e.ID == key);
+            var appliedEmployee = queryOptions.ApplyTo(employee, new ODataQuerySettings());
+            return Ok(appliedEmployee, appliedEmployee.GetType());
+
+        }
+
+        private IHttpActionResult Ok(object content, Type type)
+        {
+            var resultType = typeof(OkNegotiatedContentResult<>).MakeGenericType(type);
+            return Activator.CreateInstance(resultType, content, this) as IHttpActionResult;
         }
     }
 }

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DollarLevels/DollarLevelsDataModel.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DollarLevels/DollarLevelsDataModel.cs
@@ -12,4 +12,11 @@ namespace WebStack.QA.Test.OData.DollarLevels
 
         public IList<DLManager> DirectReports { get; set; }
     }
+
+    public class DLEmployee
+    {
+        public int ID { get; set; }
+
+        public DLEmployee Friend { get; set; }
+    }
 }

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DollarLevels/DollarLevelsEdmModel.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DollarLevels/DollarLevelsEdmModel.cs
@@ -9,6 +9,7 @@ namespace WebStack.QA.Test.OData.DollarLevels
         {
             ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
             builder.EntitySet<DLManager>("DLManagers");
+            builder.EntitySet<DLEmployee>("DLEmployees");
 
             builder.Namespace = typeof(DLManager).Namespace;
             return builder.GetEdmModel();

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DollarLevels/DollarLevelsTest.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DollarLevels/DollarLevelsTest.cs
@@ -116,10 +116,8 @@ namespace WebStack.QA.Test.OData.DollarLevels
         }
 
         [Theory]
-        [InlineData("$expand=Manager($levels=max)",
-            "$expand=Manager")]
-        [InlineData("$expand=Manager($levels=1)",
-            "$expand=Manager")]
+        [InlineData("$expand=Manager($levels=max)", "$expand=Manager")]
+        [InlineData("$expand=Manager($levels=1)", "$expand=Manager")]
         public async Task LevelsWithValidator(string originalQuery, string expandedQuery)
         {
             string requestUri = this.BaseAddress + "/odata/DLManagers?" + originalQuery;

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Validators/SelectExpandQueryValidatorTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Validators/SelectExpandQueryValidatorTest.cs
@@ -144,6 +144,27 @@ namespace System.Web.OData.Query.Validators
                     new ODataValidationSettings { MaxExpansionDepth = maxExpansionDepth }));
         }
 
+        [Fact]
+        public void Validate_Throw_WithInvalidMaxExpansionDepth()
+        {
+            int maxExpansionDepth = -1;
+            // Arrange
+            string expand = "Parent($levels=1)";
+            var validator = new SelectExpandQueryValidator();
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<ODataLevelsTest.LevelsEntity>("Entities");
+            IEdmModel model = builder.GetEdmModel();
+            var context = new ODataQueryContext(model, typeof(ODataLevelsTest.LevelsEntity));
+            var selectExpandQueryOption = new SelectExpandQueryOption(null, expand, context);
+
+            // Act & Assert
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => validator.Validate(
+                    selectExpandQueryOption,
+                    new ODataValidationSettings { MaxExpansionDepth = maxExpansionDepth }),
+                "Value must be greater than or equal to 0.\r\nParameter name: value\r\nActual value was -1.");
+        }
+
         [Theory]
         [InlineData(2, 3)]
         [InlineData(4, 4)]

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Validators/SelectExpandQueryValidatorTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Validators/SelectExpandQueryValidatorTest.cs
@@ -123,6 +123,28 @@ namespace System.Web.OData.Query.Validators
         }
 
         [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Validate_DoesNotThrow_DefaultLevelsMaxLiteralExpansionDepth(int maxExpansionDepth)
+        {
+            // Arrange
+            string expand = "Parent($levels=1)";
+            var validator = new SelectExpandQueryValidator();
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<ODataLevelsTest.LevelsEntity>("Entities");
+            IEdmModel model = builder.GetEdmModel();
+            var context = new ODataQueryContext(model, typeof(ODataLevelsTest.LevelsEntity));
+            var selectExpandQueryOption = new SelectExpandQueryOption(null, expand, context);
+
+            // Act & Assert
+            Assert.DoesNotThrow(
+                () => validator.Validate(
+                    selectExpandQueryOption,
+                    new ODataValidationSettings { MaxExpansionDepth = maxExpansionDepth }));
+        }
+
+        [Theory]
         [InlineData(2, 3)]
         [InlineData(4, 4)]
         [InlineData(3, 0)]

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Routing/ODataLevelsTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Routing/ODataLevelsTest.cs
@@ -645,11 +645,6 @@ namespace System.Web.OData.Routing
 
             public IHttpActionResult Get(ODataQueryOptions<LevelsEntity> queryOptions)
             {
-                if (queryOptions.SelectExpand != null)
-                {
-                    queryOptions.SelectExpand.LevelsMaxLiteralExpansionDepth = 5;
-                }
-
                 var validationSettings = new ODataValidationSettings { MaxExpansionDepth = 5 };
 
                 try


### PR DESCRIPTION
…ryOption.LevelsMaxLiteralExpansionDepth #516 

Although SelectExpandQueryOption.LevelsMaxLiteralExpansionDepth is used to control the actual expansion depth for each request. Although it is for internal use, but it is public so we cannot remove it. In the fix, the value of LevelsMaxLiteralExpansionDepth can be set manually or it will be set automatically to ODataValidationSettings.MaxExpansionDepth.