### PR TITLE
Issue #482: Web API does not support Edm.Date literal in $filter when…

### DIFF
--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DateAndTimeOfDay/DateAndTimeOfDayContext.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DateAndTimeOfDay/DateAndTimeOfDayContext.cs
@@ -13,4 +13,16 @@ namespace WebStack.QA.Test.OData.DateAndTimeOfDay
 
         public DbSet<EfCustomer> Customers { get; set; }
     }
+
+    public class EdmDateWithEfContext : DbContext
+    {
+        public static string ConnectionString = @"Data Source=(LocalDb)\v11.0;Integrated Security=True;Initial Catalog=EdmDateWithEfDbContext";
+
+        public EdmDateWithEfContext()
+            : base(ConnectionString)
+        {
+        }
+
+        public IDbSet<EfPerson> People { get; set; }
+    }
 }

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DateAndTimeOfDay/DateAndTimeOfDayController.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DateAndTimeOfDay/DateAndTimeOfDayController.cs
@@ -180,4 +180,36 @@ namespace WebStack.QA.Test.OData.DateAndTimeOfDay
             return Ok();
         }
     }
+
+    public class EfPeopleController : ODataController
+    {
+        private static EdmDateWithEfContext _db = new EdmDateWithEfContext();
+
+        static EfPeopleController()
+        {
+            if (_db.People.Any())
+            {
+                return;
+            }
+
+            var people = Enumerable.Range(1, 5).Select(e => new EfPerson
+            {
+                Id = e,
+                Birthday = e % 2 == 0 ? (DateTime?)null : new DateTime(2015, 10, e)
+            });
+
+            foreach (var person in people)
+            {
+                _db.People.Add(person);
+            }
+
+            _db.SaveChanges();
+        }
+
+        [EnableQuery]
+        public IHttpActionResult Get()
+        {
+            return Ok(_db.People);
+        }
+    }
 }

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DateAndTimeOfDay/DateAndTimeOfDayEdmModel.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DateAndTimeOfDay/DateAndTimeOfDayEdmModel.cs
@@ -102,5 +102,25 @@ namespace WebStack.QA.Test.OData.DateAndTimeOfDay
                             new KeyValuePathSegment(id.ToString()));
             return new Uri(uri);
         };
+
+        public static IEdmModel BuildEfPersonEdmModel()
+        {
+            string Namespace = typeof(EfPerson).Namespace;
+
+            EdmModel model = new EdmModel();
+
+            EdmEntityType person = new EdmEntityType(Namespace, "Person");
+            person.AddKeys(person.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32, isNullable: false));
+            person.AddStructuralProperty("Birthday", EdmPrimitiveTypeKind.Date, isNullable: true);
+            model.AddElement(person);
+
+            EdmEntityContainer container = new EdmEntityContainer(Namespace, "Default");
+            container.AddEntitySet("EfPeople", person);
+
+            model.AddElement(container);
+            model.SetAnnotationValue<ClrTypeAnnotation>(person, new ClrTypeAnnotation(typeof(EfPerson)));
+
+            return model;
+        }
     }
 }

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DateAndTimeOfDay/DateAndTimeOfDayModel.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DateAndTimeOfDay/DateAndTimeOfDayModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.OData.Edm.Library;
 
 namespace WebStack.QA.Test.OData.DateAndTimeOfDay
@@ -44,5 +45,13 @@ namespace WebStack.QA.Test.OData.DateAndTimeOfDay
         // nullable
         public DateTime? NullableDateTime { get; set; }
         public DateTimeOffset? NullableOffset { get; set; }
+    }
+
+    public class EfPerson
+    {
+        public int Id { get; set; }
+
+        [Column("Birthday", TypeName = "Date")]
+        public DateTime? Birthday { get; set; }
     }
 }

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DateAndTimeOfDay/DateWithEfTest.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DateAndTimeOfDay/DateWithEfTest.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Dispatcher;
+using System.Web.OData.Extensions;
+using Microsoft.OData.Core;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Library;
+using Newtonsoft.Json.Linq;
+using Nuwa;
+using WebStack.QA.Test.OData.Common;
+using Xunit;
+using Xunit.Extensions;
+
+namespace WebStack.QA.Test.OData.DateAndTimeOfDay
+{
+    [NuwaFramework]
+    [NuwaTrace(NuwaTraceAttribute.Tag.Off)]
+    public class DateWithEfTest
+    {
+        [NuwaBaseAddress]
+        public string BaseAddress { get; set; }
+
+        [NuwaHttpClient]
+        public HttpClient Client { get; set; }
+
+        [NuwaConfiguration]
+        public static void UpdateConfiguration(HttpConfiguration configuration)
+        {
+            var controllers = new[] {typeof (EfPeopleController)};
+            TestAssemblyResolver resolver = new TestAssemblyResolver(new TypesInjectionAssembly(controllers));
+            configuration.Services.Replace(typeof (IAssembliesResolver), resolver);
+
+            configuration.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
+
+            IEdmModel model = DateAndTimeOfDayEdmModel.BuildEfPersonEdmModel();
+            model.SetPayloadValueConverter(new MyConverter());
+
+            configuration.Routes.Clear();
+            configuration.MapODataServiceRoute("odata", "odata", model);
+
+            configuration.EnsureInitialized();
+        }
+
+        [Theory]
+        [InlineData("$filter=Birthday eq null", "2,4")]
+        [InlineData("$filter=Birthday ne null", "1,3,5")]
+        [InlineData("$filter=Birthday eq 2015-10-01", "1")]
+        [InlineData("$filter=Birthday eq 2015-10-03", "3")]
+        [InlineData("$filter=Birthday ne 2015-10-03", "1,2,4,5")]
+        public async Task CanFilterByDatePropertyForDateTimePropertyOnEf(string filter, string expect)
+        {
+            string requestUri = string.Format("{0}/odata/EfPeople?{1}", BaseAddress, filter);
+
+            HttpResponseMessage response = await Client.GetAsync(requestUri);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            JObject content = await response.Content.ReadAsAsync<JObject>();
+
+            Assert.Equal(expect, String.Join(",", content["value"].Select(e => e["Id"].ToString())));
+        }
+    }
+
+    public class MyConverter : ODataPayloadValueConverter
+    {
+        public override object ConvertToPayloadValue(object value, IEdmTypeReference edmTypeReference)
+        {
+            if (edmTypeReference != null && edmTypeReference.IsDate())
+            {
+                if (value is DateTimeOffset)
+                {
+                    DateTimeOffset dto = (DateTimeOffset)value;
+                    return new Date(dto.Year, dto.Month, dto.Day);
+                }
+            }
+
+            return base.ConvertToPayloadValue(value, edmTypeReference);
+        }
+    }
+}

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
@@ -152,6 +152,7 @@
     <Compile Include="DateAndTimeOfDay\DateAndTimeOfDayEdmModel.cs" />
     <Compile Include="DateAndTimeOfDay\DateAndTimeOfDayModel.cs" />
     <Compile Include="DateAndTimeOfDay\DateAndTimeOfDayTest.cs" />
+    <Compile Include="DateAndTimeOfDay\DateWithEfTest.cs" />
     <Compile Include="DollarLevels\DollarLevelsController.cs" />
     <Compile Include="DollarLevels\DollarLevelsDataModel.cs" />
     <Compile Include="DollarLevels\DollarLevelsEdmModel.cs" />


### PR DESCRIPTION
Issue #482: Web API does not support Edm.Date literal in $filter when the property is Edm.Date [Nullable=True] and the backend is EF. Thanks.