### PR TITLE
Issue #475: ETag can't work for double type.

### DIFF
--- a/OData/src/System.Web.OData/Extensions/HttpRequestMessageExtensions.cs
+++ b/OData/src/System.Web.OData/Extensions/HttpRequestMessageExtensions.cs
@@ -106,6 +106,7 @@ namespace System.Web.OData.Extensions
         /// <param name="request">The request.</param>
         /// <param name="entityTagHeaderValue">The entity tag header value.</param>
         /// <returns>The parsed <see cref="ETag"/>.</returns>
+        [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "Relies on many ODataLib classes.")]
         public static ETag GetETag(this HttpRequestMessage request, EntityTagHeaderValue entityTagHeaderValue)
         {
             if (request == null)
@@ -137,8 +138,8 @@ namespace System.Web.OData.Extensions
                 IEdmEntitySet entitySet = odataPath.NavigationSource as IEdmEntitySet;
                 if (model != null && entitySet != null)
                 {
-                    IList<string> concurrencyPropertyNames =
-                        model.GetConcurrencyProperties(entitySet).OrderBy(c => c.Name).Select(c => c.Name).AsList();
+                    IList<IEdmStructuralProperty> concurrencyProperties = model.GetConcurrencyProperties(entitySet).ToList();
+                    IList<string> concurrencyPropertyNames = concurrencyProperties.OrderBy(c => c.Name).Select(c => c.Name).AsList();
                     ETag etag = new ETag();
 
                     if (parsedETagValues.Count != concurrencyPropertyNames.Count)
@@ -151,7 +152,23 @@ namespace System.Web.OData.Extensions
                         (name, value) => new KeyValuePair<string, object>(name, value));
                     foreach (var nameValue in nameValues)
                     {
-                        etag[nameValue.Key] = nameValue.Value;
+                        IEdmStructuralProperty property = concurrencyProperties.SingleOrDefault(e => e.Name == nameValue.Key);
+                        Contract.Assert(property != null);
+
+                        Type clrType = EdmLibHelpers.GetClrType(property.Type, model);
+                        Contract.Assert(clrType != null);
+
+                        if (nameValue.Value != null)
+                        {
+                            Type valueType = nameValue.Value.GetType();
+                            etag[nameValue.Key] = valueType != clrType
+                                ? Convert.ChangeType(nameValue.Value, clrType, CultureInfo.InvariantCulture)
+                                : nameValue.Value;
+                        }
+                        else
+                        {
+                            etag[nameValue.Key] = nameValue.Value;
+                        }
                     }
 
                     return etag;

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/ETags/ETagsController.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/ETags/ETagsController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Web.Http;
@@ -14,6 +15,8 @@ namespace WebStack.QA.Test.OData.ETags
                 {
                     Id = i,
                     Name = "Customer Name " + i,
+                    ShortProperty = (short)(Int16.MaxValue - i),
+                    DoubleProperty = 2.0 * (i + 1),
                     Notes = Enumerable.Range(0, i + 1).Select(j => "This is note " + (i * 10 + j)).ToList()
                 }).ToList();
 

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/ETags/ETagsOtherTypesTest.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/ETags/ETagsOtherTypesTest.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.OData.Builder;
+using System.Web.OData.Extensions;
+using System.Web.OData.Formatter;
+using System.Web.OData.Routing;
+using System.Web.OData.Routing.Conventions;
+using Microsoft.OData.Edm;
+using Newtonsoft.Json.Linq;
+using Nuwa;
+using Xunit;
+
+namespace WebStack.QA.Test.OData.ETags
+{
+    [NuwaFramework]
+    public class ETagsOtherTypesTest
+    {
+        [NuwaBaseAddress]
+        public string BaseAddress { get; set; }
+
+        [NuwaHttpClient]
+        public HttpClient Client { get; set; }
+
+        [NuwaConfiguration]
+        public static void UpdateConfiguration(HttpConfiguration configuration)
+        {
+            configuration.Routes.Clear();
+            configuration.MapODataServiceRoute("odata1", "double", GetDoubleETagEdmModel(), new DefaultODataPathHandler(), ODataRoutingConventions.CreateDefault());
+            configuration.MapODataServiceRoute("odata2", "short", GetShortETagEdmModel(), new DefaultODataPathHandler(), ODataRoutingConventions.CreateDefault());
+        }
+
+        private static IEdmModel GetDoubleETagEdmModel()
+        {
+            var builder = new ODataConventionModelBuilder();
+            var customer = builder.EntitySet<ETagsCustomer>("ETagsCustomers").EntityType;
+            customer.Property(c => c.DoubleProperty).IsConcurrencyToken();
+            customer.Ignore(c => c.StringWithConcurrencyCheckAttributeProperty);
+            return builder.GetEdmModel();
+        }
+
+        private static IEdmModel GetShortETagEdmModel()
+        {
+            var builder = new ODataConventionModelBuilder();
+            var customer = builder.EntitySet<ETagsCustomer>("ETagsCustomers").EntityType;
+            customer.Ignore(c => c.StringWithConcurrencyCheckAttributeProperty);
+            customer.Property(c => c.ShortProperty).IsConcurrencyToken();
+            return builder.GetEdmModel();
+        }
+
+        [Fact]
+        public async Task GetEntryWithIfNoneMatchShouldReturnNotModifiedETagsTest_ForDouble()
+        {
+            string eTag;
+
+            var getUri = this.BaseAddress + "/double/ETagsCustomers?$format=json";
+            using (var response = await Client.GetAsync(getUri))
+            {
+                Assert.True(response.IsSuccessStatusCode);
+
+                var json = await response.Content.ReadAsAsync<JObject>();
+                var result = json.GetValue("value") as JArray;
+                Assert.NotNull(result);
+
+                // check the first
+                eTag = result[0]["@odata.etag"].ToString();
+                Assert.False(String.IsNullOrEmpty(eTag));
+                Assert.Equal("W/\"Mi4w\"", eTag);
+
+                EntityTagHeaderValue parsedValue;
+                Assert.True(EntityTagHeaderValue.TryParse(eTag, out parsedValue));
+                HttpConfiguration config = new HttpConfiguration();
+                IETagHandler handler = config.GetETagHandler();
+                IDictionary<string, object> tags = handler.ParseETag(parsedValue);
+                KeyValuePair<string, object> pair = Assert.Single(tags);
+                Single value = Assert.IsType<Single>(pair.Value);
+                Assert.Equal((Single)2.0, value);
+            }
+
+            var getRequestWithEtag = new HttpRequestMessage(HttpMethod.Get, this.BaseAddress + "/double/ETagsCustomers(0)");
+            getRequestWithEtag.Headers.IfNoneMatch.ParseAdd(eTag);
+            using (var response = await Client.SendAsync(getRequestWithEtag))
+            {
+                Assert.Equal(HttpStatusCode.NotModified, response.StatusCode);
+            }
+        }
+
+        [Fact]
+        public async Task GetEntryWithIfNoneMatchShouldReturnNotModifiedETagsTest_ForShort()
+        {
+            string eTag;
+
+            var getUri = this.BaseAddress + "/short/ETagsCustomers?$format=json";
+            using (var response = await Client.GetAsync(getUri))
+            {
+                Assert.True(response.IsSuccessStatusCode);
+
+                var json = await response.Content.ReadAsAsync<JObject>();
+                var result = json.GetValue("value") as JArray;
+                Assert.NotNull(result);
+
+                // check the second
+                eTag = result[1]["@odata.etag"].ToString();
+                Assert.False(String.IsNullOrEmpty(eTag));
+                Assert.Equal("W/\"MzI3NjY=\"", eTag);
+
+                EntityTagHeaderValue parsedValue;
+                Assert.True(EntityTagHeaderValue.TryParse(eTag, out parsedValue));
+                HttpConfiguration config = new HttpConfiguration();
+                IETagHandler handler = config.GetETagHandler();
+                IDictionary<string, object> tags = handler.ParseETag(parsedValue);
+                KeyValuePair<string, object> pair = Assert.Single(tags);
+                int value = Assert.IsType<int>(pair.Value);
+                Assert.Equal((short)32766, value);
+            }
+
+            var getRequestWithEtag = new HttpRequestMessage(HttpMethod.Get, this.BaseAddress + "/short/ETagsCustomers(1)");
+            getRequestWithEtag.Headers.IfNoneMatch.ParseAdd(eTag);
+            using (var response = await Client.SendAsync(getRequestWithEtag))
+            {
+                Assert.Equal(HttpStatusCode.NotModified, response.StatusCode);
+            }
+        }
+    }
+}

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
@@ -160,6 +160,7 @@
     <Compile Include="ETags\DominiosController.cs" />
     <Compile Include="ETags\ETagCurrencyTokenEfContext.cs" />
     <Compile Include="ETags\ETagCurrencyTokenEfContextTest.cs" />
+    <Compile Include="ETags\ETagsOtherTypesTest.cs" />
     <Compile Include="Routing\DynamicProperties\DynamicPropertiesController.cs" />
     <Compile Include="Routing\DynamicProperties\DynamicPropertiesModel.cs" />
     <Compile Include="Routing\DynamicProperties\DynamicPropertiesTest.cs" />


### PR DESCRIPTION
Basically, it also doesn't work for sbyte, byte, short, etc. Thanks.