### PR TITLE
Fix Issue #543 EditLink is wrong in 5.7

### DIFF
--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/LinkGenerationHelpersTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/LinkGenerationHelpersTest.cs
@@ -125,6 +125,33 @@ namespace System.Web.OData.Builder
         }
 
         [Fact]
+        public void GenerateNavigationLink_WorksToGenerateExpectedNavigationLink_ForNonContainedNavigation()
+        {
+            // Arrange
+            IEdmEntityType myOrder = (IEdmEntityType)_model.Model.FindDeclaredType("NS.MyOrder");
+            IEdmNavigationProperty orderLinesProperty = myOrder.NavigationProperties().Single(x => x.Name.Equals("NonContainedOrderLines"));
+
+            var serializerContext = new ODataSerializerContext
+            {
+                Model = _model.Model,
+                NavigationSource = _model.OrderLines,
+                Path = new ODataPath(
+                    new EntitySetPathSegment(_model.Model.FindDeclaredEntitySet("MyOrders")),
+                    new KeyValuePathSegment("42"),
+                    new NavigationPathSegment(orderLinesProperty),
+                    new KeyValuePathSegment("21")),
+                Url = GetODataRequest(_model.Model).GetUrlHelper(),
+            };
+            var entityContext = new EntityInstanceContext(serializerContext, _model.OrderLine.AsReference(), new { ID = 21 });
+
+            // Act
+            Uri uri = entityContext.GenerateSelfLink(false);
+
+            // Assert
+            Assert.Equal("http://localhost/OrderLines(21)", uri.AbsoluteUri);
+        }
+
+        [Fact]
         public void GenerateSelfLink_ThrowsArgumentNull_EntityContext()
         {
             Assert.ThrowsArgumentNull(

--- a/OData/test/UnitTest/System.Web.OData.Test/TestCommon/CustomersModelWithInheritance.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/TestCommon/CustomersModelWithInheritance.cs
@@ -104,6 +104,15 @@ namespace System.Web.OData.TestCommon
                     ContainsTarget = true,
                 });
 
+           EdmNavigationProperty nonContainedOrderLinesNavProp = myOrder.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo
+                {
+                    Name = "NonContainedOrderLines",
+                    TargetMultiplicity = EdmMultiplicity.Many,
+                    Target = orderLine,
+                    ContainsTarget = false,
+                });
+
             EdmAction tag = new EdmAction("NS", "tag", returnType: null, isBound: true, entitySetPathExpression: null);
             tag.AddParameter("entity", new EdmEntityTypeReference(orderLine, false));
             model.AddElement(tag);
@@ -125,6 +134,9 @@ namespace System.Web.OData.TestCommon
 
             // containment
             IEdmContainedEntitySet orderLines = (IEdmContainedEntitySet)myOrders.FindNavigationTarget(orderLinesNavProp);
+            
+            // no-containment
+            IEdmNavigationSource nonContainedOrderLines = myOrders.FindNavigationTarget(nonContainedOrderLinesNavProp);
 
             // actions
             EdmAction upgrade = new EdmAction("NS", "upgrade", returnType: null, isBound: true, entitySetPathExpression: null);
@@ -313,7 +325,8 @@ namespace System.Web.OData.TestCommon
             Mary = mary;
             RootOrder = rootOrder;
             OrderLine = orderLine;
-            OrderLines = orderLines;
+            OrderLines = orderLines; 
+            NonContainedOrderLines = nonContainedOrderLines;
             UpgradeCustomer = upgrade;
             UpgradeSpecialCustomer = specialUpgrade;
             CustomerName = customerName;
@@ -349,6 +362,8 @@ namespace System.Web.OData.TestCommon
         public EdmSingleton RootOrder { get; private set; }
 
         public IEdmContainedEntitySet OrderLines { get; private set; }
+        
+        public IEdmNavigationSource NonContainedOrderLines { get; private set; }
 
         public EdmEntityContainer Container { get; private set; }
 


### PR DESCRIPTION
Use default behavior when target is not contained navigation property
When target is contained navigation property, just keep the last non-contained navigation srouce.