### PR TITLE
Issue #560: Unnecessary casts in expression when querying properties of the base class for the inheritor

### DIFF
--- a/OData/src/System.Web.OData/OData/Query/Expressions/SelectExpandBinder.cs
+++ b/OData/src/System.Web.OData/OData/Query/Expressions/SelectExpandBinder.cs
@@ -126,32 +126,30 @@ namespace System.Web.OData.Query.Expressions
             IEdmEntityType declaringType = property.DeclaringType as IEdmEntityType;
             Contract.Assert(declaringType != null, "only entity types are projected.");
 
-            Expression propertyName;
-
             // derived navigation property using cast
             if (elementType != declaringType)
             {
+                Type originalType = EdmLibHelpers.GetClrType(elementType, _model);
                 Type castType = EdmLibHelpers.GetClrType(declaringType, _model);
                 if (castType == null)
                 {
                     throw new ODataException(Error.Format(SRResources.MappingDoesNotContainEntityType, declaringType.FullName()));
                 }
 
-                // Expression
-                //          source is navigationPropertyDeclaringType ? propertyName : null
-                propertyName = Expression.Condition(
-                    test: Expression.TypeIs(source, castType),
-                    ifTrue: Expression.Constant(property.Name),
-                    ifFalse: Expression.Constant(null, typeof(string)));
-            }
-            else
-            {
-                // Expression
-                //          "propertyName"
-                propertyName = Expression.Constant(property.Name);
+                if (!castType.IsAssignableFrom(originalType))
+                {
+                    // Expression
+                    //          source is navigationPropertyDeclaringType ? propertyName : null
+                    return Expression.Condition(
+                        test: Expression.TypeIs(source, castType),
+                        ifTrue: Expression.Constant(property.Name),
+                        ifFalse: Expression.Constant(null, typeof(string)));
+                }
             }
 
-            return propertyName;
+            // Expression
+            //          "propertyName"
+            return Expression.Constant(property.Name);
         }
 
         internal Expression CreatePropertyValueExpression(IEdmEntityType elementType, IEdmProperty property, Expression source)

--- a/OData/test/UnitTest/System.Web.Http.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
+++ b/OData/test/UnitTest/System.Web.Http.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
@@ -402,6 +402,18 @@ namespace System.Web.Http.OData.Query.Expressions
         }
 
         [Fact]
+        public void CreatePropertyNameExpression_BaseProperty_From_DerivedType_ReturnsConstantExpression()
+        {
+            Expression customer = Expression.Constant(new SpecialCustomer());
+            IEdmNavigationProperty ordersProperty = _model.Customer.NavigationProperties().Single();
+
+            Expression property = _binder.CreatePropertyNameExpression(_model.SpecialCustomer, ordersProperty, customer);
+
+            Assert.Equal(ExpressionType.Constant, property.NodeType);
+            Assert.Equal(ordersProperty.Name, (property as ConstantExpression).Value);
+        }
+
+        [Fact]
         public void CreatePropertyValueExpression_NonDerivedProperty_ReturnsMemberAccessExpression()
         {
             Expression customer = Expression.Constant(new Customer());

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
@@ -430,6 +430,18 @@ namespace System.Web.OData.Query.Expressions
         }
 
         [Fact]
+        public void CreatePropertyNameExpression_BaseProperty_From_DerivedType_ReturnsConstantExpression()
+        {
+            Expression customer = Expression.Constant(new SpecialCustomer());
+            IEdmNavigationProperty ordersProperty = _model.Customer.NavigationProperties().Single();
+
+            Expression property = _binder.CreatePropertyNameExpression(_model.SpecialCustomer, ordersProperty, customer);
+
+            Assert.Equal(ExpressionType.Constant, property.NodeType);
+            Assert.Equal(ordersProperty.Name, (property as ConstantExpression).Value);
+        }
+
+        [Fact]
         public void CreatePropertyValueExpression_NonDerivedProperty_ReturnsMemberAccessExpression()
         {
             Expression customer = Expression.Constant(new Customer());


### PR DESCRIPTION
Remove unnecessary casts from expression when querying properties of the base class for the inheritor.