### PR TITLE
Fix for single entity in EnableQueryAttribute

### DIFF
--- a/vNext/src/Microsoft.AspNet.OData/EnableQueryAttribute.cs
+++ b/vNext/src/Microsoft.AspNet.OData/EnableQueryAttribute.cs
@@ -58,8 +58,12 @@ namespace Microsoft.AspNet.OData
                     {
                         count = Count(result.Value, queryOptions, context.ActionDescriptor);
                     }
-                    var pageResult = new PageResult<object>(items, null, count);
-                    result.Value = pageResult;
+                    // We might be getting a single result, so no paging involved
+                    if (items != null)
+                    {
+                        var pageResult = new PageResult<object>(items, null, count);
+                        result.Value = pageResult;
+                    }
                 }
             }
         }


### PR DESCRIPTION
The code tries to create  page result when a single entity is returned,
thus failing with a null reference exception.