### PR TITLE
ProcedureConfiguration API to support types known at runtime

### DIFF
--- a/OData/src/System.Web.OData/OData/Builder/ActionConfiguration.cs
+++ b/OData/src/System.Web.OData/OData/Builder/ActionConfiguration.cs
@@ -133,19 +133,33 @@ namespace System.Web.OData.Builder
         /// Established the return type of the Action.
         /// <remarks>Used when the return type is a single Primitive or ComplexType.</remarks>
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "In keeping with rest of API")]
-        public ActionConfiguration Returns<TReturnType>()
+        public ActionConfiguration Returns(Type clrReturnType)
         {
-            Type returnType = typeof(TReturnType);
-            IEdmTypeConfiguration configuration = ModelBuilder.GetTypeConfigurationOrNull(returnType);
+            if (clrReturnType == null)
+            {
+                throw Error.ArgumentNull("clrReturnType");
+            }
+
+            IEdmTypeConfiguration configuration = ModelBuilder.GetTypeConfigurationOrNull(clrReturnType);
 
             if (configuration is EntityTypeConfiguration)
             {
                 throw Error.InvalidOperation(SRResources.ReturnEntityWithoutEntitySet, configuration.FullName);
             }
 
-            ReturnsImplementation<TReturnType>();
+            ReturnsImplementation(clrReturnType);
             return this;
+        }
+
+        /// <summary>
+        /// Established the return type of the Action.
+        /// <remarks>Used when the return type is a single Primitive or ComplexType.</remarks>
+        /// </summary>
+        [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "In keeping with rest of API")]
+        public ActionConfiguration Returns<TReturnType>()
+        {
+            Type returnType = typeof(TReturnType);
+            return this.Returns(returnType);
         }
 
         /// <summary>

--- a/OData/src/System.Web.OData/OData/Builder/FunctionConfiguration.cs
+++ b/OData/src/System.Web.OData/OData/Builder/FunctionConfiguration.cs
@@ -119,11 +119,25 @@ namespace System.Web.OData.Builder
         /// Established the return type of the Function.
         /// <remarks>Used when the return type is a single Primitive or ComplexType.</remarks>
         /// </summary>
+        public FunctionConfiguration Returns(Type clrReturnType)
+        {
+            if (clrReturnType == null)
+            {
+                throw Error.ArgumentNull("clrReturnType");
+            }
+
+            ReturnsImplementation(clrReturnType);
+            return this;
+        }
+
+        /// <summary>
+        /// Established the return type of the Function.
+        /// <remarks>Used when the return type is a single Primitive or ComplexType.</remarks>
+        /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "In keeping with rest of API")]
         public FunctionConfiguration Returns<TReturnType>()
         {
-            ReturnsImplementation<TReturnType>();
-            return this;
+            return this.Returns(typeof(TReturnType));
         }
 
         /// <summary>

--- a/OData/src/System.Web.OData/OData/Builder/ProcedureConfiguration.cs
+++ b/OData/src/System.Web.OData/OData/Builder/ProcedureConfiguration.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Web.Http;
 using System.Web.OData.Formatter;
 
 namespace System.Web.OData.Builder
@@ -205,12 +206,11 @@ namespace System.Web.OData.Builder
         /// <remarks>Used when the return type is a single Primitive or ComplexType.</remarks>
         /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "In keeping with rest of API")]
-        internal void ReturnsImplementation<TReturnType>()
+        internal void ReturnsImplementation(Type clrReturnType)
         {
-            Type returnType = typeof(TReturnType);
-            IEdmTypeConfiguration configuration = GetProcedureTypeConfiguration(returnType);
+            IEdmTypeConfiguration configuration = GetProcedureTypeConfiguration(clrReturnType);
             ReturnType = configuration;
-            OptionalReturn = EdmLibHelpers.IsNullable(returnType);
+            OptionalReturn = EdmLibHelpers.IsNullable(clrReturnType);
         }
 
         /// <summary>
@@ -252,11 +252,24 @@ namespace System.Web.OData.Builder
         /// <summary>
         /// Adds a new non-binding parameter
         /// </summary>  
+        public ParameterConfiguration Parameter(Type clrParameterType, string name)
+        {
+            if (clrParameterType == null)
+            {
+                throw Error.ArgumentNull("clrParameterType");
+            }
+
+            IEdmTypeConfiguration parameterType = GetProcedureTypeConfiguration(clrParameterType);
+            return AddParameter(name, parameterType);
+        }
+
+        /// <summary>
+        /// Adds a new non-binding parameter
+        /// </summary>  
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "In keeping with rest of API")]
         public ParameterConfiguration Parameter<TParameter>(string name)
         {
-            IEdmTypeConfiguration parameterType = GetProcedureTypeConfiguration(typeof(TParameter));
-            return AddParameter(name, parameterType);
+            return this.Parameter(typeof(TParameter), name);
         }
 
         /// <summary>

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/ActionConfigurationTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/ActionConfigurationTest.cs
@@ -210,9 +210,9 @@ namespace System.Web.OData.Builder
             // Act
             ODataModelBuilder builder = new ODataModelBuilder();
             ActionConfiguration action = builder.Action("MyAction");
-            action.Parameter<string>("p0");
-            action.Parameter<int>("p1");
-            action.Parameter<Address>("p2");
+            action.Parameter(typeof(string), "p0");
+            action.Parameter(typeof(int), "p1");
+            action.Parameter(typeof(Address), "p2");
             ParameterConfiguration[] parameters = action.Parameters.ToArray();
 
             // Assert

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/ActionConfigurationTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/ActionConfigurationTest.cs
@@ -182,6 +182,50 @@ namespace System.Web.OData.Builder
         }
 
         [Fact]
+        public void CanCreateActionWithNonbindingParameters_AddParameterGenericMethod()
+        {
+            // Arrange
+            // Act
+            ODataModelBuilder builder = new ODataModelBuilder();
+            ActionConfiguration action = builder.Action("MyAction");
+            action.Parameter<string>("p0");
+            action.Parameter<int>("p1");
+            action.Parameter<Address>("p2");
+            ParameterConfiguration[] parameters = action.Parameters.ToArray();
+
+            // Assert
+            Assert.Equal(3, parameters.Length);
+            Assert.Equal("p0", parameters[0].Name);
+            Assert.Equal("Edm.String", parameters[0].TypeConfiguration.FullName);
+            Assert.Equal("p1", parameters[1].Name);
+            Assert.Equal("Edm.Int32", parameters[1].TypeConfiguration.FullName);
+            Assert.Equal("p2", parameters[2].Name);
+            Assert.Equal(typeof(Address).FullName, parameters[2].TypeConfiguration.FullName);
+        }
+
+        [Fact]
+        public void CanCreateActionWithNonbindingParameters_AddParameterNonGenericMethod()
+        {
+            // Arrange
+            // Act
+            ODataModelBuilder builder = new ODataModelBuilder();
+            ActionConfiguration action = builder.Action("MyAction");
+            action.Parameter<string>("p0");
+            action.Parameter<int>("p1");
+            action.Parameter<Address>("p2");
+            ParameterConfiguration[] parameters = action.Parameters.ToArray();
+
+            // Assert
+            Assert.Equal(3, parameters.Length);
+            Assert.Equal("p0", parameters[0].Name);
+            Assert.Equal("Edm.String", parameters[0].TypeConfiguration.FullName);
+            Assert.Equal("p1", parameters[1].Name);
+            Assert.Equal("Edm.Int32", parameters[1].TypeConfiguration.FullName);
+            Assert.Equal("p2", parameters[2].Name);
+            Assert.Equal(typeof(Address).FullName, parameters[2].TypeConfiguration.FullName);
+        }
+
+        [Fact]
         public void CanCreateActionWithNonbindingParameters()
         {
             // Arrange

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/FunctionConfigurationTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/FunctionConfigurationTest.cs
@@ -220,6 +220,50 @@ namespace System.Web.OData.Builder
         }
 
         [Fact]
+        public void CanCreateFunctionWithNonbindingParameters_AddParameterGenericMethod()
+        {
+            // Arrange
+            // Act
+            ODataModelBuilder builder = new ODataModelBuilder();
+            FunctionConfiguration function = builder.Function("MyFunction");
+            function.Parameter<string>("p0");
+            function.Parameter<int>("p1");
+            function.Parameter<Address>("p2");
+            ParameterConfiguration[] parameters = function.Parameters.ToArray();
+
+            // Assert
+            Assert.Equal(3, parameters.Length);
+            Assert.Equal("p0", parameters[0].Name);
+            Assert.Equal("Edm.String", parameters[0].TypeConfiguration.FullName);
+            Assert.Equal("p1", parameters[1].Name);
+            Assert.Equal("Edm.Int32", parameters[1].TypeConfiguration.FullName);
+            Assert.Equal("p2", parameters[2].Name);
+            Assert.Equal(typeof(Address).FullName, parameters[2].TypeConfiguration.FullName);
+        }
+
+        [Fact]
+        public void CanCreateFunctionWithNonbindingParameters_AddParameterNonGenericMethod()
+        {
+            // Arrange
+            // Act
+            ODataModelBuilder builder = new ODataModelBuilder();
+            FunctionConfiguration function = builder.Function("MyFunction");
+            function.Parameter(typeof(string), "p0");
+            function.Parameter(typeof(int), "p1");
+            function.Parameter(typeof(Address), "p2");
+            ParameterConfiguration[] parameters = function.Parameters.ToArray();
+
+            // Assert
+            Assert.Equal(3, parameters.Length);
+            Assert.Equal("p0", parameters[0].Name);
+            Assert.Equal("Edm.String", parameters[0].TypeConfiguration.FullName);
+            Assert.Equal("p1", parameters[1].Name);
+            Assert.Equal("Edm.Int32", parameters[1].TypeConfiguration.FullName);
+            Assert.Equal("p2", parameters[2].Name);
+            Assert.Equal(typeof(Address).FullName, parameters[2].TypeConfiguration.FullName);
+        }
+
+        [Fact]
         public void CanCreateFunctionWithNonbindingParameters()
         {
             // Arrange


### PR DESCRIPTION
- ProcedureConfiguration - Add a parameter by the given clrType (not only with the generic API)
- FunctionConfiguration/ActionConfiguration - Set a return type with the given clrType(not only with the generic API)