### PR TITLE
Added config options "SerializeNullCollectionsAsEmpty" and "DoNotSeri…

### DIFF
--- a/OData/src/System.Web.OData/Extensions/HttpConfigurationExtensions.cs
+++ b/OData/src/System.Web.OData/Extensions/HttpConfigurationExtensions.cs
@@ -522,7 +522,7 @@ namespace System.Web.OData.Extensions
         /// This setting will be overridden by SetSerializeNullCollectionsAsEmpty if that is also set.
         /// </summary>
         /// <param name="configuration">The server configuration.</param>
-        internal static bool GetSerializeNullCollectionsAsEmpty(this HttpConfiguration configuration)
+        public static bool GetSerializeNullCollectionsAsEmpty(this HttpConfiguration configuration)
         {
             if (configuration == null)
             {
@@ -559,7 +559,7 @@ namespace System.Web.OData.Extensions
         /// Overrides SetSerializeNullCollectionsAsEmpty if that is also set.
         /// </summary>
         /// <param name="configuration">The server configuration.</param>
-        internal static bool GetDoNotSerializeNullCollections(this HttpConfiguration configuration)
+        public static bool GetDoNotSerializeNullCollections(this HttpConfiguration configuration)
         {
             if (configuration == null)
             {
@@ -574,8 +574,6 @@ namespace System.Web.OData.Extensions
 
             return (bool)doNotSerializeObj;
         }
-
-        internal static bool 
 
         private static string RemoveTrailingSlash(string routePrefix)
         {

--- a/OData/src/System.Web.OData/Extensions/HttpConfigurationExtensions.cs
+++ b/OData/src/System.Web.OData/Extensions/HttpConfigurationExtensions.cs
@@ -522,7 +522,7 @@ namespace System.Web.OData.Extensions
         /// This setting will be overridden by SetSerializeNullCollectionsAsEmpty if that is also set.
         /// </summary>
         /// <param name="configuration">The server configuration.</param>
-        public static bool GetSerializeNullCollectionsAsEmpty(this HttpConfiguration configuration)
+        internal static bool GetSerializeNullCollectionsAsEmpty(this HttpConfiguration configuration)
         {
             if (configuration == null)
             {
@@ -559,7 +559,7 @@ namespace System.Web.OData.Extensions
         /// Overrides SetSerializeNullCollectionsAsEmpty if that is also set.
         /// </summary>
         /// <param name="configuration">The server configuration.</param>
-        public static bool GetDoNotSerializeNullCollections(this HttpConfiguration configuration)
+        internal static bool GetDoNotSerializeNullCollections(this HttpConfiguration configuration)
         {
             if (configuration == null)
             {
@@ -574,6 +574,8 @@ namespace System.Web.OData.Extensions
 
             return (bool)doNotSerializeObj;
         }
+
+        internal static bool 
 
         private static string RemoveTrailingSlash(string routePrefix)
         {

--- a/OData/src/System.Web.OData/Extensions/HttpConfigurationExtensions.cs
+++ b/OData/src/System.Web.OData/Extensions/HttpConfigurationExtensions.cs
@@ -506,8 +506,11 @@ namespace System.Web.OData.Extensions
         /// This setting will be overridden by SetSerializeNullCollectionsAsEmpty if that is also set.
         /// </summary>
         /// <param name="configuration">The server configuration.</param>
-        /// <param name="serializeAsEmpty">Whether null collection properties should be serialized as empty collections.</param>
-        public static void SetSerializeNullCollectionsAsEmpty(this HttpConfiguration configuration, bool serializeAsEmpty)
+        /// <param name="serializeAsEmpty">Whether null collection properties should be serialized as empty 
+        /// collections.</param>
+        public static void SetSerializeNullCollectionsAsEmpty(
+            this HttpConfiguration configuration, 
+            bool serializeAsEmpty)
         {
             if (configuration == null)
             {
@@ -522,7 +525,7 @@ namespace System.Web.OData.Extensions
         /// This setting will be overridden by SetSerializeNullCollectionsAsEmpty if that is also set.
         /// </summary>
         /// <param name="configuration">The server configuration.</param>
-        public static bool GetSerializeNullCollectionsAsEmpty(this HttpConfiguration configuration)
+        internal static bool GetSerializeNullCollectionsAsEmpty(this HttpConfiguration configuration)
         {
             if (configuration == null)
             {
@@ -530,7 +533,9 @@ namespace System.Web.OData.Extensions
             }
 
             object serializeAsEmptyObj;
-            if (!configuration.Properties.TryGetValue(SerializeNullCollectionsAsEmptySettingsKey, out serializeAsEmptyObj))
+            if (!configuration.Properties.TryGetValue(
+                SerializeNullCollectionsAsEmptySettingsKey, 
+                out serializeAsEmptyObj))
             {
                 return false;
             }
@@ -543,8 +548,11 @@ namespace System.Web.OData.Extensions
         /// Overrides SetSerializeNullCollectionsAsEmpty if that is also set.
         /// </summary>
         /// <param name="configuration">The server configuration.</param>
-        /// <param name="doNotSerialize">Whether null collection properties should be omitted from serialization.</param>
-        public static void SetDoNotSerializeNullCollections(this HttpConfiguration configuration, bool doNotSerialize)
+        /// <param name="doNotSerialize">Whether null collection properties should be omitted from serialization.
+        /// </param>
+        public static void SetDoNotSerializeNullCollections(
+            this HttpConfiguration configuration, 
+            bool doNotSerialize)
         {
             if (configuration == null)
             {
@@ -559,7 +567,7 @@ namespace System.Web.OData.Extensions
         /// Overrides SetSerializeNullCollectionsAsEmpty if that is also set.
         /// </summary>
         /// <param name="configuration">The server configuration.</param>
-        public static bool GetDoNotSerializeNullCollections(this HttpConfiguration configuration)
+        internal static bool GetDoNotSerializeNullCollections(this HttpConfiguration configuration)
         {
             if (configuration == null)
             {

--- a/OData/src/System.Web.OData/Extensions/HttpConfigurationExtensions.cs
+++ b/OData/src/System.Web.OData/Extensions/HttpConfigurationExtensions.cs
@@ -19,7 +19,7 @@ using Microsoft.OData.Edm;
 namespace System.Web.OData.Extensions
 {
     /// <summary>
-    /// Provides extension methods for the <see cref="HttpConfiguration"/> class.
+    /// Provides extension methods for the <see cref="HttpConfiguration"/> class. 
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class HttpConfigurationExtensions
@@ -35,6 +35,10 @@ namespace System.Web.OData.Extensions
         private const string ContinueOnErrorKey = "System.Web.OData.ContinueOnErrorKey";
 
         private const string NullDynamicPropertyKey = "System.Web.OData.NullDynamicPropertyKey";
+
+        private const string SerializeNullCollectionsAsEmptySettingsKey = "System.Web.OData.SerializeNullCollectionsAsEmptySettingsKey";
+
+        private const string DoNotSerializeNullCollectionsSettingsKey = "System.Web.OData.DoNotSerializeNullCollectionsSettingsKey";
 
         /// <summary>
         /// Enables query support for actions with an <see cref="IQueryable" /> or <see cref="IQueryable{T}" /> return
@@ -495,6 +499,80 @@ namespace System.Web.OData.Extensions
                 handler: defaultHandler);
             routes.Add(routeName, route);
             return route;
+        }
+
+        /// <summary>
+        /// If true, null collection properties will be serialized as empty collections.
+        /// This setting will be overridden by SetSerializeNullCollectionsAsEmpty if that is also set.
+        /// </summary>
+        /// <param name="configuration">The server configuration.</param>
+        /// <param name="serializeAsEmpty">Whether null collection properties should be serialized as empty collections.</param>
+        public static void SetSerializeNullCollectionsAsEmpty(this HttpConfiguration configuration, bool serializeAsEmpty)
+        {
+            if (configuration == null)
+            {
+                throw Error.ArgumentNull("configuration");
+            }
+
+            configuration.Properties[SerializeNullCollectionsAsEmptySettingsKey] = serializeAsEmpty;
+        }
+
+        /// <summary>
+        /// If true, null collection properties will be serialized as empty collections.
+        /// This setting will be overridden by SetSerializeNullCollectionsAsEmpty if that is also set.
+        /// </summary>
+        /// <param name="configuration">The server configuration.</param>
+        public static bool GetSerializeNullCollectionsAsEmpty(this HttpConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw Error.ArgumentNull("configuration");
+            }
+
+            object serializeAsEmptyObj;
+            if (!configuration.Properties.TryGetValue(SerializeNullCollectionsAsEmptySettingsKey, out serializeAsEmptyObj))
+            {
+                return false;
+            }
+
+            return (bool)serializeAsEmptyObj;
+        }
+
+        /// <summary>
+        /// If true, null collection properties will not be serialized.
+        /// Overrides SetSerializeNullCollectionsAsEmpty if that is also set.
+        /// </summary>
+        /// <param name="configuration">The server configuration.</param>
+        /// <param name="doNotSerialize">Whether null collection properties should be omitted from serialization.</param>
+        public static void SetDoNotSerializeNullCollections(this HttpConfiguration configuration, bool doNotSerialize)
+        {
+            if (configuration == null)
+            {
+                throw Error.ArgumentNull("configuration");
+            }
+
+            configuration.Properties[DoNotSerializeNullCollectionsSettingsKey] = doNotSerialize;
+        }
+
+        /// <summary>
+        /// If true, null collection properties will not be serialized.
+        /// Overrides SetSerializeNullCollectionsAsEmpty if that is also set.
+        /// </summary>
+        /// <param name="configuration">The server configuration.</param>
+        public static bool GetDoNotSerializeNullCollections(this HttpConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw Error.ArgumentNull("configuration");
+            }
+
+            object doNotSerializeObj;
+            if (!configuration.Properties.TryGetValue(DoNotSerializeNullCollectionsSettingsKey, out doNotSerializeObj))
+            {
+                return false;
+            }
+
+            return (bool)doNotSerializeObj;
         }
 
         private static string RemoveTrailingSlash(string routePrefix)

--- a/OData/src/System.Web.OData/OData/EntityInstanceContext.cs
+++ b/OData/src/System.Web.OData/OData/EntityInstanceContext.cs
@@ -177,7 +177,7 @@ namespace System.Web.OData
         /// </summary>
         /// <param name="propertyName">The name of the property to get.</param>
         /// <returns>The value of the property if present.</returns>
-        internal object GetPropertyValue(string propertyName)
+        public virtual object GetPropertyValue(string propertyName)
         {
             if (EdmObject == null)
             {

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataComplexTypeSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataComplexTypeSerializer.cs
@@ -139,7 +139,7 @@ namespace System.Web.OData.Formatter.Serialization
             // Try to add the dynamic properties if the complex type is open.
             if (complexType.ComplexDefinition().IsOpen)
             {
-                List<ODataProperty> dynamicProperties =
+                List<ODataProperty> dynamicProperties = 
                     AppendDynamicProperties(complexObject, complexType, writeContext, propertyCollection, new string[0]);
 
                 if (dynamicProperties != null)

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataEntityTypeSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataEntityTypeSerializer.cs
@@ -465,10 +465,20 @@ namespace System.Web.OData.Formatter.Serialization
             List<ODataProperty> properties = new List<ODataProperty>();
             foreach (IEdmStructuralProperty structuralProperty in structuralProperties)
             {
-                ODataProperty property = CreateStructuralProperty(structuralProperty, entityInstanceContext);
-                if (property != null)
+                ODataSerializerContext writeContext = entityInstanceContext.SerializerContext;
+                object propertyValue = entityInstanceContext.GetPropertyValue(structuralProperty.Name);
+
+                var config = writeContext.Request.GetConfiguration();
+                bool doNotSerializeIfNull = config.GetDoNotSerializeNullCollections();
+
+                bool skipEntireCollectionSerialization = (propertyValue == null && structuralProperty.Type.Definition.TypeKind == EdmTypeKind.Collection && doNotSerializeIfNull);
+                if (!skipEntireCollectionSerialization)
                 {
-                    properties.Add(property);
+                    ODataProperty property = CreateStructuralProperty(structuralProperty, entityInstanceContext);
+                    if (property != null)
+                    {
+                        properties.Add(property);
+                    }
                 }
             }
 

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Deserialization/ODataCollectionDeserializerTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Deserialization/ODataCollectionDeserializerTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.Serialization;
+using System.Web.Http;
 using System.Web.OData.Builder;
 using System.Web.OData.Formatter.Serialization;
 using System.Web.OData.Formatter.Serialization.Models;
@@ -182,9 +183,12 @@ namespace System.Web.OData.Formatter.Deserialization
             {
                 ODataUri = new ODataUri { ServiceRoot = new Uri("http://any/") }
             };
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
             ODataMessageWriter messageWriter = new ODataMessageWriter(message as IODataResponseMessage, settings, _model);
             ODataMessageReader messageReader = new ODataMessageReader(message as IODataResponseMessage, new ODataMessageReaderSettings(), _model);
-            ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "Property", Model = _model };
+            ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "Property", Model = _model, Request = request };
             ODataDeserializerContext readContext = new ODataDeserializerContext() { Model = _model };
 
             serializer.WriteObject(addresses, addresses.GetType(), messageWriter, writeContext);
@@ -208,9 +212,12 @@ namespace System.Web.OData.Formatter.Deserialization
             {
                 ODataUri = new ODataUri { ServiceRoot = new Uri("http://any/") }
             };
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
             ODataMessageWriter messageWriter = new ODataMessageWriter(message as IODataResponseMessage, settings, _model);
             ODataMessageReader messageReader = new ODataMessageReader(message as IODataResponseMessage, new ODataMessageReaderSettings(), _model);
-            ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "Property", Model = _model };
+            ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "Property", Model = _model, Request = request };
             ODataDeserializerContext readContext = new ODataDeserializerContext() { Model = _model };
 
             serializer.WriteObject(numbers, numbers.GetType(), messageWriter, writeContext);

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Deserialization/ODataPrimitiveDeserializerTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Deserialization/ODataPrimitiveDeserializerTests.cs
@@ -138,9 +138,12 @@ namespace System.Web.OData.Formatter.Deserialization
             };
             settings.SetContentType(ODataFormat.Json);
 
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
             ODataMessageWriter messageWriter = new ODataMessageWriter(message as IODataResponseMessage, settings, model);
             ODataMessageReader messageReader = new ODataMessageReader(message as IODataResponseMessage, new ODataMessageReaderSettings(), model);
-            ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "Property", Model = model };
+            ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "Property", Model = model, Request = request };
             ODataDeserializerContext readContext = new ODataDeserializerContext { Model = model };
 
             Type type = obj == null ? typeof(int) : obj.GetType();
@@ -169,9 +172,12 @@ namespace System.Web.OData.Formatter.Deserialization
             };
             settings.SetContentType(ODataFormat.Json);
 
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
             ODataMessageWriter messageWriter = new ODataMessageWriter(message as IODataResponseMessage, settings, model);
             ODataMessageReader messageReader = new ODataMessageReader(message as IODataResponseMessage, new ODataMessageReaderSettings(), model);
-            ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "Property", Model = model };
+            ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "Property", Model = model, Request = request };
             ODataDeserializerContext readContext = new ODataDeserializerContext { Model = model };
 
             Type type = obj == null ? typeof(int) : expected.GetType();

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/NullCollectionsTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/NullCollectionsTests.cs
@@ -51,7 +51,8 @@ namespace System.Web.OData.Formatter
         }
 
         [Theory]
-        // -- "NormalPass_FromEntity" -- ensure existing behavior has not changed when serializing properties off the base entity
+        // -- "NormalPass_FromEntity" -- ensure existing behavior has not changed when serializing 
+        //                               properties off the base entity
         [InlineData("Array", NullCollectionsTestMode.NormalPass_FromEntity)]
         [InlineData("IEnumerable", NullCollectionsTestMode.NormalPass_FromEntity)]
         [InlineData("ICollection", NullCollectionsTestMode.NormalPass_FromEntity)]
@@ -61,7 +62,8 @@ namespace System.Web.OData.Formatter
         [InlineData("CustomCollection", NullCollectionsTestMode.NormalPass_FromEntity)]
         [InlineData("NullableColors", NullCollectionsTestMode.NormalPass_FromEntity)]
         [InlineData("ComplexCollection", NullCollectionsTestMode.NormalPass_FromEntity)]
-        // -- "NormalFail_FromEntity" -- ensure existing behavior has not changed when serializing properties off the base entity
+        // -- "NormalFail_FromEntity" -- ensure existing behavior has not changed when serializing 
+        //                               properties off the base entity
         [InlineData("Array", NullCollectionsTestMode.NormalFail_FromEntity)]
         [InlineData("IEnumerable", NullCollectionsTestMode.NormalFail_FromEntity)]
         [InlineData("ICollection", NullCollectionsTestMode.NormalFail_FromEntity)]
@@ -71,7 +73,8 @@ namespace System.Web.OData.Formatter
         [InlineData("CustomCollection", NullCollectionsTestMode.NormalFail_FromEntity)]
         [InlineData("NullableColors", NullCollectionsTestMode.NormalFail_FromEntity)]
         [InlineData("ComplexCollection", NullCollectionsTestMode.NormalFail_FromEntity)]
-        // -- "DoNotSerialize_FromEntity" -- ensure null collections are left out of serialization when setting is enabled when serializing properties off the base entity
+        // -- "DoNotSerialize_FromEntity" -- ensure null collections are left out of serialization when 
+        //                                   setting is enabled when serializing properties off the base entity
         [InlineData("Array", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
         [InlineData("IEnumerable", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
         [InlineData("ICollection", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
@@ -81,7 +84,8 @@ namespace System.Web.OData.Formatter
         [InlineData("CustomCollection", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
         [InlineData("NullableColors", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
         [InlineData("ComplexCollection", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
-        // -- "SerializeAsEmpty_FromEntity" -- ensure null collections are serialized as if they were empty collections when serializing properties off the base entity
+        // -- "SerializeAsEmpty_FromEntity" -- ensure null collections are serialized as if they were 
+        //                                     empty collections when serializing properties off the base entity
         [InlineData("Array", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
         [InlineData("IEnumerable", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
         [InlineData("ICollection", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
@@ -91,7 +95,8 @@ namespace System.Web.OData.Formatter
         [InlineData("CustomCollection", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
         [InlineData("NullableColors", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
         [InlineData("ComplexCollection", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
-        // -- "NormalPass_FromParentComplex" -- ensure existing behavior has not changed when serializing properties off a complex attached to the entity
+        // -- "NormalPass_FromParentComplex" -- ensure existing behavior has not changed when serializing 
+        //                                      properties off a complex attached to the entity
         [InlineData("Array", NullCollectionsTestMode.NormalPass_FromParentComplex)]
         [InlineData("IEnumerable", NullCollectionsTestMode.NormalPass_FromParentComplex)]
         [InlineData("ICollection", NullCollectionsTestMode.NormalPass_FromParentComplex)]
@@ -101,7 +106,8 @@ namespace System.Web.OData.Formatter
         [InlineData("CustomCollection", NullCollectionsTestMode.NormalPass_FromParentComplex)]
         [InlineData("NullableColors", NullCollectionsTestMode.NormalPass_FromParentComplex)]
         [InlineData("ComplexCollection", NullCollectionsTestMode.NormalPass_FromParentComplex)]
-        // -- "NormalFail_FromParentComplex" -- ensure existing behavior has not changed when serializing properties off a complex attached to the entity
+        // -- "NormalFail_FromParentComplex" -- ensure existing behavior has not changed when serializing 
+        //                                      properties off a complex attached to the entity
         [InlineData("Array", NullCollectionsTestMode.NormalFail_FromParentComplex)]
         [InlineData("IEnumerable", NullCollectionsTestMode.NormalFail_FromParentComplex)]
         [InlineData("ICollection", NullCollectionsTestMode.NormalFail_FromParentComplex)]
@@ -111,7 +117,9 @@ namespace System.Web.OData.Formatter
         [InlineData("CustomCollection", NullCollectionsTestMode.NormalFail_FromParentComplex)]
         [InlineData("NullableColors", NullCollectionsTestMode.NormalFail_FromParentComplex)]
         [InlineData("ComplexCollection", NullCollectionsTestMode.NormalFail_FromParentComplex)]
-        // -- "DoNotSerialize_FromParentComplex" -- ensure null collections are left out of serialization when setting is enabled when serializing properties off a complex attached to the entity
+        // -- "DoNotSerialize_FromParentComplex" -- ensure null collections are left out of serialization 
+        //                                          when setting is enabled when serializing properties off a complex 
+        //                                          attached to the entity
         [InlineData("Array", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
         [InlineData("IEnumerable", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
         [InlineData("ICollection", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
@@ -121,7 +129,9 @@ namespace System.Web.OData.Formatter
         [InlineData("CustomCollection", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
         [InlineData("NullableColors", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
         [InlineData("ComplexCollection", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
-        // -- "SerializeAsEmpty_FromParentComplex" -- ensure null collections are serialized as if they were empty collections when serializing properties off a complex attached to the entity
+        // -- "SerializeAsEmpty_FromParentComplex" -- ensure null collections are serialized as if they were empty 
+        //                                            collections when serializing properties off a complex attached 
+        //                                            to the entity
         [InlineData("Array", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
         [InlineData("IEnumerable", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
         [InlineData("ICollection", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
@@ -133,7 +143,7 @@ namespace System.Web.OData.Formatter
         [InlineData("ComplexCollection", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
         public void NullCollectionProperties_Deserialize(string propertyName, NullCollectionsTestMode testMode)
         {
-            // setup
+            // Arrange
             NullCollectionsTestsModel testObject = new NullCollectionsTestsModel();
             switch (testMode)
             {
@@ -153,20 +163,23 @@ namespace System.Web.OData.Formatter
                 case NullCollectionsTestMode.NormalPass_FromParentComplex:
                     break;
                 case NullCollectionsTestMode.NormalFail_FromParentComplex:
-                    testObject.ParentComplex.GetType().GetProperty(propertyName).SetValue(testObject.ParentComplex, null);
+                    testObject.ParentComplex.GetType().GetProperty(propertyName)
+                        .SetValue(testObject.ParentComplex, null);
                     break;
                 case NullCollectionsTestMode.DoNotSerialize_FromParentComplex:
-                    testObject.ParentComplex.GetType().GetProperty(propertyName).SetValue(testObject.ParentComplex, null);
+                    testObject.ParentComplex.GetType().GetProperty(propertyName)
+                        .SetValue(testObject.ParentComplex, null);
                     _config.SetDoNotSerializeNullCollections(true);
                     break;
                 case NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex:
-                    testObject.ParentComplex.GetType().GetProperty(propertyName).SetValue(testObject.ParentComplex, null);
+                    testObject.ParentComplex.GetType().GetProperty(propertyName)
+                        .SetValue(testObject.ParentComplex, null);
                     _config.SetSerializeNullCollectionsAsEmpty(true);
                     break;
             }
             NullCollectionsTestsController.TestObject = testObject;
 
-            // execute
+            // Act
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/NullCollectionsTests/");
             HttpResponseMessage response = null;
             try
@@ -176,7 +189,7 @@ namespace System.Web.OData.Formatter
             }
             catch (Exception e)
             {
-                // validate
+                // Assert
                 if (testMode == NullCollectionsTestMode.NormalFail_FromEntity ||
                     testMode == NullCollectionsTestMode.NormalFail_FromParentComplex)
                 {
@@ -187,16 +200,18 @@ namespace System.Web.OData.Formatter
                     throw;
             }
 
-            // validate
+            // Assert
             string responseJson = response.Content.ReadAsStringAsync().Result;
             dynamic result = JToken.Parse(responseJson);
             switch (testMode)
             {
                 case NullCollectionsTestMode.NormalPass_FromEntity:
                     if (propertyName == "NullableColors")
-                        Assert.Equal(new[] { Color.Red.ToString() }, (IEnumerable<string>)result[propertyName].Values<string>());
+                        Assert.Equal(new[] { Color.Red.ToString() }, (IEnumerable<string>)result[propertyName]
+                            .Values<string>());
                     else if (propertyName == "ComplexCollection")
-                        Assert.Equal(new[] { 42 }, ((IEnumerable<JObject>)result[propertyName].Values<JObject>()).Select(v => (int)v.Property("A")));
+                        Assert.Equal(new[] { 42 }, ((IEnumerable<JObject>)result[propertyName].Values<JObject>())
+                            .Select(v => (int)v.Property("A")));
                     else
                         Assert.Equal(new[] { 42 }, (IEnumerable<int>)result[propertyName].Values<int>());
                     break;
@@ -211,9 +226,11 @@ namespace System.Web.OData.Formatter
                 case NullCollectionsTestMode.NormalPass_FromParentComplex:
                     var parent = result["ParentComplex"];
                     if (propertyName == "NullableColors")
-                        Assert.Equal(new[] { Color.Red.ToString() }, (IEnumerable<string>)parent[propertyName].Values<string>());
+                        Assert.Equal(new[] { Color.Red.ToString() }, (IEnumerable<string>)parent[propertyName]
+                            .Values<string>());
                     else if (propertyName == "ComplexCollection")
-                        Assert.Equal(new[] { 42 }, ((IEnumerable<JObject>)parent[propertyName].Values<JObject>()).Select(v => (int)v.Property("A")));
+                        Assert.Equal(new[] { 42 }, ((IEnumerable<JObject>)parent[propertyName].Values<JObject>())
+                            .Select(v => (int)v.Property("A")));
                     else
                         Assert.Equal(new[] { 42 }, (IEnumerable<int>)parent[propertyName].Values<int>());
                     break;
@@ -280,10 +297,6 @@ namespace System.Web.OData.Formatter
 
         public NullComplexParent ParentComplex { get; set; }
 
-        //public Vehicle[] Vehicles { get; set; }
-
-        //public Vehicle Vehicle { get; set; }
-
         public CustomCollection_NullCollectionsTestsModel<int> CustomCollection { get; set; }
 
         public IEnumerable<Color?> NullableColors { get; set; }
@@ -325,10 +338,6 @@ namespace System.Web.OData.Formatter
         public List<int> List { get; set; }
 
         public IEnumerable<NullComplexChild> ComplexCollection { get; set; }
-
-        //public Vehicle[] Vehicles { get; set; }
-
-        //public Vehicle Vehicle { get; set; }
 
         public CustomCollection_NullCollectionsTestsModel<int> CustomCollection { get; set; }
 

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/NullCollectionsTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/NullCollectionsTests.cs
@@ -133,7 +133,7 @@ namespace System.Web.OData.Formatter
         [InlineData("ComplexCollection", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
         public void NullCollectionProperties_Deserialize(string propertyName, NullCollectionsTestMode testMode)
         {
-            // Arrange
+            // setup
             NullCollectionsTestsModel testObject = new NullCollectionsTestsModel();
             switch (testMode)
             {
@@ -166,7 +166,7 @@ namespace System.Web.OData.Formatter
             }
             NullCollectionsTestsController.TestObject = testObject;
 
-            // Act
+            // execute
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/NullCollectionsTests/");
             HttpResponseMessage response = null;
             try
@@ -176,7 +176,7 @@ namespace System.Web.OData.Formatter
             }
             catch (Exception e)
             {
-                // Assert
+                // validate
                 if (testMode == NullCollectionsTestMode.NormalFail_FromEntity ||
                     testMode == NullCollectionsTestMode.NormalFail_FromParentComplex)
                 {
@@ -187,7 +187,7 @@ namespace System.Web.OData.Formatter
                     throw;
             }
 
-            // Assert
+            // validate
             string responseJson = response.Content.ReadAsStringAsync().Result;
             dynamic result = JToken.Parse(responseJson);
             switch (testMode)
@@ -280,6 +280,10 @@ namespace System.Web.OData.Formatter
 
         public NullComplexParent ParentComplex { get; set; }
 
+        //public Vehicle[] Vehicles { get; set; }
+
+        //public Vehicle Vehicle { get; set; }
+
         public CustomCollection_NullCollectionsTestsModel<int> CustomCollection { get; set; }
 
         public IEnumerable<Color?> NullableColors { get; set; }
@@ -321,6 +325,10 @@ namespace System.Web.OData.Formatter
         public List<int> List { get; set; }
 
         public IEnumerable<NullComplexChild> ComplexCollection { get; set; }
+
+        //public Vehicle[] Vehicles { get; set; }
+
+        //public Vehicle Vehicle { get; set; }
 
         public CustomCollection_NullCollectionsTestsModel<int> CustomCollection { get; set; }
 

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/NullCollectionsTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/NullCollectionsTests.cs
@@ -1,0 +1,341 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Web.Http;
+using System.Web.OData.Builder;
+using System.Web.OData.Builder.TestModels;
+using System.Web.OData.Extensions;
+using Microsoft.OData.Edm;
+using Microsoft.TestCommon;
+using Newtonsoft.Json.Linq;
+
+namespace System.Web.OData.Formatter
+{
+    public class NullCollectionsTests
+    {
+        private HttpClient _client;
+        private HttpConfiguration _config;
+
+        public enum NullCollectionsTestMode
+        {
+            NormalPass_FromEntity,
+            NormalFail_FromEntity,
+            DoNotSerialize_FromEntity,
+            SerializeAsEmpty_FromEntity,
+            NormalPass_FromParentComplex,
+            NormalFail_FromParentComplex,
+            DoNotSerialize_FromParentComplex,
+            SerializeAsEmpty_FromParentComplex,
+        }
+
+        public NullCollectionsTests()
+        {
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<NullCollectionsTestsModel>("NullCollectionsTests");
+            builder.EntitySet<Vehicle>("vehicles");
+            IEdmModel model = builder.GetEdmModel();
+
+            _config = new[] { typeof(NullCollectionsTestsController) }.GetHttpConfiguration();
+            _config.Formatters.Clear();
+            _config.Formatters.AddRange(ODataMediaTypeFormatters.Create());
+            _config.MapODataServiceRoute(model);
+
+            HttpServer server = new HttpServer(_config);
+            _client = new HttpClient(server);
+        }
+
+        [Theory]
+        // -- "NormalPass_FromEntity" -- ensure existing behavior has not changed when serializing properties off the base entity
+        [InlineData("Array", NullCollectionsTestMode.NormalPass_FromEntity)]
+        [InlineData("IEnumerable", NullCollectionsTestMode.NormalPass_FromEntity)]
+        [InlineData("ICollection", NullCollectionsTestMode.NormalPass_FromEntity)]
+        [InlineData("IList", NullCollectionsTestMode.NormalPass_FromEntity)]
+        [InlineData("List", NullCollectionsTestMode.NormalPass_FromEntity)]
+        [InlineData("Collection", NullCollectionsTestMode.NormalPass_FromEntity)]
+        [InlineData("CustomCollection", NullCollectionsTestMode.NormalPass_FromEntity)]
+        [InlineData("NullableColors", NullCollectionsTestMode.NormalPass_FromEntity)]
+        [InlineData("ComplexCollection", NullCollectionsTestMode.NormalPass_FromEntity)]
+        // -- "NormalFail_FromEntity" -- ensure existing behavior has not changed when serializing properties off the base entity
+        [InlineData("Array", NullCollectionsTestMode.NormalFail_FromEntity)]
+        [InlineData("IEnumerable", NullCollectionsTestMode.NormalFail_FromEntity)]
+        [InlineData("ICollection", NullCollectionsTestMode.NormalFail_FromEntity)]
+        [InlineData("IList", NullCollectionsTestMode.NormalFail_FromEntity)]
+        [InlineData("List", NullCollectionsTestMode.NormalFail_FromEntity)]
+        [InlineData("Collection", NullCollectionsTestMode.NormalFail_FromEntity)]
+        [InlineData("CustomCollection", NullCollectionsTestMode.NormalFail_FromEntity)]
+        [InlineData("NullableColors", NullCollectionsTestMode.NormalFail_FromEntity)]
+        [InlineData("ComplexCollection", NullCollectionsTestMode.NormalFail_FromEntity)]
+        // -- "DoNotSerialize_FromEntity" -- ensure null collections are left out of serialization when setting is enabled when serializing properties off the base entity
+        [InlineData("Array", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
+        [InlineData("IEnumerable", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
+        [InlineData("ICollection", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
+        [InlineData("IList", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
+        [InlineData("List", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
+        [InlineData("Collection", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
+        [InlineData("CustomCollection", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
+        [InlineData("NullableColors", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
+        [InlineData("ComplexCollection", NullCollectionsTestMode.DoNotSerialize_FromEntity)]
+        // -- "SerializeAsEmpty_FromEntity" -- ensure null collections are serialized as if they were empty collections when serializing properties off the base entity
+        [InlineData("Array", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
+        [InlineData("IEnumerable", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
+        [InlineData("ICollection", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
+        [InlineData("IList", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
+        [InlineData("List", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
+        [InlineData("Collection", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
+        [InlineData("CustomCollection", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
+        [InlineData("NullableColors", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
+        [InlineData("ComplexCollection", NullCollectionsTestMode.SerializeAsEmpty_FromEntity)]
+        // -- "NormalPass_FromParentComplex" -- ensure existing behavior has not changed when serializing properties off a complex attached to the entity
+        [InlineData("Array", NullCollectionsTestMode.NormalPass_FromParentComplex)]
+        [InlineData("IEnumerable", NullCollectionsTestMode.NormalPass_FromParentComplex)]
+        [InlineData("ICollection", NullCollectionsTestMode.NormalPass_FromParentComplex)]
+        [InlineData("IList", NullCollectionsTestMode.NormalPass_FromParentComplex)]
+        [InlineData("List", NullCollectionsTestMode.NormalPass_FromParentComplex)]
+        [InlineData("Collection", NullCollectionsTestMode.NormalPass_FromParentComplex)]
+        [InlineData("CustomCollection", NullCollectionsTestMode.NormalPass_FromParentComplex)]
+        [InlineData("NullableColors", NullCollectionsTestMode.NormalPass_FromParentComplex)]
+        [InlineData("ComplexCollection", NullCollectionsTestMode.NormalPass_FromParentComplex)]
+        // -- "NormalFail_FromParentComplex" -- ensure existing behavior has not changed when serializing properties off a complex attached to the entity
+        [InlineData("Array", NullCollectionsTestMode.NormalFail_FromParentComplex)]
+        [InlineData("IEnumerable", NullCollectionsTestMode.NormalFail_FromParentComplex)]
+        [InlineData("ICollection", NullCollectionsTestMode.NormalFail_FromParentComplex)]
+        [InlineData("IList", NullCollectionsTestMode.NormalFail_FromParentComplex)]
+        [InlineData("List", NullCollectionsTestMode.NormalFail_FromParentComplex)]
+        [InlineData("Collection", NullCollectionsTestMode.NormalFail_FromParentComplex)]
+        [InlineData("CustomCollection", NullCollectionsTestMode.NormalFail_FromParentComplex)]
+        [InlineData("NullableColors", NullCollectionsTestMode.NormalFail_FromParentComplex)]
+        [InlineData("ComplexCollection", NullCollectionsTestMode.NormalFail_FromParentComplex)]
+        // -- "DoNotSerialize_FromParentComplex" -- ensure null collections are left out of serialization when setting is enabled when serializing properties off a complex attached to the entity
+        [InlineData("Array", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
+        [InlineData("IEnumerable", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
+        [InlineData("ICollection", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
+        [InlineData("IList", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
+        [InlineData("List", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
+        [InlineData("Collection", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
+        [InlineData("CustomCollection", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
+        [InlineData("NullableColors", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
+        [InlineData("ComplexCollection", NullCollectionsTestMode.DoNotSerialize_FromParentComplex)]
+        // -- "SerializeAsEmpty_FromParentComplex" -- ensure null collections are serialized as if they were empty collections when serializing properties off a complex attached to the entity
+        [InlineData("Array", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
+        [InlineData("IEnumerable", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
+        [InlineData("ICollection", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
+        [InlineData("IList", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
+        [InlineData("List", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
+        [InlineData("Collection", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
+        [InlineData("CustomCollection", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
+        [InlineData("NullableColors", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
+        [InlineData("ComplexCollection", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
+        public void NullCollectionProperties_Deserialize(string propertyName, NullCollectionsTestMode testMode)
+        {
+            // setup
+            NullCollectionsTestsModel testObject = new NullCollectionsTestsModel();
+            switch (testMode)
+            {
+                case NullCollectionsTestMode.NormalPass_FromEntity:
+                    break;
+                case NullCollectionsTestMode.NormalFail_FromEntity:
+                    testObject.GetType().GetProperty(propertyName).SetValue(testObject, null);
+                    break;
+                case NullCollectionsTestMode.DoNotSerialize_FromEntity:
+                    testObject.GetType().GetProperty(propertyName).SetValue(testObject, null);
+                    _config.SetDoNotSerializeNullCollections(true);
+                    break;
+                case NullCollectionsTestMode.SerializeAsEmpty_FromEntity:
+                    testObject.GetType().GetProperty(propertyName).SetValue(testObject, null);
+                    _config.SetSerializeNullCollectionsAsEmpty(true);
+                    break;
+                case NullCollectionsTestMode.NormalPass_FromParentComplex:
+                    break;
+                case NullCollectionsTestMode.NormalFail_FromParentComplex:
+                    testObject.ParentComplex.GetType().GetProperty(propertyName).SetValue(testObject.ParentComplex, null);
+                    break;
+                case NullCollectionsTestMode.DoNotSerialize_FromParentComplex:
+                    testObject.ParentComplex.GetType().GetProperty(propertyName).SetValue(testObject.ParentComplex, null);
+                    _config.SetDoNotSerializeNullCollections(true);
+                    break;
+                case NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex:
+                    testObject.ParentComplex.GetType().GetProperty(propertyName).SetValue(testObject.ParentComplex, null);
+                    _config.SetSerializeNullCollectionsAsEmpty(true);
+                    break;
+            }
+            NullCollectionsTestsController.TestObject = testObject;
+
+            // execute
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/NullCollectionsTests/");
+            HttpResponseMessage response = null;
+            try
+            {
+                response = _client.SendAsync(request).Result;
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception e)
+            {
+                // validate
+                if (testMode == NullCollectionsTestMode.NormalFail_FromEntity ||
+                    testMode == NullCollectionsTestMode.NormalFail_FromParentComplex)
+                {
+                    Assert.Equal("Null collections cannot be serialized.", e.InnerException.Message);
+                    return;
+                }
+                else
+                    throw;
+            }
+
+            // validate
+            string responseJson = response.Content.ReadAsStringAsync().Result;
+            dynamic result = JToken.Parse(responseJson);
+            switch (testMode)
+            {
+                case NullCollectionsTestMode.NormalPass_FromEntity:
+                    if (propertyName == "NullableColors")
+                        Assert.Equal(new[] { Color.Red.ToString() }, (IEnumerable<string>)result[propertyName].Values<string>());
+                    else if (propertyName == "ComplexCollection")
+                        Assert.Equal(new[] { 42 }, ((IEnumerable<JObject>)result[propertyName].Values<JObject>()).Select(v => (int)v.Property("A")));
+                    else
+                        Assert.Equal(new[] { 42 }, (IEnumerable<int>)result[propertyName].Values<int>());
+                    break;
+                case NullCollectionsTestMode.DoNotSerialize_FromEntity:
+                    Assert.Null(result[propertyName]); 
+                    break;
+                case NullCollectionsTestMode.SerializeAsEmpty_FromEntity:
+                    Assert.NotNull(result[propertyName]);
+                    IEnumerable<JObject> collection = result[propertyName].Values<JObject>();
+                    Assert.Empty(collection);
+                    break;
+                case NullCollectionsTestMode.NormalPass_FromParentComplex:
+                    var parent = result["ParentComplex"];
+                    if (propertyName == "NullableColors")
+                        Assert.Equal(new[] { Color.Red.ToString() }, (IEnumerable<string>)parent[propertyName].Values<string>());
+                    else if (propertyName == "ComplexCollection")
+                        Assert.Equal(new[] { 42 }, ((IEnumerable<JObject>)parent[propertyName].Values<JObject>()).Select(v => (int)v.Property("A")));
+                    else
+                        Assert.Equal(new[] { 42 }, (IEnumerable<int>)parent[propertyName].Values<int>());
+                    break;
+                case NullCollectionsTestMode.DoNotSerialize_FromParentComplex:
+                    var parent2 = result["ParentComplex"];
+                    Assert.Null(parent2[propertyName]); 
+                    break;
+                case NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex:
+                    var parent3 = result["ParentComplex"];
+                    Assert.NotNull(parent3[propertyName]);
+                    IEnumerable<JObject> collection2 = parent3[propertyName].Values<JObject>();
+                    Assert.Empty(collection2);
+                    break;
+            }
+        }
+    }
+
+    public class NullCollectionsTestsController : ODataController
+    {
+        internal static NullCollectionsTestsModel TestObject { get; set; }
+
+        public NullCollectionsTestsModel Get()
+        {
+            if (!ModelState.IsValid)
+            {
+                throw new HttpResponseException(HttpStatusCode.ExpectationFailed);
+            }
+
+            return TestObject;
+        }
+    }
+
+    public class NullCollectionsTestsModel
+    {
+        public NullCollectionsTestsModel()
+        {
+            Array = new int[] { 42 };
+            IEnumerable = new int[] { 42 };
+            ICollection = new int[] { 42 };
+            IList = new int[] { 42 };
+            List = new List<int> { 42 };
+            Collection = new Collection<int> { 42 };
+            ComplexCollection = new NullComplexChild[] { new NullComplexChild { A = 42 } };
+            ParentComplex = new NullComplexParent();
+            CustomCollection = new CustomCollection_NullCollectionsTestsModel<int> { 42 };
+            NullableColors = new Color?[] { Color.Red };
+        }
+
+        public int ID { get; set; }
+
+        public int[] Array { get; set; }
+
+        public IEnumerable<int> IEnumerable { get; set; }
+
+        public IList<int> IList { get; set; }
+
+        public ICollection<int> ICollection { get; set; }
+
+        public Collection<int> Collection { get; set; }
+
+        public List<int> List { get; set; }
+
+        public IEnumerable<NullComplexChild> ComplexCollection { get; set; }
+
+        public NullComplexParent ParentComplex { get; set; }
+
+        //public Vehicle[] Vehicles { get; set; }
+
+        //public Vehicle Vehicle { get; set; }
+
+        public CustomCollection_NullCollectionsTestsModel<int> CustomCollection { get; set; }
+
+        public IEnumerable<Color?> NullableColors { get; set; }
+    }
+
+    public class NullComplexChild
+    {
+        public int A { get; set; }
+    }
+
+    // we re-test all of the above properties on the entity (except ourself but including a different child complex 
+    // collection) because the serializer handles each parent type (including entity vs complex) through different 
+    // code paths
+    public class NullComplexParent
+    {
+        public NullComplexParent()
+        {
+            Array = new int[] { 42 };
+            IEnumerable = new int[] { 42 };
+            ICollection = new int[] { 42 };
+            IList = new int[] { 42 };
+            List = new List<int> { 42 };
+            Collection = new Collection<int> { 42 };
+            ComplexCollection = new NullComplexChild[] { new NullComplexChild { A = 42 } };
+            CustomCollection = new CustomCollection_NullCollectionsTestsModel<int> { 42 };
+            NullableColors = new Color?[] { Color.Red };
+        }
+
+        public int[] Array { get; set; }
+
+        public IEnumerable<int> IEnumerable { get; set; }
+
+        public IList<int> IList { get; set; }
+
+        public ICollection<int> ICollection { get; set; }
+
+        public Collection<int> Collection { get; set; }
+
+        public List<int> List { get; set; }
+
+        public IEnumerable<NullComplexChild> ComplexCollection { get; set; }
+
+        //public Vehicle[] Vehicles { get; set; }
+
+        //public Vehicle Vehicle { get; set; }
+
+        public CustomCollection_NullCollectionsTestsModel<int> CustomCollection { get; set; }
+
+        public IEnumerable<Color?> NullableColors { get; set; }
+    }
+
+    public class CustomCollection_NullCollectionsTestsModel<T> : List<T>
+    {
+    }
+}

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/NullCollectionsTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/NullCollectionsTests.cs
@@ -133,7 +133,7 @@ namespace System.Web.OData.Formatter
         [InlineData("ComplexCollection", NullCollectionsTestMode.SerializeAsEmpty_FromParentComplex)]
         public void NullCollectionProperties_Deserialize(string propertyName, NullCollectionsTestMode testMode)
         {
-            // setup
+            // Arrange
             NullCollectionsTestsModel testObject = new NullCollectionsTestsModel();
             switch (testMode)
             {
@@ -166,7 +166,7 @@ namespace System.Web.OData.Formatter
             }
             NullCollectionsTestsController.TestObject = testObject;
 
-            // execute
+            // Act
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/NullCollectionsTests/");
             HttpResponseMessage response = null;
             try
@@ -176,7 +176,7 @@ namespace System.Web.OData.Formatter
             }
             catch (Exception e)
             {
-                // validate
+                // Assert
                 if (testMode == NullCollectionsTestMode.NormalFail_FromEntity ||
                     testMode == NullCollectionsTestMode.NormalFail_FromParentComplex)
                 {
@@ -187,7 +187,7 @@ namespace System.Web.OData.Formatter
                     throw;
             }
 
-            // validate
+            // Assert
             string responseJson = response.Content.ReadAsStringAsync().Result;
             dynamic result = JToken.Parse(responseJson);
             switch (testMode)
@@ -280,10 +280,6 @@ namespace System.Web.OData.Formatter
 
         public NullComplexParent ParentComplex { get; set; }
 
-        //public Vehicle[] Vehicles { get; set; }
-
-        //public Vehicle Vehicle { get; set; }
-
         public CustomCollection_NullCollectionsTestsModel<int> CustomCollection { get; set; }
 
         public IEnumerable<Color?> NullableColors { get; set; }
@@ -325,10 +321,6 @@ namespace System.Web.OData.Formatter
         public List<int> List { get; set; }
 
         public IEnumerable<NullComplexChild> ComplexCollection { get; set; }
-
-        //public Vehicle[] Vehicles { get; set; }
-
-        //public Vehicle Vehicle { get; set; }
 
         public CustomCollection_NullCollectionsTestsModel<int> CustomCollection { get; set; }
 

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataComplexTypeSerializerTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataComplexTypeSerializerTests.cs
@@ -101,9 +101,12 @@ namespace System.Web.OData.Formatter.Serialization
             };
             settings.SetContentType(ODataFormat.Json);
 
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
             ODataMessageWriter messageWriter = new ODataMessageWriter(message, settings);
             Mock<ODataComplexTypeSerializer> serializer = new Mock<ODataComplexTypeSerializer>(new DefaultODataSerializerProvider());
-            ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "ComplexPropertyName", Model = _model };
+            ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "ComplexPropertyName", Model = _model, Request = request };
             object graph = new object();
             ODataComplexValue complexValue = new ODataComplexValue
             {
@@ -165,7 +168,11 @@ namespace System.Web.OData.Formatter.Serialization
         [Fact]
         public void CreateODataComplexValue_WritesAllDeclaredProperties()
         {
-            var odataValue = _serializer.CreateODataComplexValue(_address, _addressTypeRef, new ODataSerializerContext { Model = _model });
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
+            ODataSerializerContext writeContext = new ODataSerializerContext { Model = _model, Request = request };
+            var odataValue = _serializer.CreateODataComplexValue(_address, _addressTypeRef, writeContext);
 
             ODataComplexValue complexValue = Assert.IsType<ODataComplexValue>(odataValue);
 
@@ -191,7 +198,11 @@ namespace System.Web.OData.Formatter.Serialization
             };
 
             // Act
-            var odataValue = _serializer.CreateODataComplexValue(location, _locationTypeRef, new ODataSerializerContext { Model = _model });
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
+            ODataSerializerContext writeContext = new ODataSerializerContext { Model = _model, Request = request };
+            var odataValue = _serializer.CreateODataComplexValue(location, _locationTypeRef, writeContext);
             ODataComplexValue complexValue = Assert.IsType<ODataComplexValue>(odataValue);
 
             // Assert
@@ -235,7 +246,11 @@ namespace System.Web.OData.Formatter.Serialization
             };
 
             // Act
-            var odataValue = _serializer.CreateODataComplexValue(location, _locationTypeRef, new ODataSerializerContext { Model = _model });
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
+            ODataSerializerContext writeContext = new ODataSerializerContext { Model = _model, Request = request };
+            var odataValue = _serializer.CreateODataComplexValue(location, _locationTypeRef, writeContext);
             ODataComplexValue complexValue = Assert.IsType<ODataComplexValue>(odataValue);
 
             // Assert
@@ -272,7 +287,11 @@ namespace System.Web.OData.Formatter.Serialization
             };
 
             // Act
-            var odataValue = _serializer.CreateODataComplexValue(location, _locationTypeRef, new ODataSerializerContext { Model = _model });
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
+            ODataSerializerContext writeContext = new ODataSerializerContext { Model = _model, Request = request };
+            var odataValue = _serializer.CreateODataComplexValue(location, _locationTypeRef, writeContext);
             ODataComplexValue complexValue = Assert.IsType<ODataComplexValue>(odataValue);
 
             // Assert
@@ -305,11 +324,15 @@ namespace System.Web.OData.Formatter.Serialization
 
             IEdmComplexTypeReference addressTypeRef = addressType.ToEdmTypeReference(isNullable: false).AsComplex();
 
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
             ODataSerializerProvider serializerProvider = new DefaultODataSerializerProvider();
             ODataComplexTypeSerializer serializer = new ODataComplexTypeSerializer(serializerProvider);
             ODataSerializerContext context = new ODataSerializerContext
             {
-                Model = model
+                Model = model,
+                Request = request
             };
 
             SimpleOpenAddress address = new SimpleOpenAddress()
@@ -376,11 +399,15 @@ namespace System.Web.OData.Formatter.Serialization
 
             IEdmComplexTypeReference addressTypeRef = addressType.ToEdmTypeReference(isNullable: false).AsComplex();
 
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
             ODataSerializerProvider serializerProvider = new DefaultODataSerializerProvider();
             ODataComplexTypeSerializer serializer = new ODataComplexTypeSerializer(serializerProvider);
             ODataSerializerContext context = new ODataSerializerContext
             {
-                Model = model
+                Model = model,
+                Request = request
             };
 
             SimpleOpenAddress topAddress = new SimpleOpenAddress()
@@ -464,11 +491,15 @@ namespace System.Web.OData.Formatter.Serialization
 
             IEdmComplexTypeReference addressTypeRef = addressType.ToEdmTypeReference(isNullable: false).AsComplex();
 
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
             ODataSerializerProvider serializerProvider = new DefaultODataSerializerProvider();
             ODataComplexTypeSerializer serializer = new ODataComplexTypeSerializer(serializerProvider);
             ODataSerializerContext context = new ODataSerializerContext
             {
-                Model = model
+                Model = model,
+                Request = request
             };
 
             SimpleOpenAddress address = new SimpleOpenAddress()
@@ -515,11 +546,15 @@ namespace System.Web.OData.Formatter.Serialization
 
             IEdmComplexTypeReference addressTypeRef = addressType.ToEdmTypeReference(isNullable: false).AsComplex();
 
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
             ODataSerializerProvider serializerProvider = new DefaultODataSerializerProvider();
             ODataComplexTypeSerializer serializer = new ODataComplexTypeSerializer(serializerProvider);
             ODataSerializerContext context = new ODataSerializerContext
             {
-                Model = model
+                Model = model,
+                Request = request
             };
 
             SimpleOpenAddress address = new SimpleOpenAddress()
@@ -627,11 +662,15 @@ namespace System.Web.OData.Formatter.Serialization
 
             IEdmComplexTypeReference addressTypeRef = addressType.ToEdmTypeReference(isNullable: false).AsComplex();
 
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
             ODataSerializerProvider serializerProvider = new DefaultODataSerializerProvider();
             ODataComplexTypeSerializer serializer = new ODataComplexTypeSerializer(serializerProvider);
             ODataSerializerContext context = new ODataSerializerContext
             {
-                Model = model
+                Model = model,
+                Request = request
             };
 
             Address address = new CnAddress()
@@ -697,7 +736,10 @@ namespace System.Web.OData.Formatter.Serialization
             complexEdmType.AddStructuralProperty("Property", EdmPrimitiveTypeKind.Int32);
             IEdmComplexTypeReference edmTypeReference = new EdmComplexTypeReference(complexEdmType, isNullable: false);
 
-            ODataSerializerContext context = new ODataSerializerContext();
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
+            ODataSerializerContext context = new ODataSerializerContext() { Request = request };
             TypedEdmComplexObject edmObject = new TypedEdmComplexObject(new { Property = 42 }, edmTypeReference, context.Model);
             ODataComplexTypeSerializer serializer = new ODataComplexTypeSerializer(new DefaultODataSerializerProvider());
 

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataPrimitiveSerializerTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataPrimitiveSerializerTests.cs
@@ -112,7 +112,10 @@ namespace System.Web.OData.Formatter.Serialization
         [Fact]
         public void WriteObject_Calls_CreateODataPrimitiveValue()
         {
-            ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "Property", Model = EdmCoreModel.Instance };
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
+            ODataSerializerContext writeContext = new ODataSerializerContext { RootElementName = "Property", Model = EdmCoreModel.Instance, Request = request };
             Mock<ODataPrimitiveSerializer> serializer = new Mock<ODataPrimitiveSerializer>();
             serializer.CallBase = true;
             serializer.Setup(s => s.CreateODataPrimitiveValue(
@@ -255,10 +258,14 @@ namespace System.Web.OData.Formatter.Serialization
         {
             // Arrange
             ODataPrimitiveSerializer serializer = new ODataPrimitiveSerializer();
+            HttpRequestMessage request = new HttpRequestMessage();
+            var config = new HttpConfiguration();
+            request.SetConfiguration(config);
             ODataSerializerContext writecontext = new ODataSerializerContext()
             {
                 RootElementName = "PropertyName",
-                Model = EdmCoreModel.Instance
+                Model = EdmCoreModel.Instance,
+                Request = request
             };
 
             ODataMessageWriterSettings settings = new ODataMessageWriterSettings

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataSingletonSerializerTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataSingletonSerializerTest.cs
@@ -36,7 +36,8 @@ namespace System.Web.OData.Formatter.Deserialization
                 Url = new UrlHelper(request),
                 Path = request.ODataProperties().Path,
                 Model = model,
-                NavigationSource = singleton
+                NavigationSource = singleton,
+                Request = request
             };
 
             ODataSerializerProvider serializerProvider = new DefaultODataSerializerProvider();

--- a/OData/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
+++ b/OData/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
@@ -140,6 +140,7 @@
     <Compile Include="OData\DateTimeTest.cs" />
     <Compile Include="OData\EdmEnumObjectCollectionTest.cs" />
     <Compile Include="OData\EdmEnumObjectTest.cs" />
+    <Compile Include="OData\Formatter\NullCollectionsTests.cs" />
     <Compile Include="OData\Formatter\ODataFunctionTests.cs" />
     <Compile Include="OData\EdmChangedObjectCollectionTest.cs" />
     <Compile Include="OData\EnableQueryTests.cs" />

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cd OData
 build
 ```
 ### Testing
-Each solution contains some test projects. Test projects use xUnit runner nuget package. Open the project, build it, and then test cases should appear in test explorer. Run all the tests in the test explorer. For running end-to-end tests you must open the solution as *Administrator*. More detail at [this](http://odata.github.io/WebApi/#09-01-unittest-e2etest).
+Each solution contains some test projects. Test projects use xUnit runner nuget package. Open the project, build it, and then test cases should appear in test explorer. If not, this is because the assemblies are delay signed and you're missing the private key so xunit will not load them in Visual Studio. To fix, un-check "Sign the assembly" in all project properties and remove the "PublicKey=" portion of all InternalsVisibleTo assembly attributes (do not check in this temporary workaround). Run all the tests in the test explorer. For running end-to-end tests you must open the solution as *Administrator*. More detail at [this](http://odata.github.io/WebApi/#09-01-unittest-e2etest).
 
 ### Nightly builds
 1.	In your NuGet Package Manager settings add the following package source:


### PR DESCRIPTION
…alizeNullCollections".  Updated existing tests (some things the serializer now touches, such as the config, were not moq'ed).  Added a series of new tests (via "Theory") which both validate the existing behavior is unchanged when the options are turned off, and that the new options work properly when turned on.  The new tests exercise the serializer via both the entity and complex type serialization paths using a variety of child collection types including nested complexes. Verified the full command-line build/test script passes.