### PR TITLE
[vNext] Returning proper EDM type for procedures returning primitive type

### DIFF
--- a/vNext/samples/ODataSample.Web/Models/ISampleService.cs
+++ b/vNext/samples/ODataSample.Web/Models/ISampleService.cs
@@ -13,6 +13,8 @@ namespace ODataSample.Web.Models
         Customer AddCustomerProduct(int customerId, int productId);
         [ODataAction(IsBound = true, BindingName = "customer")]
         Customer AddCustomerProducts(int customerId, IEnumerable<int> products);
+        [ODataFunction]
+        bool TestPrimitiveReturnType();
     }
 
 }

--- a/vNext/samples/ODataSample.Web/Models/SampleContext.cs
+++ b/vNext/samples/ODataSample.Web/Models/SampleContext.cs
@@ -170,6 +170,12 @@ namespace ODataSample.Web.Models
             int count = _customers.RemoveAll(p => p.CustomerId == id);
             return count > 0;
         }
+
+        public bool TestPrimitiveReturnType()
+        {
+            return true;
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Modified the default model provider to support the primitive return type
functionality. Added a simple test method to the sample.