### PR TITLE
[vNext] simple fixes for EdmBuilder

### DIFF
--- a/vNext/src/Microsoft.AspNet.OData/Builder/Conventions/Attributes/AttributeConvention.cs
+++ b/vNext/src/Microsoft.AspNet.OData/Builder/Conventions/Attributes/AttributeConvention.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNet.OData.Builder.Conventions.Attributes
         /// <returns></returns>
         public Attribute[] GetAttributes(Type type)
         {
-            return type.GetTypeInfo().GetCustomAttributes<Attribute>(false).ToArray();
+            return type.GetTypeInfo().GetCustomAttributes<Attribute>(false).OfType<Attribute>().Where(AttributeFilter).ToArray();
         }
     }
 }

--- a/vNext/src/Microsoft.AspNet.OData/Builder/EdmTypeBuilder.cs
+++ b/vNext/src/Microsoft.AspNet.OData/Builder/EdmTypeBuilder.cs
@@ -351,10 +351,21 @@ namespace Microsoft.AspNet.OData.Builder
         private IList<IEdmStructuralProperty> GetDeclaringPropertyInfo(IEnumerable<PropertyInfo> propertyInfos)
         {
             IList<IEdmProperty> edmProperties = new List<IEdmProperty>();
-            foreach (PropertyInfo propInfo in propertyInfos)
+            foreach (PropertyInfo pi in propertyInfos)
             {
+                var propInfo = pi;
+
                 IEdmProperty edmProperty;
-                if (_properties.TryGetValue(propInfo, out edmProperty))
+                if(!_properties.TryGetValue(propInfo, out edmProperty))
+                {
+#if DNX451
+                    if (propInfo.ReflectedType != propInfo.DeclaringType)
+                        propInfo = propInfo.DeclaringType.GetProperty(propInfo.Name);
+                    _properties.TryGetValue(propInfo, out edmProperty);
+#endif
+                }
+
+                if (edmProperty != null)
                 {
                     edmProperties.Add(edmProperty);
                 }

--- a/vNext/src/Microsoft.AspNet.OData/Builder/EdmTypeBuilder.cs
+++ b/vNext/src/Microsoft.AspNet.OData/Builder/EdmTypeBuilder.cs
@@ -351,28 +351,17 @@ namespace Microsoft.AspNet.OData.Builder
         private IList<IEdmStructuralProperty> GetDeclaringPropertyInfo(IEnumerable<PropertyInfo> propertyInfos)
         {
             IList<IEdmProperty> edmProperties = new List<IEdmProperty>();
-            foreach (PropertyInfo pi in propertyInfos)
+            foreach (PropertyInfo propInfo in propertyInfos)
             {
-                var propInfo = pi;
-
                 IEdmProperty edmProperty;
-                if(!_properties.TryGetValue(propInfo, out edmProperty))
-                {
-#if DNX451
-                    if (propInfo.ReflectedType != propInfo.DeclaringType)
-                        propInfo = propInfo.DeclaringType.GetProperty(propInfo.Name);
-                    _properties.TryGetValue(propInfo, out edmProperty);
-#endif
-                }
-
-                if (edmProperty != null)
+                if (_properties.TryGetValue(propInfo, out edmProperty))
                 {
                     edmProperties.Add(edmProperty);
                 }
                 else
                 {
                     Contract.Assert(propInfo.DeclaringType != null);
-                    Type baseType = propInfo.DeclaringType.GetTypeInfo().BaseType;
+                    Type baseType = propInfo.DeclaringType;
                     while (baseType != null)
                     {
                         PropertyInfo basePropInfo = baseType.GetProperty(propInfo.Name);


### PR DESCRIPTION
Hi,

I found missing attributions filtering for conventions applyings. Also propInfo.DeclaringType.GetTypeInfo().BaseType for most cases returns just System.Object instead of base class of entity. I can't locate any unit tests for vNext stuff, so I just pulling this fixes with label "it works for me" ;)