### PR TITLE
Provide an extensibility hook for consumers of ODataMediaTypeFormatter to customize base address of service root in OData uris

### DIFF
--- a/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
@@ -187,6 +187,19 @@ namespace System.Web.OData.Formatter
         public ODataMessageReaderSettings MessageReaderSettings { get; private set; }
 
         /// <summary>
+        /// Delegate type for calculating the base address for a given request.
+        /// </summary>
+        /// <param name="request">The HttpRequestMessage object.</param>
+        /// <returns>A base address uri to be used in the service root of the OData uri.</returns>
+        public delegate Uri GetBaseAddressDelegate(HttpRequestMessage request);
+
+        /// <summary>
+        /// Gets or sets a delegate method that allows consumers to provide an alternate base
+        /// address for OData uris.
+        /// </summary>
+        public GetBaseAddressDelegate GetBaseAddress { get; set; }
+
+        /// <summary>
         /// The request message associated with the per-request formatter instance.
         /// </summary>
         internal HttpRequestMessage Request { get; set; }
@@ -393,7 +406,7 @@ namespace System.Web.OData.Formatter
                 try
                 {
                     ODataMessageReaderSettings oDataReaderSettings = new ODataMessageReaderSettings(MessageReaderSettings);
-                    oDataReaderSettings.BaseUri = GetBaseAddress(Request);
+                    oDataReaderSettings.BaseUri = GetBaseAddressInternal(Request);
 
                     IODataRequestMessage oDataRequestMessage = new ODataMessageWrapper(readStream, contentHeaders, Request.GetODataContentIdMapping());
                     ODataMessageReader oDataMessageReader = new ODataMessageReader(oDataRequestMessage, oDataReaderSettings, model);
@@ -499,7 +512,7 @@ namespace System.Web.OData.Formatter
                 responseMessage.PreferenceAppliedHeader().AnnotationFilter = annotationFilter;
             }
 
-            Uri baseAddress = GetBaseAddress(Request);
+            Uri baseAddress = GetBaseAddressInternal(Request);
             ODataMessageWriterSettings writerSettings = new ODataMessageWriterSettings(MessageWriterSettings)
             {
                 PayloadBaseUri = baseAddress,
@@ -733,7 +746,33 @@ namespace System.Web.OData.Formatter
                 (type.IsCollection() && type.AsCollection().ElementType().IsEntity());
         }
 
-        private static Uri GetBaseAddress(HttpRequestMessage request)
+        /// <summary>
+        /// Internal method used for selecting the base address to be used with OData uris.
+        /// If the consumer has provided a delegate for overriding our default implementation,
+        /// we call that, otherwise we default to existing behavior below.
+        /// </summary>
+        /// <param name="request">The HttpRequestMessage object for the given request.</param>
+        /// <returns>The base address to be used as part of the service root; must terminate with a trailing '/'.</returns>
+        private Uri GetBaseAddressInternal(HttpRequestMessage request)
+        {
+            GetBaseAddressDelegate baseAddressDelegate = this.GetBaseAddress;
+
+            if (baseAddressDelegate != null)
+            {
+                return baseAddressDelegate(request);
+            }
+            else
+            {
+                return ODataMediaTypeFormatter.GetDefaultBaseAddress(request);
+            }
+        }
+
+        /// <summary>
+        /// Returns a base address to be used in the service root when reading or writing OData uris.
+        /// </summary>
+        /// <param name="request">The HttpRequestMessage object for the given request.</param>
+        /// <returns>The base address to be used as part of the service root in the OData uri; must terminate with a trailing '/'.</returns>
+        public static Uri GetDefaultBaseAddress(HttpRequestMessage request)
         {
             UrlHelper urlHelper = request.GetUrlHelper() ?? new UrlHelper(request);
 

--- a/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
@@ -774,6 +774,11 @@ namespace System.Web.OData.Formatter
         /// <returns>The base address to be used as part of the service root in the OData uri; must terminate with a trailing '/'.</returns>
         public static Uri GetDefaultBaseAddress(HttpRequestMessage request)
         {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
             UrlHelper urlHelper = request.GetUrlHelper() ?? new UrlHelper(request);
 
             string baseAddress = urlHelper.CreateODataLink();

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/ODataMediaTypeFormatterTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/ODataMediaTypeFormatterTests.cs
@@ -180,7 +180,7 @@ namespace System.Web.OData.Formatter
         }
 
         [Fact]
-        public void ODataMediaTypeFormatter_AllowsBaseAddressOverride()
+        public void GetBaseAddress_AllowsBaseAddressOverride()
         {
             string routeName = "Route";
             string routePrefix = "prefix";
@@ -204,6 +204,36 @@ namespace System.Web.OData.Formatter
             string actualContent = content.ReadAsStringAsync().Result;
 
             Assert.Contains("\"@odata.context\":\"" + newBaseUri, actualContent);
+        }
+
+        [Fact]
+        public void GetDefaultBaseAddress_ThrowsWhenRequestIsNull()
+        {
+            Assert.ThrowsArgumentNull(() => ODataMediaTypeFormatter.GetDefaultBaseAddress(null), "request");
+        }
+
+        [Fact]
+        public void GetDefaultBaseAddress_ReturnsCorrectBaseAddress()
+        {
+            // Arrange
+            string baseUriText = "http://discovery.contoso.com/";
+            string routePrefix = "api/discovery/v21.0";
+            string expectedBaseAddress = baseUriText + routePrefix + "/";
+            string fullUriText = baseUriText + routePrefix + "/Instances";
+            string routeName = "Route";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, fullUriText);
+            HttpConfiguration configuration = new HttpConfiguration();
+            IEdmModel model = new ODataConventionModelBuilder().GetEdmModel();
+            configuration.MapODataServiceRoute(routeName, routePrefix, model);
+            request.SetConfiguration(configuration);
+            request.ODataProperties().Model = model;
+            request.ODataProperties().RouteName = routeName;
+
+            // Act
+            Uri baseUri = ODataMediaTypeFormatter.GetDefaultBaseAddress(request);
+
+            // Assert
+            Assert.Equal(expectedBaseAddress, baseUri.ToString());
         }
 
         [Theory]

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/ODataMediaTypeFormatterTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/ODataMediaTypeFormatterTests.cs
@@ -157,6 +157,55 @@ namespace System.Web.OData.Formatter
                 "The ODataMediaTypeFormatter was unable to determine the base URI for the request. The request must be processed by an OData route for the OData formatter to serialize the response.");
         }
 
+        /// <summary>
+        /// Host name used by tests for verifying GetBaseAddress delegate
+        /// </summary>
+        private const string CustomHost = "www.microsoft.com";
+
+        /// <summary>
+        /// Delegate for GetBaseAddress that converts uris to https
+        /// </summary>
+        /// <param name="httpRequestMessage">The HttpRequestMessage representing this request.</param>
+        /// <returns>A custom uri for the base address.</returns>
+        private Uri GetCustomBaseAddress(HttpRequestMessage httpRequestMessage)
+        {
+            Uri baseAddress = ODataMediaTypeFormatter.GetDefaultBaseAddress(httpRequestMessage);
+
+            UriBuilder uriBuilder = new UriBuilder(baseAddress);
+            uriBuilder.Scheme = Uri.UriSchemeHttps;
+            uriBuilder.Port = -1;
+            uriBuilder.Host = CustomHost;
+            baseAddress = uriBuilder.Uri;
+            return baseAddress;
+        }
+
+        [Fact]
+        public void ODataMediaTypeFormatter_AllowsBaseAddressOverride()
+        {
+            string routeName = "Route";
+            string routePrefix = "prefix";
+            string baseUri = "http://localhost/prefix";
+            string newBaseUri = "https://" + CustomHost + "/" + routePrefix + "/";
+            IEdmModel model = new ODataConventionModelBuilder().GetEdmModel();
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, baseUri);
+            HttpConfiguration configuration = new HttpConfiguration();
+            configuration.MapODataServiceRoute(routeName, routePrefix, model);
+            request.SetConfiguration(configuration);
+            request.ODataProperties().Model = model;
+            request.ODataProperties().Path = new ODataPath();
+            request.ODataProperties().RouteName = routeName;
+            HttpRouteData routeData = new HttpRouteData(new HttpRoute());
+            routeData.Values.Add("a", "prefix");
+            request.SetRouteData(routeData);
+
+            ODataMediaTypeFormatter formatter = CreateFormatterWithJson(model, request, ODataPayloadKind.ServiceDocument);
+            formatter.GetBaseAddress = GetCustomBaseAddress;
+            var content = new ObjectContent<ODataServiceDocument>(new ODataServiceDocument(), formatter);
+            string actualContent = content.ReadAsStringAsync().Result;
+
+            Assert.Contains("\"@odata.context\":\"" + newBaseUri, actualContent);
+        }
+
         [Theory]
         [InlineData(null, null, "4.0")]
         [InlineData("1.0", null, "4.0")]


### PR DESCRIPTION
Issue #644 

- Added optional delegate for consumers of ODataMediaTypeFormatter
- Exposed existing GetBaseAddress method as public and renamed to GetDefaultBaseAddress
- Added test case to verify functionality

See https://github.com/OData/WebApi/issues/644