### PR TITLE
Update terminology in ODataMediaTypeFormatter to use "service root" per OData specification

### DIFF
--- a/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
@@ -187,6 +187,19 @@ namespace System.Web.OData.Formatter
         public ODataMessageReaderSettings MessageReaderSettings { get; private set; }
 
         /// <summary>
+        /// Delegate type for calculating the base address for a given request.
+        /// </summary>
+        /// <param name="request">The HttpRequestMessage object.</param>
+        /// <returns>A base address uri to be used in the service root of the OData uri.</returns>
+        public delegate Uri GetBaseAddressDelegate(HttpRequestMessage request);
+
+        /// <summary>
+        /// Gets or sets a delegate method that allows consumers to provide an alternate base
+        /// address for OData uris.
+        /// </summary>
+        public GetBaseAddressDelegate GetBaseAddress { get; set; }
+
+        /// <summary>
         /// The request message associated with the per-request formatter instance.
         /// </summary>
         internal HttpRequestMessage Request { get; set; }
@@ -393,7 +406,7 @@ namespace System.Web.OData.Formatter
                 try
                 {
                     ODataMessageReaderSettings oDataReaderSettings = new ODataMessageReaderSettings(MessageReaderSettings);
-                    oDataReaderSettings.BaseUri = GetBaseAddress(Request);
+                    oDataReaderSettings.BaseUri = GetBaseAddressInternal(Request);
 
                     IODataRequestMessage oDataRequestMessage = new ODataMessageWrapper(readStream, contentHeaders, Request.GetODataContentIdMapping());
                     ODataMessageReader oDataMessageReader = new ODataMessageReader(oDataRequestMessage, oDataReaderSettings, model);
@@ -499,7 +512,7 @@ namespace System.Web.OData.Formatter
                 responseMessage.PreferenceAppliedHeader().AnnotationFilter = annotationFilter;
             }
 
-            Uri baseAddress = GetBaseAddress(Request);
+            Uri baseAddress = GetBaseAddressInternal(Request);
             ODataMessageWriterSettings writerSettings = new ODataMessageWriterSettings(MessageWriterSettings)
             {
                 PayloadBaseUri = baseAddress,
@@ -733,7 +746,33 @@ namespace System.Web.OData.Formatter
                 (type.IsCollection() && type.AsCollection().ElementType().IsEntity());
         }
 
-        private static Uri GetBaseAddress(HttpRequestMessage request)
+        /// <summary>
+        /// Internal method used for selecting the base address to be used with OData uris.
+        /// If the consumer has provided a delegate for overriding our default implementation,
+        /// we call that, otherwise we default to existing behavior below.
+        /// </summary>
+        /// <param name="request">The HttpRequestMessage object for the given request.</param>
+        /// <returns>The base address to be used as part of the service root; must terminate with a trailing '/'.</returns>
+        private Uri GetBaseAddressInternal(HttpRequestMessage request)
+        {
+            GetBaseAddressDelegate baseAddressDelegate = this.GetBaseAddress;
+
+            if (baseAddressDelegate != null)
+            {
+                return baseAddressDelegate(request);
+            }
+            else
+            {
+                return ODataMediaTypeFormatter.GetDefaultBaseAddress(request);
+            }
+        }
+
+        /// <summary>
+        /// Returns a base address to be used in the service root when reading or writing OData uris.
+        /// </summary>
+        /// <param name="request">The HttpRequestMessage object for the given request.</param>
+        /// <returns>The base address to be used as part of the service root in the OData uri; must terminate with a trailing '/'.</returns>
+        public static Uri GetDefaultBaseAddress(HttpRequestMessage request)
         {
             UrlHelper urlHelper = request.GetUrlHelper() ?? new UrlHelper(request);
 

--- a/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
@@ -187,10 +187,10 @@ namespace System.Web.OData.Formatter
         public ODataMessageReaderSettings MessageReaderSettings { get; private set; }
 
         /// <summary>
-        /// Gets or sets a method that allows consumers to provide an alternate base
-        /// address for OData Uri.
+        /// Gets or sets a method that allows consumers to provide an alternate service
+        /// root for OData Uris.
         /// </summary>
-        public Func<HttpRequestMessage, Uri> BaseAddressFactory { get; set; }
+        public Func<HttpRequestMessage, Uri> ServiceRootResolver { get; set; }
 
         /// <summary>
         /// The request message associated with the per-request formatter instance.
@@ -399,7 +399,7 @@ namespace System.Web.OData.Formatter
                 try
                 {
                     ODataMessageReaderSettings oDataReaderSettings = new ODataMessageReaderSettings(MessageReaderSettings);
-                    oDataReaderSettings.BaseUri = GetBaseAddressInternal(Request);
+                    oDataReaderSettings.BaseUri = GetServiceRootInternal(Request);
 
                     IODataRequestMessage oDataRequestMessage = new ODataMessageWrapper(readStream, contentHeaders, Request.GetODataContentIdMapping());
                     ODataMessageReader oDataMessageReader = new ODataMessageReader(oDataRequestMessage, oDataReaderSettings, model);
@@ -505,10 +505,10 @@ namespace System.Web.OData.Formatter
                 responseMessage.PreferenceAppliedHeader().AnnotationFilter = annotationFilter;
             }
 
-            Uri baseAddress = GetBaseAddressInternal(Request);
+            Uri serviceRootUri = GetServiceRootInternal(Request);
             ODataMessageWriterSettings writerSettings = new ODataMessageWriterSettings(MessageWriterSettings)
             {
-                PayloadBaseUri = baseAddress,
+                PayloadBaseUri = serviceRootUri,
                 Version = _version,
             };
 
@@ -521,7 +521,7 @@ namespace System.Web.OData.Formatter
 
             writerSettings.ODataUri = new ODataUri
             {
-                ServiceRoot = baseAddress,
+                ServiceRoot = serviceRootUri,
 
                 // TODO: 1604 Convert webapi.odata's ODataPath to ODL's ODataPath, or use ODL's ODataPath.
                 SelectAndExpand = Request.ODataProperties().SelectExpandClause,
@@ -740,30 +740,30 @@ namespace System.Web.OData.Formatter
         }
 
         /// <summary>
-        /// Internal method used for selecting the base address to be used with OData uris.
+        /// Internal method used for selecting the service root to be used with OData uris.
         /// If the consumer has provided a delegate for overriding our default implementation,
         /// we call that, otherwise we default to existing behavior below.
         /// </summary>
         /// <param name="request">The HttpRequestMessage object for the given request.</param>
-        /// <returns>The base address to be used as part of the service root; must terminate with a trailing '/'.</returns>
-        private Uri GetBaseAddressInternal(HttpRequestMessage request)
+        /// <returns>The service root to be used when generating OData uris; must terminate with a trailing '/'.</returns>
+        private Uri GetServiceRootInternal(HttpRequestMessage request)
         {
-            if (BaseAddressFactory != null)
+            if (ServiceRootResolver != null)
             {
-                return BaseAddressFactory(request);
+                return ServiceRootResolver(request);
             }
             else
             {
-                return ODataMediaTypeFormatter.GetDefaultBaseAddress(request);
+                return ODataMediaTypeFormatter.GetDefaultServiceRoot(request);
             }
         }
 
         /// <summary>
-        /// Returns a base address to be used in the service root when reading or writing OData uris.
+        /// Returns an OData service root to be used in the service root when reading or writing OData uris.
         /// </summary>
         /// <param name="request">The HttpRequestMessage object for the given request.</param>
-        /// <returns>The base address to be used as part of the service root in the OData uri; must terminate with a trailing '/'.</returns>
-        public static Uri GetDefaultBaseAddress(HttpRequestMessage request)
+        /// <returns>The service root to be used as part of the service root in the OData uri; must terminate with a trailing '/'.</returns>
+        public static Uri GetDefaultServiceRoot(HttpRequestMessage request)
         {
             if (request == null)
             {
@@ -772,13 +772,13 @@ namespace System.Web.OData.Formatter
 
             UrlHelper urlHelper = request.GetUrlHelper() ?? new UrlHelper(request);
 
-            string baseAddress = urlHelper.CreateODataLink();
-            if (baseAddress == null)
+            string serviceRoot = urlHelper.CreateODataLink();
+            if (serviceRoot == null)
             {
                 throw new SerializationException(SRResources.UnableToDetermineBaseUrl);
             }
 
-            return baseAddress[baseAddress.Length - 1] != '/' ? new Uri(baseAddress + '/') : new Uri(baseAddress);
+            return serviceRoot[serviceRoot.Length - 1] != '/' ? new Uri(serviceRoot + '/') : new Uri(serviceRoot);
         }
 
         internal static ODataVersion GetODataResponseVersion(HttpRequestMessage request)

--- a/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
@@ -759,10 +759,10 @@ namespace System.Web.OData.Formatter
         }
 
         /// <summary>
-        /// Returns an OData service root to be used in the service root when reading or writing OData uris.
+        /// Returns an OData service root to be used when reading or writing OData uris.
         /// </summary>
         /// <param name="request">The HttpRequestMessage object for the given request.</param>
-        /// <returns>The service root to be used as part of the service root in the OData uri; must terminate with a trailing '/'.</returns>
+        /// <returns>The service root to be used in OData uris; must terminate with a trailing '/'.</returns>
         public static Uri GetDefaultServiceRoot(HttpRequestMessage request)
         {
             if (request == null)

--- a/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
@@ -774,6 +774,11 @@ namespace System.Web.OData.Formatter
         /// <returns>The base address to be used as part of the service root in the OData uri; must terminate with a trailing '/'.</returns>
         public static Uri GetDefaultBaseAddress(HttpRequestMessage request)
         {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
             UrlHelper urlHelper = request.GetUrlHelper() ?? new UrlHelper(request);
 
             string baseAddress = urlHelper.CreateODataLink();

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/ODataMediaTypeFormatterTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/ODataMediaTypeFormatterTests.cs
@@ -180,7 +180,7 @@ namespace System.Web.OData.Formatter
         }
 
         [Fact]
-        public void ODataMediaTypeFormatter_AllowsBaseAddressOverride()
+        public void GetBaseAddress_AllowsBaseAddressOverride()
         {
             string routeName = "Route";
             string routePrefix = "prefix";
@@ -204,6 +204,36 @@ namespace System.Web.OData.Formatter
             string actualContent = content.ReadAsStringAsync().Result;
 
             Assert.Contains("\"@odata.context\":\"" + newBaseUri, actualContent);
+        }
+
+        [Fact]
+        public void GetDefaultBaseAddress_ThrowsWhenRequestIsNull()
+        {
+            Assert.ThrowsArgumentNull(() => ODataMediaTypeFormatter.GetDefaultBaseAddress(null), "request");
+        }
+
+        [Fact]
+        public void GetDefaultBaseAddress_ReturnsCorrectBaseAddress()
+        {
+            // Arrange
+            string baseUriText = "http://discovery.contoso.com/";
+            string routePrefix = "api/discovery/v21.0";
+            string expectedBaseAddress = baseUriText + routePrefix + "/";
+            string fullUriText = baseUriText + routePrefix + "/Instances";
+            string routeName = "Route";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, fullUriText);
+            HttpConfiguration configuration = new HttpConfiguration();
+            IEdmModel model = new ODataConventionModelBuilder().GetEdmModel();
+            configuration.MapODataServiceRoute(routeName, routePrefix, model);
+            request.SetConfiguration(configuration);
+            request.ODataProperties().Model = model;
+            request.ODataProperties().RouteName = routeName;
+
+            // Act
+            Uri baseUri = ODataMediaTypeFormatter.GetDefaultBaseAddress(request);
+
+            // Assert
+            Assert.Equal(expectedBaseAddress, baseUri.ToString());
         }
 
         [Theory]

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/ODataMediaTypeFormatterTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/ODataMediaTypeFormatterTests.cs
@@ -157,6 +157,55 @@ namespace System.Web.OData.Formatter
                 "The ODataMediaTypeFormatter was unable to determine the base URI for the request. The request must be processed by an OData route for the OData formatter to serialize the response.");
         }
 
+        /// <summary>
+        /// Host name used by tests for verifying GetBaseAddress delegate
+        /// </summary>
+        private const string CustomHost = "www.microsoft.com";
+
+        /// <summary>
+        /// Delegate for GetBaseAddress that converts uris to https
+        /// </summary>
+        /// <param name="httpRequestMessage">The HttpRequestMessage representing this request.</param>
+        /// <returns>A custom uri for the base address.</returns>
+        private Uri GetCustomBaseAddress(HttpRequestMessage httpRequestMessage)
+        {
+            Uri baseAddress = ODataMediaTypeFormatter.GetDefaultBaseAddress(httpRequestMessage);
+
+            UriBuilder uriBuilder = new UriBuilder(baseAddress);
+            uriBuilder.Scheme = Uri.UriSchemeHttps;
+            uriBuilder.Port = -1;
+            uriBuilder.Host = CustomHost;
+            baseAddress = uriBuilder.Uri;
+            return baseAddress;
+        }
+
+        [Fact]
+        public void ODataMediaTypeFormatter_AllowsBaseAddressOverride()
+        {
+            string routeName = "Route";
+            string routePrefix = "prefix";
+            string baseUri = "http://localhost/prefix";
+            string newBaseUri = "https://" + CustomHost + "/" + routePrefix + "/";
+            IEdmModel model = new ODataConventionModelBuilder().GetEdmModel();
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, baseUri);
+            HttpConfiguration configuration = new HttpConfiguration();
+            configuration.MapODataServiceRoute(routeName, routePrefix, model);
+            request.SetConfiguration(configuration);
+            request.ODataProperties().Model = model;
+            request.ODataProperties().Path = new ODataPath();
+            request.ODataProperties().RouteName = routeName;
+            HttpRouteData routeData = new HttpRouteData(new HttpRoute());
+            routeData.Values.Add("a", "prefix");
+            request.SetRouteData(routeData);
+
+            ODataMediaTypeFormatter formatter = CreateFormatterWithJson(model, request, ODataPayloadKind.ServiceDocument);
+            formatter.GetBaseAddress = GetCustomBaseAddress;
+            var content = new ObjectContent<ODataServiceDocument>(new ODataServiceDocument(), formatter);
+            string actualContent = content.ReadAsStringAsync().Result;
+
+            Assert.Contains("\"@odata.context\":\"" + newBaseUri, actualContent);
+        }
+
         [Theory]
         [InlineData(null, null, "4.0")]
         [InlineData("1.0", null, "4.0")]

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/ODataMediaTypeFormatterTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/ODataMediaTypeFormatterTests.cs
@@ -158,18 +158,18 @@ namespace System.Web.OData.Formatter
         }
 
         /// <summary>
-        /// Host name used by tests for verifying GetBaseAddress delegate
+        /// Host name used by tests for verifying ServiceRootResolver
         /// </summary>
         private const string CustomHost = "www.microsoft.com";
 
         /// <summary>
-        /// Delegate for GetBaseAddress that converts uris to https
+        /// Custom implementation of GetServiceRoot that converts uris to https
         /// </summary>
         /// <param name="httpRequestMessage">The HttpRequestMessage representing this request.</param>
-        /// <returns>A custom uri for the base address.</returns>
-        private Uri GetCustomBaseAddress(HttpRequestMessage httpRequestMessage)
+        /// <returns>A custom uri for the service root.</returns>
+        private Uri CustomServiceRootResolver(HttpRequestMessage httpRequestMessage)
         {
-            Uri baseAddress = ODataMediaTypeFormatter.GetDefaultBaseAddress(httpRequestMessage);
+            Uri baseAddress = ODataMediaTypeFormatter.GetDefaultServiceRoot(httpRequestMessage);
 
             UriBuilder uriBuilder = new UriBuilder(baseAddress);
             uriBuilder.Scheme = Uri.UriSchemeHttps;
@@ -180,7 +180,7 @@ namespace System.Web.OData.Formatter
         }
 
         [Fact]
-        public void GetBaseAddress_AllowsBaseAddressOverride()
+        public void ServiceRootResolver_AllowsServiceRootOverride()
         {
             // Arrange
             string routeName = "Route";
@@ -200,7 +200,7 @@ namespace System.Web.OData.Formatter
 
             // Act
             ODataMediaTypeFormatter formatter = CreateFormatterWithJson(model, request, ODataPayloadKind.ServiceDocument);
-            formatter.BaseAddressFactory = GetCustomBaseAddress;
+            formatter.ServiceRootResolver = CustomServiceRootResolver;
             var content = new ObjectContent<ODataServiceDocument>(new ODataServiceDocument(), formatter);
             string actualContent = content.ReadAsStringAsync().Result;
 
@@ -209,13 +209,13 @@ namespace System.Web.OData.Formatter
         }
 
         [Fact]
-        public void GetDefaultBaseAddress_ThrowsWhenRequestIsNull()
+        public void ServiceRootResolver_ThrowsWhenRequestIsNull()
         {
-            Assert.ThrowsArgumentNull(() => ODataMediaTypeFormatter.GetDefaultBaseAddress(null), "request");
+            Assert.ThrowsArgumentNull(() => ODataMediaTypeFormatter.GetDefaultServiceRoot(null), "request");
         }
 
         [Fact]
-        public void GetDefaultBaseAddress_ReturnsCorrectBaseAddress()
+        public void GetDefaultServiceRoot_ReturnsCorrectServiceRoot()
         {
             // Arrange
             string baseUriText = "http://discovery.contoso.com/";
@@ -231,7 +231,7 @@ namespace System.Web.OData.Formatter
             request.ODataProperties().RouteName = routeName;
 
             // Act
-            Uri baseUri = ODataMediaTypeFormatter.GetDefaultBaseAddress(request);
+            Uri baseUri = ODataMediaTypeFormatter.GetDefaultServiceRoot(request);
 
             // Assert
             Assert.Equal(baseUriText + routePrefix + "/", baseUri.ToString());


### PR DESCRIPTION
This PR resolves #644 Updating latest change for "GetBaseAddress" extensibility to use proper OData terminology, namely "service root" instead of "base address".