### PR TITLE
Fixing NRE when referencing same enum twice

### DIFF
--- a/OData/src/System.Web.OData/OData/Builder/ODataConventionModelBuilder.cs
+++ b/OData/src/System.Web.OData/OData/Builder/ODataConventionModelBuilder.cs
@@ -231,9 +231,9 @@ namespace System.Web.OData.Builder
                     EnumMemberConfiguration enumMemberConfiguration = enumTypeConfiguration.AddMember((Enum)member);
                     enumMemberConfiguration.AddedExplicitly = addedExplicitly;
                 }
-            }
 
-            ApplyEnumTypeConventions(enumTypeConfiguration);
+                ApplyEnumTypeConventions(enumTypeConfiguration);
+            }
 
             return enumTypeConfiguration;
         }

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/EnumTypeTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/EnumTypeTest.cs
@@ -1084,6 +1084,19 @@ namespace System.Web.OData.Builder
             Assert.True(enumType.Members.Any(m => m.Name.Equals("KeepDefaultName")));
         }
 
+        
+        [Fact]
+        public void ODataConventionModelBuilder_DataContractAttribute_AllowsReferencingSameEnumTwice()
+        {
+            // Arrange
+            var builder = new ODataConventionModelBuilder();
+            builder.EnumType<Life>();
+
+            // Act
+            builder.EnumType<Life>();
+            IEdmModel model = builder.GetEdmModel();
+        }
+
         [Fact]
         public void ODataConventionModelBuilder_DataContractAttribute_WithAddedExplicitlyMember()
         {


### PR DESCRIPTION
Referencing same enum twice with EnumMember attributes causes NRE. Details are here: https://github.com/OData/WebApi/issues/711