### PR TITLE
issue #418 ignore non-odata query parameters when building parameter …

### DIFF
--- a/OData/src/System.Web.OData/OData/Query/ODataQueryOptions.cs
+++ b/OData/src/System.Web.OData/OData/Query/ODataQueryOptions.cs
@@ -78,10 +78,10 @@ namespace System.Web.OData.Query
             Context = context;
             Request = request;
 
-            // Parse the query from request Uri
+            // Parse the query from request Uri, including only keys which look like OData parameters
             RawValues = new ODataRawQueryOptions();
             IDictionary<string, string> queryParameters = 
-                request.GetQueryNameValuePairs().ToDictionary(p => p.Key, p => p.Value);
+                request.GetQueryNameValuePairs().Where(p => p.Key.StartsWith("$")).ToDictionary(p => p.Key, p => p.Value);
             
             _queryOptionParser = new ODataQueryOptionParser(
                 context.Model,

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/ODataQueryOptionTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/ODataQueryOptionTest.cs
@@ -716,6 +716,27 @@ namespace System.Web.OData.Query
             Assert.False(ODataQueryOptions.IsSystemQueryOption("$invalidqueryname"));
         }
 
+        [Fact]
+        public void DuplicateUnsupportedQueryParametersIgnored()
+        {
+            // Arrange
+            var model = new ODataModelBuilder().Add_Customer_EntityType().Add_Customers_EntitySet().GetEdmModel();
+
+            // a simple query with duplicate ignored parameters (key=test)
+            string uri = "http://server/service/Customers?$top=10&test=1&test=2";
+            var message = new HttpRequestMessage(
+                HttpMethod.Get,
+                new Uri(uri)
+            );
+
+            // Act
+            var queryOptions = new ODataQueryOptions(new ODataQueryContext(model, typeof(Customer)), message);
+
+            // Assert
+            Assert.Equal(queryOptions.RawValues.Top, "10");
+        }
+
+
         [Theory]
         [InlineData(1, true)]
         [InlineData(2, true)]


### PR DESCRIPTION
### Issues
This pull request fixes issue #418.

### Description
For `System.Web.OData`, when constructing `ODataQueryOptions` only query parameters that start with $ are included in the queryParameters dictionary.  This allows for duplicate non-OData related query parameters in the request url.

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
None. Initially I wanted to use `IsSupportedQueryOption` for the filtering.  However, the parser / resolver options can't be constructed until after the parameter dictionary is built.