### PR TITLE
Upgrade tooling to .NET Core 1.0 RTM and .NET Core SDK preview 2.

### DIFF
--- a/vNext/global.json
+++ b/vNext/global.json
@@ -1,6 +1,3 @@
 {
-    "projects": [ "src", "test" ],
-    "sdk": {
-      "version": "1.0.0-preview1-002702"
-    }
+    "projects": [ "src", "test" ]
 }

--- a/vNext/samples/ODataSample.Web/ODataSample.Web.xproj
+++ b/vNext/samples/ODataSample.Web/ODataSample.Web.xproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>46706ca6-2056-4355-b672-3e7c80d4cbf4</ProjectGuid>
+    <ProjectGuid>533d4ad6-fce4-41d5-85be-891a2d092b72</ProjectGuid>
     <RootNamespace>ODataSample.Web</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>

--- a/vNext/samples/ODataSample.Web/project.json
+++ b/vNext/samples/ODataSample.Web/project.json
@@ -1,19 +1,16 @@
-﻿{
-  "dependencies": {
-    "Microsoft.AspNetCore.Mvc": "1.0.0",
-    "Microsoft.AspNetCore.OData": "6.0.0-alpha1-rtm",
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
-    "Microsoft.Extensions.Logging": "1.0.0",
-    "Microsoft.Extensions.Logging.Console": "1.0.0"
-  },
+{
+    "dependencies": {
+        "Microsoft.AspNetCore.Mvc": "1.0.0",
+        "Microsoft.AspNetCore.OData": "6.0.0-alpha1-rtm",
+        "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+        "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+        "Microsoft.Extensions.Logging": "1.0.0",
+        "Microsoft.Extensions.Logging.Console": "1.0.0"
+    },
 
-  "tools": {
-    "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
-      "version": "1.0.0-preview1-final",
-      "imports": "portable-net45+win8+dnxcore50"
-    }
-  },
+    "tools": {
+        "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final"
+    },
 
   "frameworks": {
     "net452": { }

--- a/vNext/tools/ResxGenerator/project.json
+++ b/vNext/tools/ResxGenerator/project.json
@@ -3,8 +3,6 @@
   "description": "",
   "authors": [ "" ],
 
-  
-
   "commands": {
     "ResxGenerator": "ResxGenerator"
   },


### PR DESCRIPTION
### Issues
No pre-existing issues.

### Description
This PR upgrades the vNext branch to be able to compile using the .NET Core 1.0 RTM and .NET Core SDK preview 2 software. 

