### PR TITLE
reduced full MVC dependency to Mvc.Core

### DIFF
--- a/vNext/samples/ODataSample.Web/project.json
+++ b/vNext/samples/ODataSample.Web/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.AspNetCore.Mvc": "1.0.0",
+    "Microsoft.AspNetCore.Mvc": "1.0.1",
     "Microsoft.AspNetCore.OData": "6.0.0-alpha1-rtm",
     "Microsoft.OData.Core": "7.0.0",
     "Microsoft.OData.Edm": "7.0.0",

--- a/vNext/src/Microsoft.AspNetCore.OData/MetadataController.cs
+++ b/vNext/src/Microsoft.AspNetCore.OData/MetadataController.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.OData
 {
     [ApiExplorerSettings(IgnoreApi = true)]
     // [Route("odata/$metadata")]
-    public class MetadataController : Controller
+    public class MetadataController : ControllerBase
     {
         private static readonly Version _defaultEdmxVersion = new Version(4, 0);
 

--- a/vNext/src/Microsoft.AspNetCore.OData/project.json
+++ b/vNext/src/Microsoft.AspNetCore.OData/project.json
@@ -7,7 +7,8 @@
     "Microsoft.OData.Core": "7.0.0",
     "Microsoft.OData.Edm": "7.0.0",
     "Microsoft.Spatial": "7.0.0",
-    "Microsoft.AspNetCore.Mvc": "1.0.0"
+    "Microsoft.AspNetCore.Mvc.Core": "1.0.1",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0"
   },
 
   "frameworks": {


### PR DESCRIPTION
### Issues

Removed dependency on entire MVC package and moving to just Mvc.Core. This should be a more logical base as it doesn't require other view based features that are included in the full MVC package.
### Description

Changing dependency from `Microsoft.AspNetCore.Mvc` to `Microsoft.AspNetCore.Mvc` and updated packages for minor release
### Checklist (Uncheck if it is not completed)
- [  ] Test cases added
- [ x ] Build and test with one-click build and test script passed ➝ built with `dotnet build` and tested with `dotnet test`on macOS
