### PR TITLE
Create a copy constructor for SelectExpandNode

### DIFF
--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/SelectExpandNode.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/SelectExpandNode.cs
@@ -36,6 +36,23 @@ namespace System.Web.OData.Formatter.Serialization
         }
 
         /// <summary>
+        /// Creates a new instance of the <see cref="SelectExpandNode"/> class by copying the state of another instance. This is
+        /// intended for scenarios that wish to modify state without updating the values cached within ODataResourceSerializer.
+        /// </summary>
+        /// <param name="selectExpandNodeToCopy">The instance from which the state for the new instance will be copied.</param>
+        public SelectExpandNode(SelectExpandNode selectExpandNodeToCopy)
+        {
+            ExpandedNavigationProperties = new Dictionary<IEdmNavigationProperty, SelectExpandClause>(selectExpandNodeToCopy.ExpandedNavigationProperties);
+            SelectedActions = new HashSet<IEdmAction>(selectExpandNodeToCopy.SelectedActions);
+            SelectAllDynamicProperties = selectExpandNodeToCopy.SelectAllDynamicProperties;
+            SelectedComplexProperties = new HashSet<IEdmStructuralProperty>(selectExpandNodeToCopy.SelectedComplexProperties);
+            SelectedDynamicProperties = new HashSet<string>(selectExpandNodeToCopy.SelectedDynamicProperties);
+            SelectedFunctions = new HashSet<IEdmFunction>(selectExpandNodeToCopy.SelectedFunctions);
+            SelectedNavigationProperties = new HashSet<IEdmNavigationProperty>(selectExpandNodeToCopy.SelectedNavigationProperties);
+            SelectedStructuralProperties = new HashSet<IEdmStructuralProperty>(selectExpandNodeToCopy.SelectedStructuralProperties);
+        }
+
+        /// <summary>
         /// Creates a new instance of the <see cref="SelectExpandNode"/> class describing the set of structural properties,
         /// nested properties, navigation properties, and actions to select and expand for the given <paramref name="writeContext"/>.
         /// </summary>


### PR DESCRIPTION
### Description
Prior to `OData 6.0` it was possible to prevent the serialization of literal `null` using a method described in [this StackOverflow question](http://stackoverflow.com/questions/33192231/prevent-null-values-from-being-emitted-in-a-webapi-odata-v4-service). Unfortunately this stopped working as the serialization code now enumerates of the various properties of `SelectExpandNode` instead of `ODataResource.Properties`.

A new method to accomplish the same goal is to therefore override `CreateSelectExpandNode` and remove the applicable properties from the `SelectExpandNode` created in the base implementation. Unfortunately this implementation utilizes a cache, and so directly modifying those instances leads to tricky bugs. Ultimately the easiest solution here was to create a copy constructor for `SelectExpandNode` so the properties could be modified without updating the original. This still **does not** allow the overriding of the `SelectAllDynamicProperties` Boolean, but that can be worked around if needed.

### Checklist (Uncheck if it is not completed)
- [ x ] Build and test with one-click build and test script passed

