### PR TITLE
Add support to now() function on filter clauses

### DIFF
--- a/OData/src/System.Web.OData/OData/Query/Expressions/ClrCanonicalFunctions.cs
+++ b/OData/src/System.Web.OData/OData/Query/Expressions/ClrCanonicalFunctions.cs
@@ -42,6 +42,7 @@ namespace System.Web.OData.Query.Expressions
         internal const string IsofFunctionName = "isof";
         internal const string DateFunctionName = "date";
         internal const string TimeFunctionName = "time";
+        internal const string NowFunctionName = "now";
 
         // string functions
         public static readonly MethodInfo StartsWith;

--- a/OData/src/System.Web.OData/OData/Query/Expressions/ExpressionBinderBase.cs
+++ b/OData/src/System.Web.OData/OData/Query/Expressions/ExpressionBinderBase.cs
@@ -641,6 +641,13 @@ namespace System.Web.OData.Query.Expressions
             {
                 MemberExpression memberAccess = expression as MemberExpression;
                 Contract.Assert(memberAccess != null);
+
+                var propertyInfo = memberAccess.Member as PropertyInfo;
+                if (propertyInfo != null && propertyInfo.GetMethod.IsStatic)
+                {
+                    return propertyInfo.GetValue(new object());
+                }
+
                 if (memberAccess.Expression.NodeType == ExpressionType.Constant)
                 {
                     ConstantExpression constant = memberAccess.Expression as ConstantExpression;

--- a/OData/src/System.Web.OData/OData/Query/Expressions/FilterBinder.cs
+++ b/OData/src/System.Web.OData/OData/Query/Expressions/FilterBinder.cs
@@ -630,6 +630,9 @@ namespace System.Web.OData.Query.Expressions
                 case ClrCanonicalFunctions.TimeFunctionName:
                     return BindTime(node);
 
+                case ClrCanonicalFunctions.NowFunctionName:
+                    return BindNow(node);
+
                 default:
                     // Get Expression of custom binded method.
                     Expression expression = BindCustomMethodExpressionOrNull(node);
@@ -885,6 +888,17 @@ namespace System.Web.OData.Query.Expressions
             // EF doesn't support new Date(int, int, int), also doesn't support other property access, for example DateTime.Date.
             // Therefore, we just return the source (DateTime or DateTimeOffset).
             return arguments[0];
+        }
+
+        private Expression BindNow(SingleValueFunctionCallNode node)
+        {
+            Contract.Assert("now" == node.Name);
+
+            // Function Now() does not take any arguemnts.
+            Expression[] arguments = BindArguments(node.Parameters);
+            Contract.Assert(arguments.Length == 0);
+
+            return Expression.Property(null, typeof(DateTimeOffset), "UtcNow");
         }
 
         private Expression BindTime(SingleValueFunctionCallNode node)

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DateTimeOffsetSupport/DateTimeOffsetController.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DateTimeOffsetSupport/DateTimeOffsetController.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Web.Http;
+using System.Web.OData;
+using System.Web.OData.Routing;
+
+namespace WebStack.QA.Test.OData.DateTimeOffsetSupport
+{
+    public class FilesController : ODataController
+    {
+        private static readonly FilesContext _db = new FilesContext();
+
+        public static List<File> CreateFiles(DateTimeOffset dateTime)
+        {
+            return Enumerable.Range(1, 5).Select(e =>
+            new File
+            {
+                FileId = e,
+                Name = "File #" + e,
+                CreatedDate = dateTime.AddMonths(3 - e),
+                DeleteDate = dateTime,
+            }).ToList();
+        }
+
+        public FilesController() { }
+
+        [EnableQuery]
+        public IQueryable<File> Get()
+        {
+            var db = new FilesContext();
+            return db.Files;
+        }
+
+        [EnableQuery]
+        public IHttpActionResult Get([FromODataUri] int key)
+        {
+            var db = new FilesContext();
+            File file = db.Files.FirstOrDefault(c => c.FileId == key);
+            if (file == null)
+            {
+                return NotFound();
+            }
+            return Ok(file);
+        }
+
+        public IHttpActionResult Post(File file)
+        {
+            var db = new FilesContext();
+            db.Files.Add(file);
+            db.SaveChanges();
+
+            return Created(file);
+        }
+
+        public IHttpActionResult Patch(int key, Delta<File> patch)
+        {
+            var db = new FilesContext();
+            var file = db.Files.SingleOrDefault(c => c.FileId == key);
+
+            if (file == null)
+            {
+                return NotFound();
+            }
+
+            patch.Patch(file);
+            db.SaveChanges();
+
+            return Updated(file);
+        }
+
+        public IHttpActionResult Delete(int key)
+        {
+            var db = new FilesContext();
+            File original = db.Files.FirstOrDefault(c => c.FileId == key);
+            if (original == null)
+            {
+                return NotFound();
+            }
+
+            db.Files.Remove(original);
+            db.SaveChanges();
+
+            return StatusCode(HttpStatusCode.NoContent);
+        }
+
+        public IHttpActionResult GetCreatedDate(int key)
+        {
+            var db = new FilesContext();
+            File file = db.Files.FirstOrDefault(c => c.FileId == key);
+            if (file == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(file.CreatedDate);
+        }
+
+        [ODataRoute("ResetDataSource")]
+        public IHttpActionResult ResetDataSource(String time)
+        {
+            var dateTime = DateTimeOffset.Parse(time.Replace(' ', '+'));
+            var files = CreateFiles(dateTime);
+
+            _db.Files.RemoveRange(_db.Files);
+            _db.SaveChanges();
+
+            _db.Database.Delete();
+            _db.Database.Create();
+
+            _db.Files.AddRange(files);
+            _db.SaveChanges();
+
+            return StatusCode(HttpStatusCode.NoContent);
+        }
+    }
+}

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DateTimeOffsetSupport/DateTimeOffsetDataModel.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DateTimeOffsetSupport/DateTimeOffsetDataModel.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace WebStack.QA.Test.OData.DateTimeOffsetSupport
+{
+    public class FilesContext : DbContext
+    {
+        public static string ConnectionString =
+            @"Data Source=.;Integrated Security=True;Initial Catalog=DateTimeOffsetSupport";
+
+        public FilesContext() : base(ConnectionString) { }
+
+        public DbSet<File> Files { get; set; }
+    }
+
+    public class File
+    {
+        [Key]
+        public int FileId { get; set; }
+
+        public string Name { get; set; }
+
+        public DateTimeOffset CreatedDate { get; set; }
+
+        public DateTimeOffset? DeleteDate { get; set; }
+
+        public override bool Equals(Object o)
+        {
+            var f = o as File;
+            if (f == null)
+            {
+                return false;
+            }
+
+            var v1 = FileId.Equals(f.FileId);
+            var v2 = Name.Equals(f.Name);
+            var v3 = CreatedDate.Equals(f.CreatedDate);
+            var v4 = Object.Equals(DeleteDate, f.DeleteDate);
+            return v1 && v2 && v3 && v4;
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DateTimeOffsetSupport/DateTimeOffsetDataModel.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DateTimeOffsetSupport/DateTimeOffsetDataModel.cs
@@ -10,7 +10,7 @@ namespace WebStack.QA.Test.OData.DateTimeOffsetSupport
     public class FilesContext : DbContext
     {
         public static string ConnectionString =
-            @"Data Source=.;Integrated Security=True;Initial Catalog=DateTimeOffsetSupport";
+            @"Data Source=(LocalDb)\v11.0;;Integrated Security=True;Initial Catalog=DateTimeOffsetSupport";
 
         public FilesContext() : base(ConnectionString) { }
 

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DateTimeOffsetSupport/DateTimeOffsetEdmModel.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DateTimeOffsetSupport/DateTimeOffsetEdmModel.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Web.OData;
+using System.Web.OData.Builder;
+using System.Web.OData.Extensions;
+using System.Web.OData.Routing;
+using Microsoft.OData.Edm;
+
+namespace WebStack.QA.Test.OData.DateTimeOffsetSupport
+{
+    public class DateTimeOffsetEdmModel
+    {
+        public static IEdmModel GetExplicitModel()
+        {
+            ODataModelBuilder builder = new ODataModelBuilder();
+            var fileType = builder.EntityType<File>().HasKey(f => f.FileId);
+            fileType.Property(f => f.Name);
+            fileType.Property(f => f.CreatedDate);
+            fileType.Property(f => f.DeleteDate);
+
+            var files = builder.EntitySet<File>("Files");
+            files.HasIdLink(link, true);
+            files.HasEditLink(link, true);
+
+            BuildFunctions(builder);
+            BuildActions(builder);
+
+            return builder.GetEdmModel();
+        }
+
+        public static IEdmModel GetConventionModel()
+        {
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<File>("Files");
+
+            BuildFunctions(builder);
+            BuildActions(builder);
+
+            return builder.GetEdmModel();
+        }
+
+        private static void BuildFunctions(ODataModelBuilder builder)
+        {
+            FunctionConfiguration function =
+                builder.EntityType<File>()
+                    .Collection.Function("GetFilesModifiedAt")
+                    .ReturnsCollectionViaEntitySetPath<File>("bindingParameter");
+            function.Parameter<DateTime>("modifiedDate");
+        }
+
+        private static void BuildActions(ODataModelBuilder builder)
+        {
+            builder.EntityType<File>().Action("CopyFiles").Parameter<DateTime>("createdDate");
+
+            builder.Action("ResetDataSource");
+        }
+
+        private static Func<EntityInstanceContext, Uri> link = entityContext =>
+        {
+            object id;
+            entityContext.EdmObject.TryGetPropertyValue("FileId", out id);
+            string uri = entityContext.Url.CreateODataLink(
+                            new EntitySetPathSegment(entityContext.NavigationSource.Name),
+                            new KeyValuePathSegment(id.ToString()));
+            return new Uri(uri);
+        };
+    }
+}

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DateTimeOffsetSupport/DateTimeOffsetTest.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DateTimeOffsetSupport/DateTimeOffsetTest.cs
@@ -1,0 +1,400 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Dispatcher;
+using System.Web.OData;
+using System.Web.OData.Batch;
+using System.Web.OData.Extensions;
+using Microsoft.OData.Core;
+using Microsoft.OData.Edm;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
+using Nuwa;
+using WebStack.QA.Common.XUnit;
+using WebStack.QA.Test.OData.Common;
+using WebStack.QA.Test.OData.ModelBuilder;
+using Xunit;
+using Xunit.Extensions;
+
+namespace WebStack.QA.Test.OData.DateTimeOffsetSupport
+{
+    [NuwaFramework]
+    [NuwaTrace(NuwaTraceAttribute.Tag.Off)]
+    public class DateTimeOffsetTest
+    {
+        #region Configuration and Static Members
+        [NuwaBaseAddress]
+        public string BaseAddress { get; set; }
+
+        [NuwaHttpClient]
+        public HttpClient Client { get; set; }
+
+        [NuwaConfiguration]
+        public static void UpdateConfiguration(HttpConfiguration configuration)
+        {
+            var controllers = new[] { typeof(FilesController), typeof(MetadataController) };
+            TestAssemblyResolver resolver = new TestAssemblyResolver(new TypesInjectionAssembly(controllers));
+            configuration.Services.Replace(typeof(IAssembliesResolver), resolver);
+
+            configuration.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
+
+            TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"); // -8:00
+            configuration.SetTimeZoneInfo(timeZoneInfo);
+
+            configuration.Routes.Clear();
+            HttpServer httpServer = configuration.GetHttpServer();
+            configuration.MapODataServiceRoute(
+                routeName: "convention",
+                routePrefix: "convention",
+                model: DateTimeOffsetEdmModel.GetConventionModel());
+
+            configuration.MapODataServiceRoute(
+                routeName: "explicit",
+                routePrefix: "explicit",
+                model: DateTimeOffsetEdmModel.GetExplicitModel(),
+                batchHandler: new DefaultODataBatchHandler(httpServer));
+
+            configuration.EnsureInitialized();
+        }
+
+        public static TheoryDataSet<string, string> MediaTypes
+        {
+            get
+            {
+                string[] modes = new string[] { "convention", "explicit" };
+                string[] mimes = new string[]{
+                    "json",
+                    "application/json",
+                    "application/json;odata.metadata=none",
+                    "application/json;odata.metadata=minimal",
+                    "application/json;odata.metadata=full"};
+                TheoryDataSet<string, string> data = new TheoryDataSet<string, string>();
+                foreach (string mode in modes)
+                {
+                    foreach (string mime in mimes)
+                    {
+                        data.Add(mode, mime);
+                    }
+                }
+                return data;
+            }
+        }
+        #endregion
+
+        #region Helper methods
+        private async Task<HttpResponseMessage> ResetDatasource(DateTimeOffset time)
+        {
+            var uriReset = string.Format("{0}/convention/ResetDataSource/?time={1}", this.BaseAddress, time.ToString("o"));
+            var response = await this.Client.PostAsync(uriReset, null);
+            return response;
+        }
+
+        private File CreateFile(DateTimeOffset createDate)
+        {
+            return new File() {
+                FileId = 0,
+                Name = "FileName",
+                CreatedDate = createDate,
+            };
+        }
+
+        private string Serialize(Object obj)
+        {
+            return JsonConvert.SerializeObject(obj);
+        }
+
+        private File Deserialize(HttpResponseMessage response)
+        {
+            return JsonConvert.DeserializeObject<File>(response.Content.ReadAsStringAsync().Result);
+        }
+
+        private IList<File> DeserializeList(HttpResponseMessage response)
+        {
+            JObject json = JObject.Parse(response.Content.ReadAsStringAsync().Result);
+            IList<JToken> value = json["value"].Children().ToList();
+            IList<File> files = new List<File>();
+
+            foreach (JToken token in value) 
+            {
+                var file = JsonConvert.DeserializeObject<File>(token.ToString());
+                files.Add(file);
+            }
+
+            return files;
+        }
+        #endregion
+
+        #region CRUD on DateTimeOffset related entity
+        [Theory]
+        [PropertyData("MediaTypes")]
+        public async Task QueryFileEntityTest(string mode, string mime)
+        {
+            DateTimeOffset serverTime = DateTimeOffset.Now;
+            await ResetDatasource(serverTime);
+
+            var files = FilesController.CreateFiles(serverTime);
+            for (int i = 1; i <= 5; ++i)
+            {
+                string requestUri = string.Format("{0}/{1}/Files({2})?$format={3}", BaseAddress, mode, i, mime);
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+                var response = await Client.SendAsync(request);
+
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                File file = Deserialize(response);
+                Assert.Equal(files[i-1], file);
+            }
+        }
+
+        [Theory]
+        [InlineData("convention")]
+        [InlineData("explicit")]
+        public async Task UpdateFileEntityTestRoundTrip(string mode)
+        {
+            DateTimeOffset now = DateTimeOffset.Now;
+            await ResetDatasource(now);
+            string requestUri = string.Format("{0}/{1}/Files(2)", BaseAddress, mode);
+
+            // GET ~/Files(2)
+            var response = await Client.GetAsync(requestUri);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            File file2 = Deserialize(response);
+
+            var contentObject = new { DeleteDate = now };
+            string content = Serialize(contentObject);
+
+            // Patch ~/Files(2)
+            HttpRequestMessage request = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri);
+            request.Content = new StringContent(content);
+            request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+
+            response = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+            // GET ~/Files(2)
+            response = await Client.GetAsync(requestUri);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            file2.DeleteDate = now;
+            File newFile2 = Deserialize(response);
+            Assert.Equal(file2, newFile2);
+        }
+
+        [Theory]
+        [InlineData("convention")]
+        [InlineData("explicit")]
+        public async Task CreateDeleteFileEntityRoundTrip(string mode)
+        {
+            DateTimeOffset now = DateTimeOffset.Now;
+
+            await ResetDatasource(now);
+            string filesUri = string.Format("{0}/{1}/Files", BaseAddress, mode);
+            string fileUri = filesUri + "(6)";
+
+            File newFile = CreateFile(now);
+            string content = Serialize(newFile);
+            
+            // POST ~/Files
+            HttpRequestMessage postRequest = new HttpRequestMessage(HttpMethod.Post, filesUri);
+            postRequest.Content = new StringContent(content);
+            postRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+
+            var postResponse = await Client.SendAsync(postRequest);
+            Assert.Equal(HttpStatusCode.Created, postResponse.StatusCode);
+
+            var postResult = Deserialize(postResponse);
+            newFile.FileId = postResult.FileId;
+            Assert.NotNull(postResult.FileId);
+            Assert.Equal(newFile, postResult);
+
+            // GET ~/Files(6)
+            HttpResponseMessage getResponse = await Client.GetAsync(fileUri);
+            Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+            var getResult = JsonConvert.DeserializeObject<File>(getResponse.Content.ReadAsStringAsync().Result);
+            Assert.NotNull(getResult.FileId);
+            Assert.Equal(getResult, postResult);
+
+            // Delete ~/Files(6)
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Delete, fileUri);
+            var deleteResponse = await Client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+            // GET ~/Files(6)
+            getResponse = this.Client.GetAsync(fileUri).Result;
+            Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+        }
+        #endregion
+
+        #region Query option on DateTime
+
+        [Theory]
+        [InlineData("convention")]
+        [InlineData("explicit")]
+        public async Task CanSelectDateTimeProperty(string mode)
+        {
+            DateTimeOffset now = DateTimeOffset.Now;
+            await ResetDatasource(now);
+
+            string requestUri = string.Format("{0}/{1}/Files(3)?$select=CreatedDate", BaseAddress, mode);
+
+            HttpResponseMessage response = await Client.GetAsync(requestUri);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var dateType = new { CreatedDate = now };
+            var date = JsonConvert.DeserializeAnonymousType(response.Content.ReadAsStringAsync().Result, dateType);
+
+            Assert.Equal(date.CreatedDate, now);
+        }
+
+        [Theory]
+        [InlineData("convention")]
+        [InlineData("explicit")]
+        public async Task CanFilterDateTimeProperty(string mode)
+        {
+            DateTimeOffset time =  new DateTimeOffset(2010, 12, 1, 12, 0, 0, TimeSpan.Zero);
+            var fileList = FilesController.CreateFiles(time);
+            fileList = fileList.GetRange(2, 3);
+            await ResetDatasource(time);
+
+            string requestUri = string.Format("{0}/{1}/Files?$filter=year(CreatedDate) eq 2010", BaseAddress, mode);
+
+            HttpResponseMessage response = await Client.GetAsync(requestUri);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var responseFileList = DeserializeList(response);
+            Assert.Equal(3, fileList.Count());
+            Assert.True(fileList.SequenceEqual(responseFileList));
+        }
+
+        [Theory]
+        [InlineData("convention")]
+        [InlineData("explicit")]
+        public async Task CanOrderByDateTimeProperty(string mode)
+        {
+            DateTimeOffset time = DateTimeOffset.Now;
+            var fileList = FilesController.CreateFiles(time);
+            await ResetDatasource(time);
+
+            string requestUri = string.Format("{0}/{1}/Files?$orderby=CreatedDate ", BaseAddress, mode);
+
+            HttpResponseMessage response = await Client.GetAsync(requestUri + "desc");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var responseFileList = DeserializeList(response);
+
+            Assert.True(fileList.SequenceEqual(responseFileList));
+
+            response = await Client.GetAsync(requestUri + "asc");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            responseFileList = DeserializeList(response);
+
+            fileList.Reverse();
+            Assert.True(fileList.SequenceEqual(responseFileList));
+        }
+        #endregion
+
+        #region now() Function Tests
+        [Theory]
+        [InlineData("convention")]
+        [InlineData("explicit")]
+        public async Task Now_FilterDateTimePropertyWithGt(string mode)
+        {
+            DateTimeOffset time = DateTimeOffset.Now.AddHours(1);
+            var fileList = FilesController.CreateFiles(time);
+            fileList = fileList.GetRange(0, 3);
+            await ResetDatasource(time);
+
+            string requestUri = string.Format("{0}/{1}/Files?$filter=CreatedDate gt now()", BaseAddress, mode);
+
+            HttpResponseMessage response = await Client.GetAsync(requestUri);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var responseFileList = DeserializeList(response);
+            Assert.Equal(3, fileList.Count());
+            Assert.True(fileList.SequenceEqual(responseFileList));
+        }
+
+        [Theory]
+        [InlineData("convention")]
+        [InlineData("explicit")]
+        public async Task NowFilterDateTimePropertyWithLt(string mode)
+        {
+            DateTimeOffset time = DateTimeOffset.Now.AddHours(1);
+            var fileList = FilesController.CreateFiles(time);
+            fileList = fileList.GetRange(3, 2);
+            await ResetDatasource(time);
+
+            string requestUri = string.Format("{0}/{1}/Files?$filter=CreatedDate lt now()", BaseAddress, mode);
+
+            HttpResponseMessage response = await Client.GetAsync(requestUri);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var responseFileList = DeserializeList(response);
+            Assert.Equal(2, fileList.Count());
+            Assert.True(fileList.SequenceEqual(responseFileList));
+        }
+
+        [Theory]
+        [InlineData("convention")]
+        [InlineData("explicit")]
+        public async Task NowFilterDateTimePropertyWithDayFunction(string mode)
+        {
+            DateTimeOffset time = DateTimeOffset.Now;
+            var fileList = FilesController.CreateFiles(time);
+            await ResetDatasource(time);
+
+            string requestUri = string.Format("{0}/{1}/Files?$filter=day(CreatedDate) eq day(now())", BaseAddress, mode);
+
+            HttpResponseMessage response = await Client.GetAsync(requestUri);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var responseFileList = DeserializeList(response);
+            Assert.Equal(5, fileList.Count());
+            Assert.True(fileList.SequenceEqual(responseFileList));
+        }
+
+        [Theory]
+        [InlineData("convention")]
+        [InlineData("explicit")]
+        public async Task NowFilterDateTimePropertyWithMonthFunction(string mode)
+        {
+            DateTimeOffset time = DateTimeOffset.Now;
+            await ResetDatasource(time);
+            var fileList = FilesController.CreateFiles(time);
+
+            string requestUri = string.Format("{0}/{1}/Files?$filter=month(CreatedDate) eq month(now())", BaseAddress, mode);
+
+            HttpResponseMessage response = await Client.GetAsync(requestUri);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var responseFileList = DeserializeList(response);
+            Assert.Contains(fileList[2], responseFileList);
+        }
+
+        [Theory]
+        [InlineData("convention")]
+        [InlineData("explicit")]
+        public async Task NowFilterDateTimePropertyWithYearFunction(string mode)
+        {
+            DateTimeOffset time = DateTimeOffset.Now;
+            await ResetDatasource(time);
+            var fileList = FilesController.CreateFiles(time);
+
+            string requestUri = string.Format("{0}/{1}/Files?$filter=year(CreatedDate) ge year(now())", BaseAddress, mode);
+
+            HttpResponseMessage response = await Client.GetAsync(requestUri);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var responseFileList = DeserializeList(response);
+            Assert.Contains(fileList[2], responseFileList);
+            Assert.Contains(fileList[1], responseFileList);
+            Assert.Contains(fileList[0], responseFileList);
+        }
+
+        #endregion
+    }
+}

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
@@ -162,6 +162,10 @@
     <Compile Include="DateAndTimeOfDay\DateAndTimeOfDayTest.cs" />
     <Compile Include="DateAndTimeOfDay\DateAndTimeOfDayWithEfTest.cs" />
     <Compile Include="DateAndTimeOfDay\DateWithEfTest.cs" />
+    <Compile Include="DateTimeOffsetSupport\DateTimeOffsetController.cs" />
+    <Compile Include="DateTimeOffsetSupport\DateTimeOffsetDataModel.cs" />
+    <Compile Include="DateTimeOffsetSupport\DateTimeOffsetEdmModel.cs" />
+    <Compile Include="DateTimeOffsetSupport\DateTimeOffsetTest.cs" />
     <Compile Include="DollarLevels\DollarLevelsController.cs" />
     <Compile Include="DollarLevels\DollarLevelsDataModel.cs" />
     <Compile Include="DollarLevels\DollarLevelsEdmModel.cs" />

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/ExpressionStringBuilder.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/ExpressionStringBuilder.cs
@@ -52,7 +52,13 @@ namespace System.Web.OData.Query.Expressions
 
         protected override Expression VisitMember(MemberExpression node)
         {
-            if (node.Expression.NodeType == ExpressionType.Constant)
+            // If it is a static member expression the Expression is null.
+            if (node.Expression == null && node.NodeType == ExpressionType.MemberAccess)
+            {
+                Visit(node.Expression);
+                Out(node.Member.DeclaringType.Name + "." + node.Member.Name);
+            }
+            else if (node.Expression.NodeType == ExpressionType.Constant)
             {
                 Visit(node.Expression);
             }

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/FilterBinderTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/FilterBinderTests.cs
@@ -1098,6 +1098,7 @@ namespace System.Web.OData.Query.Expressions
         [InlineData("hour(DiscontinuedOffset) eq 100", "$it => ($it.DiscontinuedOffset.Hour == 100)")]
         [InlineData("minute(DiscontinuedOffset) eq 100", "$it => ($it.DiscontinuedOffset.Minute == 100)")]
         [InlineData("second(DiscontinuedOffset) eq 100", "$it => ($it.DiscontinuedOffset.Second == 100)")]
+        [InlineData("now() eq 2016-11-08Z", "$it => (DateTimeOffset.UtcNow == 11/08/2016 00:00:00 +00:00)")]
         public void DateTimeOffsetFunctions(string filter, string expression)
         {
             VerifyQueryDeserialization(filter, expression);


### PR DESCRIPTION
### Issues
*This pull request fixes issue #514.*  

### Description
*Added support to the now() function on filter queries for the WebAPI project. The odata.net project already parses and handles the now query correctly. Unit tests and E2E tests were added too.*

### Checklist
- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary
*None*
