### PR TITLE
Fixes for writing Delta Responses - 5.x

### DIFF
--- a/OData/src/System.Web.OData/Extensions/HttpRequestMessageProperties.cs
+++ b/OData/src/System.Web.OData/Extensions/HttpRequestMessageProperties.cs
@@ -25,6 +25,7 @@ namespace System.Web.OData.Extensions
     {
         // Maintain the System.Web.OData. prefix in any new properties to avoid conflicts with user properties
         // and those of the v3 assembly.
+        private const string DeltaLinkKey = "System.Web.OData.DeltaLink";
         private const string ModelKey = "System.Web.OData.Model";
         private const string NextLinkKey = "System.Web.OData.NextLink";
         private const string PathHandlerKey = "System.Web.OData.PathHandler";
@@ -200,6 +201,22 @@ namespace System.Web.OData.Extensions
             set
             {
                 _request.Properties[NextLinkKey] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the delta link for the OData response.
+        /// </summary>
+        /// <value><c>null</c> if no delta link should be sent back to the client.</value>
+        public Uri DeltaLink
+        {
+            get
+            {
+                return GetValueOrNull<Uri>(DeltaLinkKey);
+            }
+            set
+            {
+                _request.Properties[DeltaLinkKey] = value;
             }
         }
 

--- a/OData/src/System.Web.OData/OData/Builder/NavigationSourceLinkBuilderAnnotation.cs
+++ b/OData/src/System.Web.OData/OData/Builder/NavigationSourceLinkBuilderAnnotation.cs
@@ -144,23 +144,10 @@ namespace System.Web.OData.Builder
             {
                 throw Error.ArgumentNull("instanceContext");
             }
-
-            bool writeId = false;
-            if (instanceContext.EdmObject.IsDeltaObject())
-            {
-                IDelta deltaObject = instanceContext.EdmObject as IDelta;
-                IEdmEntityType entityType = instanceContext.EntityType as IEdmEntityType;
-                if (null != entityType)
-                {
-                    IEnumerable<string> keyProperties = entityType.DeclaredKey.Select(k => k.Name).AsList<string>();
-                    if (keyProperties.Any(k => !deltaObject.GetChangedPropertyNames().Contains(k)))
-                        writeId = true;
-                }
-            }
-
+            
             if (_idLinkBuilder != null &&
                 (metadataLevel == ODataMetadataLevel.FullMetadata ||
-                (metadataLevel == ODataMetadataLevel.MinimalMetadata && (!_idLinkBuilder.FollowsConventions || writeId) ) ))
+                (metadataLevel == ODataMetadataLevel.MinimalMetadata && !_idLinkBuilder.FollowsConventions)))
             {
                 return _idLinkBuilder.Factory(instanceContext);
             }

--- a/OData/src/System.Web.OData/OData/EdmDeltaComplexObject.cs
+++ b/OData/src/System.Web.OData/OData/EdmDeltaComplexObject.cs
@@ -14,9 +14,9 @@ namespace System.Web.OData
     public class EdmDeltaComplexObject : EdmComplexObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="EdmStructuredObject"/> class.
+        /// Initializes a new instance of the <see cref="EdmDeltaComplexObject"/> class.
         /// </summary>
-        /// <param name="edmType">The <see cref="IEdmStructuredType"/> of this object.</param>
+        /// <param name="edmType">The <see cref="IEdmComplexType"/> of this object.</param>
         public EdmDeltaComplexObject(IEdmComplexType edmType)
             : this(edmType, isNullable: false)
         {

--- a/OData/src/System.Web.OData/OData/EdmDeltaComplexObject.cs
+++ b/OData/src/System.Web.OData/OData/EdmDeltaComplexObject.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Diagnostics.Contracts;
+using Microsoft.OData.Edm;
+
+namespace System.Web.OData
+{
+    /// <summary>
+    /// Represents an <see cref="IEdmChangedObject"/> with no backing CLR <see cref="Type"/>.
+    /// Used to hold the Entry object in the Delta Feed Payload.
+    /// </summary>
+    [NonValidatingParameterBinding]
+    public class EdmDeltaComplexObject : EdmComplexObject
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmStructuredObject"/> class.
+        /// </summary>
+        /// <param name="edmType">The <see cref="IEdmStructuredType"/> of this object.</param>
+        public EdmDeltaComplexObject(IEdmComplexType edmType)
+            : this(edmType, isNullable: false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmDeltaComplexObject"/> class.
+        /// </summary>
+        /// <param name="edmType">The <see cref="IEdmComplexTypeReference"/> of this object.</param>
+        public EdmDeltaComplexObject(IEdmComplexTypeReference edmType)
+            : this(edmType.ComplexDefinition(), edmType.IsNullable)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmDeltaComplexObject"/> class.
+        /// </summary>
+        /// <param name="edmType">The <see cref="IEdmComplexType"/> of this object.</param>
+        /// <param name="isNullable">true if this object can be nullable; otherwise, false.</param>
+        public EdmDeltaComplexObject(IEdmComplexType edmType, bool isNullable)
+            : base(edmType, isNullable)
+        {
+        }
+    }
+}

--- a/OData/src/System.Web.OData/OData/EdmDeltaDeletedEntityObject.cs
+++ b/OData/src/System.Web.OData/OData/EdmDeltaDeletedEntityObject.cs
@@ -17,6 +17,7 @@ namespace System.Web.OData
         private string _id;
         private DeltaDeletedEntryReason _reason;
         private EdmDeltaType _edmType;
+        private IEdmNavigationSource _navigationSource;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmDeltaDeletedEntityObject"/> class.
@@ -80,6 +81,21 @@ namespace System.Web.OData
             {
                 Contract.Assert(_edmType != null);
                 return _edmType.DeltaKind;
+            }
+        }
+
+        /// <summary>
+        /// The navigation source of the deleted entity. If null, then the deleted entity is from the current feed.
+        /// </summary>
+        public IEdmNavigationSource NavigationSource
+        {
+            get
+            {
+                return _navigationSource;
+            }
+            set
+            {
+                _navigationSource = value;
             }
         }
     }

--- a/OData/src/System.Web.OData/OData/EdmDeltaEntityObject.cs
+++ b/OData/src/System.Web.OData/OData/EdmDeltaEntityObject.cs
@@ -14,6 +14,7 @@ namespace System.Web.OData
     public class EdmDeltaEntityObject : EdmEntityObject, IEdmChangedObject
     {
         private EdmDeltaType _edmType;
+        private IEdmNavigationSource _navigationSource;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmDeltaEntityObject"/> class.
@@ -51,6 +52,21 @@ namespace System.Web.OData
             {
                 Contract.Assert(_edmType != null);
                 return _edmType.DeltaKind;
+            }
+        }
+
+        /// <summary>
+        /// The navigation source of the deleted entity. If null, then the deleted entity is from the current feed.
+        /// </summary>
+        public IEdmNavigationSource NavigationSource
+        {
+            get
+            {
+                return _navigationSource;
+            }
+            set
+            {
+                _navigationSource = value;
             }
         }
     }

--- a/OData/src/System.Web.OData/OData/EdmEntityObject.cs
+++ b/OData/src/System.Web.OData/OData/EdmEntityObject.cs
@@ -12,7 +12,7 @@ namespace System.Web.OData
     public class EdmEntityObject : EdmStructuredObject, IEdmEntityObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="EdmStructuredObject"/> class.
+        /// Initializes a new instance of the <see cref="EdmEntityObject"/> class.
         /// </summary>
         /// <param name="edmType">The <see cref="IEdmEntityType"/> of this object.</param>
         public EdmEntityObject(IEdmEntityType edmType)
@@ -21,7 +21,7 @@ namespace System.Web.OData
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EdmStructuredObject"/> class.
+        /// Initializes a new instance of the <see cref="EdmEntityObject"/> class.
         /// </summary>
         /// <param name="edmType">The <see cref="IEdmEntityTypeReference"/> of this object.</param>
         public EdmEntityObject(IEdmEntityTypeReference edmType)
@@ -30,7 +30,7 @@ namespace System.Web.OData
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EdmStructuredObject"/> class.
+        /// Initializes a new instance of the <see cref="EdmEntityObject"/> class.
         /// </summary>
         /// <param name="edmType">The <see cref="IEdmEntityType"/> of this object.</param>
         /// <param name="isNullable">true if this object can be nullable; otherwise, false.</param>

--- a/OData/src/System.Web.OData/OData/EdmTypeExtensions.cs
+++ b/OData/src/System.Web.OData/OData/EdmTypeExtensions.cs
@@ -24,5 +24,20 @@ namespace System.Web.OData
             }
             return (type.GetType() == typeof(EdmDeltaCollectionType));
         }
+
+        /// <summary>
+        /// Method to determine whether the current type is containing a Delta Entry
+        /// </summary>
+        /// <param name="type">IEdmType to be compared</param>
+        /// <returns>True or False if type is same as <see cref="EdmDeltaEntityObject"/></returns>
+        public static bool IsDeltaObject(this IEdmObject type)
+        {
+            if (type == null)
+            {
+                throw Error.ArgumentNull("type");
+            }
+            return (type is EdmDeltaEntityObject || type is EdmDeltaComplexObject);
+        }
+
     }
 }

--- a/OData/src/System.Web.OData/OData/EdmTypeExtensions.cs
+++ b/OData/src/System.Web.OData/OData/EdmTypeExtensions.cs
@@ -12,7 +12,7 @@ namespace System.Web.OData
     public static class EdmTypeExtensions
     {
         /// <summary>
-        /// Method to determine whether the current type is containing a Delta Feed
+        /// Method to determine whether the current type is a Delta Feed
         /// </summary>
         /// <param name="type">IEdmType to be compared</param>
         /// <returns>True or False if type is same as <see cref="EdmDeltaCollectionType"/></returns>
@@ -26,18 +26,17 @@ namespace System.Web.OData
         }
 
         /// <summary>
-        /// Method to determine whether the current type is containing a Delta Entry
+        /// Method to determine whether the current Edm object is a Delta Entry
         /// </summary>
-        /// <param name="type">IEdmType to be compared</param>
-        /// <returns>True or False if type is same as <see cref="EdmDeltaEntityObject"/></returns>
-        public static bool IsDeltaObject(this IEdmObject type)
+        /// <param name="resource">IEdmObject to be compared</param>
+        /// <returns>True or False if type is same as <see cref="EdmDeltaEntityObject"/> or <see cref="EdmDeltaComplexObject"/></returns>
+        public static bool IsDeltaResource(this IEdmObject resource)
         {
-            if (type == null)
+            if (resource == null)
             {
-                throw Error.ArgumentNull("type");
+                throw Error.ArgumentNull("resource");
             }
-            return (type is EdmDeltaEntityObject || type is EdmDeltaComplexObject);
+            return (resource is EdmDeltaEntityObject || resource is EdmDeltaComplexObject);
         }
-
     }
 }

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataCollectionSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataCollectionSerializer.cs
@@ -91,7 +91,7 @@ namespace System.Web.OData.Formatter.Serialization
                 {
                     collectionStart.NextPageLink = writeContext.Request.ODataProperties().NextLink;
                 }
-
+                
                 if (writeContext.Request.ODataProperties().TotalCount != null)
                 {
                     collectionStart.Count = writeContext.Request.ODataProperties().TotalCount;

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataComplexTypeSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataComplexTypeSerializer.cs
@@ -91,7 +91,7 @@ namespace System.Web.OData.Formatter.Serialization
 
             IEdmComplexObject complexObject = graph as IEdmComplexObject ?? new TypedEdmComplexObject(graph, complexType, writeContext.Model);
             List<IEdmProperty> settableProperties = new List<IEdmProperty>(complexType.ComplexDefinition().Properties());
-            if (complexObject.IsDeltaObject())
+            if (complexObject.IsDeltaResource())
             {
                 IDelta deltaProperty = graph as IDelta;
                 Contract.Assert(deltaProperty != null);

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
@@ -243,6 +243,13 @@ namespace System.Web.OData.Formatter.Serialization
             ODataDeltaDeletedEntry deltaDeletedEntry = new ODataDeltaDeletedEntry(
                edmDeltaDeletedEntity.Id, edmDeltaDeletedEntity.Reason);
 
+            if (edmDeltaDeletedEntity.NavigationSource != null)
+            {
+                ODataDeltaSerializationInfo serializationInfo = new ODataDeltaSerializationInfo();
+                serializationInfo.NavigationSourceName = edmDeltaDeletedEntity.NavigationSource.Name;
+                deltaDeletedEntry.SetSerializationInfo(serializationInfo);
+            }
+
             if (deltaDeletedEntry != null)
             {
                 writer.WriteDeltaDeletedEntry(deltaDeletedEntry);

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
@@ -204,6 +204,7 @@ namespace System.Web.OData.Formatter.Serialization
                 else if (writeContext.Request != null)
                 {
                     feed.NextPageLink = writeContext.Request.ODataProperties().NextLink;
+                    feed.DeltaLink = writeContext.Request.ODataProperties().DeltaLink;
 
                     long? countValue = writeContext.Request.ODataProperties().TotalCount;
                     if (countValue.HasValue)

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataEntityTypeSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataEntityTypeSerializer.cs
@@ -565,6 +565,15 @@ namespace System.Web.OData.Formatter.Serialization
             Contract.Assert(entityInstanceContext != null);
 
             List<ODataProperty> properties = new List<ODataProperty>();
+
+            if (entityInstanceContext.EdmObject.IsDeltaObject())
+            {
+                IDelta deltaObject = entityInstanceContext.EdmObject as IDelta;
+                Contract.Assert(deltaObject != null);
+                IEnumerable<string> changedProperties = deltaObject.GetChangedPropertyNames();
+                structuralProperties = structuralProperties.Where(p => changedProperties.Contains(p.Name));
+            }
+
             foreach (IEdmStructuralProperty structuralProperty in structuralProperties)
             {
                 ODataProperty property = CreateStructuralProperty(structuralProperty, entityInstanceContext);

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataEntityTypeSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataEntityTypeSerializer.cs
@@ -566,7 +566,7 @@ namespace System.Web.OData.Formatter.Serialization
 
             List<ODataProperty> properties = new List<ODataProperty>();
 
-            if (entityInstanceContext.EdmObject.IsDeltaObject())
+            if (null != entityInstanceContext.EdmObject && entityInstanceContext.EdmObject.IsDeltaResource())
             {
                 IDelta deltaObject = entityInstanceContext.EdmObject as IDelta;
                 Contract.Assert(deltaObject != null);

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataFeedSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataFeedSerializer.cs
@@ -204,6 +204,8 @@ namespace System.Web.OData.Formatter.Serialization
                 {
                     feed.NextPageLink = writeContext.Request.ODataProperties().NextLink;
 
+                    feed.DeltaLink = writeContext.Request.ODataProperties().DeltaLink;
+
                     long? countValue = writeContext.Request.ODataProperties().TotalCount;
                     if (countValue.HasValue)
                     {

--- a/OData/src/System.Web.OData/OData/Query/TopQueryOption.cs
+++ b/OData/src/System.Web.OData/OData/Query/TopQueryOption.cs
@@ -101,7 +101,7 @@ namespace System.Web.OData.Query
                         throw new ODataException(Error.Format(
                             SRResources.SkipTopLimitExceeded,
                             Int32.MaxValue,
-                            AllowedQueryOptions.Skip,
+                            AllowedQueryOptions.Top,
                             RawValue));
                     }
 

--- a/OData/src/System.Web.OData/System.Web.OData.csproj
+++ b/OData/src/System.Web.OData/System.Web.OData.csproj
@@ -87,6 +87,7 @@
     <Compile Include="OData\Builder\CapabilitiesVocabularyConstants.cs" />
     <Compile Include="OData\Builder\CapabilitiesVocabularyExtensionMethods.cs" />
     <Compile Include="OData\Builder\CapabilitiesNavigationType.cs" />
+    <Compile Include="OData\EdmDeltaComplexObject.cs" />
     <Compile Include="OData\ODataSwaggerUtilities.cs" />
     <Compile Include="OData\ODataSwaggerConverter.cs" />
     <Compile Include="OData\EdmEnumObjectCollection.cs" />

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DeltaQueryTests/DeltaQueryTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DeltaQueryTests/DeltaQueryTests.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Net.Http;
+using System.Web.Http;
+using System.Web.OData;
+using System.Web.OData.Builder;
+using System.Web.OData.Extensions;
+using System.Web.OData.Routing;
+using System.Web.OData.Routing.Conventions;
+using Microsoft.OData.Edm;
+using Newtonsoft.Json.Linq;
+using Nuwa;
+using Xunit;
+using Microsoft.OData.Core;
+
+namespace WebStack.QA.Test.OData
+{
+    [NuwaFramework]
+    [NuwaHttpClientConfiguration(MessageLog = false)]
+    public class DeltaQueryTests
+    {
+        private string baseAddress = null;
+
+        [NuwaBaseAddress]
+        public string BaseAddress
+        {
+            get
+            {
+                return baseAddress;
+            }
+            set
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    this.baseAddress = value.Replace("localhost", Environment.MachineName);
+                }
+            }
+        }
+
+        [NuwaHttpClient]
+        public HttpClient Client { get; set; }
+
+        [NuwaConfiguration]
+        public static void UpdateConfiguration(HttpConfiguration config)
+        {
+            config.Routes.Clear();
+            config.MapODataServiceRoute("odata", "odata", GetModel(), new DefaultODataPathHandler(), ODataRoutingConventions.CreateDefault());
+        }
+
+        private static IEdmModel GetModel()
+        {
+            ODataModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<TestCustomer>("TestCustomers");
+            builder.EntitySet<TestOrder>("TestOrders");
+            return builder.GetEdmModel();
+        }
+
+        [Fact]
+        public void DeltaContainsExpectedProperties()
+        {
+            HttpRequestMessage get = new HttpRequestMessage(HttpMethod.Get, BaseAddress + "/odata/TestCustomers?$deltaToken=abc");
+            HttpResponseMessage response = Client.SendAsync(get).Result;
+            Assert.True(response.IsSuccessStatusCode);
+            dynamic results = response.Content.ReadAsAsync<JObject>().Result;
+
+            Assert.True(results.value.Count == 5);
+
+            var changeEntity = results.value[0];
+            Assert.Equal(3, ((JToken)changeEntity).Count());
+            Assert.Equal(1, changeEntity.Id.Value);
+            Assert.Equal("Name", changeEntity.Name.Value);
+            Assert.Equal(2, ((JToken)changeEntity.Address).Count());
+            Assert.Equal("State", changeEntity.Address.State.Value);
+            Assert.True(changeEntity.Address.ZipCode.Value == (int?)null);
+
+            var newEntity = results.value[1];
+            Assert.Equal(10, newEntity.Id.Value);
+            Assert.Equal("NewCustomer", newEntity.Name.Value);
+            Assert.Equal(2, ((JToken)newEntity).Count());
+
+            var deletedEntity = results.value[2];
+            Assert.Equal("7", deletedEntity.id.Value);
+            Assert.Equal("changed", deletedEntity.reason.Value);
+
+            var deletedLink = results.value[3];
+            Assert.Equal("http://localhost/odata/DeltaCustomers(1)", deletedLink.source.Value);
+            Assert.Equal("http://localhost/odata/DeltaOrders(1)", deletedLink.target.Value);
+            Assert.Equal("Orders", deletedLink.relationship.Value);
+
+            var addedLink = results.value[4];
+            Assert.Equal("http://localhost/odata/DeltaCustomers(10)", addedLink.source.Value);
+            Assert.Equal("http://localhost/odata/DeltaOrders(1)", addedLink.target.Value);
+            Assert.Equal("Orders", addedLink.relationship.Value);
+        }
+    }
+
+    public class TestCustomersController : ODataController
+    {
+
+        public IHttpActionResult Get()
+        {
+            List<IEdmChangedObject> changedObjects = new List<IEdmChangedObject>();
+            IEdmEntityType entityType = Request.ODataProperties().Model.FindDeclaredType("WebStack.QA.Test.OData.TestCustomer") as IEdmEntityType;
+            IEdmComplexType addressType = Request.ODataProperties().Model.FindDeclaredType("WebStack.QA.Test.OData.TestAddress") as IEdmComplexType;
+
+            EdmDeltaComplexObject a = new EdmDeltaComplexObject(addressType);
+            a.TrySetPropertyValue("State", "State");
+            a.TrySetPropertyValue("ZipCode", null);
+
+            EdmDeltaEntityObject changedEntity = new EdmDeltaEntityObject(entityType);
+            changedEntity.TrySetPropertyValue("Id", 1);
+            changedEntity.TrySetPropertyValue("Name", "Name");
+            changedEntity.TrySetPropertyValue("Address", a);
+            changedObjects.Add(changedEntity);
+
+            var newEntity = new EdmDeltaEntityObject(entityType);
+            newEntity.TrySetPropertyValue("Id", 10);
+            newEntity.TrySetPropertyValue("Name", "NewCustomer");
+            changedObjects.Add(newEntity);
+
+            var deletedEntity = new EdmDeltaDeletedEntityObject(entityType);
+            deletedEntity.Id = "7";
+            deletedEntity.Reason = DeltaDeletedEntryReason.Changed;
+            changedObjects.Add(deletedEntity);
+
+            var deletedLink = new EdmDeltaDeletedLink(entityType);
+            deletedLink.Source = new Uri("http://localhost/odata/DeltaCustomers(1)");
+            deletedLink.Target = new Uri("http://localhost/odata/DeltaOrders(1)");
+            deletedLink.Relationship = "Orders";
+            changedObjects.Add(deletedLink);
+
+            var addedLink = new EdmDeltaLink(entityType);
+            addedLink.Source = new Uri("http://localhost/odata/DeltaCustomers(10)");
+            addedLink.Target = new Uri("http://localhost/odata/DeltaOrders(1)");
+            addedLink.Relationship = "Orders";
+            changedObjects.Add(addedLink);
+
+            return Ok(new EdmChangedObjectCollection(entityType, changedObjects));
+        }
+    }
+
+    public class TestCustomer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int Age { get; set; }
+        public virtual IList<TestOrder> Orders { get; set; }
+        public virtual TestAddress Address { get; set; }
+    }
+
+    public class TestOrder
+    {
+        public int Id { get; set; }
+        public int Amount { get; set; }
+    }
+
+    public class TestAddress
+    {
+        public string State { get; set; }
+        public string City { get; set; }
+        public int? ZipCode { get; set; }
+    }
+}

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DeltaQueryTests/DeltaQueryTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DeltaQueryTests/DeltaQueryTests.cs
@@ -13,6 +13,7 @@ using Microsoft.OData.Edm;
 using Newtonsoft.Json.Linq;
 using Nuwa;
 using Xunit;
+using Microsoft.OData.Edm.Library;
 using Microsoft.OData.Core;
 
 namespace WebStack.QA.Test.OData
@@ -58,41 +59,79 @@ namespace WebStack.QA.Test.OData
         }
 
         [Fact]
-        public void DeltaContainsExpectedProperties()
+        public void DeltaVerifyReslt()
         {
             HttpRequestMessage get = new HttpRequestMessage(HttpMethod.Get, BaseAddress + "/odata/TestCustomers?$deltaToken=abc");
+            get.Headers.Add("Accept", "application/json;odata.metadata=minimal");
             HttpResponseMessage response = Client.SendAsync(get).Result;
             Assert.True(response.IsSuccessStatusCode);
             dynamic results = response.Content.ReadAsAsync<JObject>().Result;
 
-            Assert.True(results.value.Count == 5);
+            Assert.True(results.value.Count == 7, "There should be 7 entries in the response");
 
             var changeEntity = results.value[0];
-            Assert.Equal(3, ((JToken)changeEntity).Count());
-            Assert.Equal(1, changeEntity.Id.Value);
-            Assert.Equal("Name", changeEntity.Name.Value);
-            Assert.Equal(2, ((JToken)changeEntity.Address).Count());
-            Assert.Equal("State", changeEntity.Address.State.Value);
-            Assert.True(changeEntity.Address.ZipCode.Value == (int?)null);
+            Assert.True(((JToken)changeEntity).Count() == 5, "The changed customer should have 4 properties plus type written.");
+            string changeEntityType = changeEntity["@odata.type"].Value as string;
+            Assert.True(changeEntityType != null, "The changed customer should have type written");
+            Assert.True(changeEntityType.Contains("#WebStack.QA.Test.OData.TestCustomerWithAddress"), "The changed order should be a TestCustomerWithAddress");
+            Assert.True(changeEntity.Id.Value == 1, "The ID Of changed customer should be 1.");
+            Assert.True(changeEntity.Name.Value == "Name", "The Name of changed customer should be 'Name'");
+            Assert.True(((JToken)changeEntity.Address).Count() == 2, "The changed entity's Address should have 2 properties written.");
+            Assert.True(changeEntity.Address.State.Value == "State", "The changed customer's Address.State should be 'State'.");
+            Assert.True(changeEntity.Address.ZipCode.Value == (int?)null, "The changed customer's Address.ZipCode should be null.");
 
-            var newEntity = results.value[1];
-            Assert.Equal(10, newEntity.Id.Value);
-            Assert.Equal("NewCustomer", newEntity.Name.Value);
-            Assert.Equal(2, ((JToken)newEntity).Count());
+            var phoneNumbers = changeEntity.PhoneNumbers;
+            Assert.True(((JToken)phoneNumbers).Count() == 2, "The changed customer should have 2 phone numbers");
+            Assert.True(phoneNumbers[0].Value == "123-4567", "The first phone number should be '123-4567'");
+            Assert.True(phoneNumbers[1].Value == "765-4321", "The second phone number should be '765-4321'");
 
-            var deletedEntity = results.value[2];
-            Assert.Equal("7", deletedEntity.id.Value);
-            Assert.Equal("changed", deletedEntity.reason.Value);
+            var newCustomer = results.value[1];
+            Assert.True(((JToken)newCustomer).Count() == 3, "The new customer should have 3 properties written");
+            Assert.True(newCustomer.Id.Value == 10, "The ID of the new customer should be 10");
+            Assert.True(newCustomer.Name.Value == "NewCustomer", "The name of the new customer should be 'NewCustomer'");
 
-            var deletedLink = results.value[3];
-            Assert.Equal("http://localhost/odata/DeltaCustomers(1)", deletedLink.source.Value);
-            Assert.Equal("http://localhost/odata/DeltaOrders(1)", deletedLink.target.Value);
-            Assert.Equal("Orders", deletedLink.relationship.Value);
+            var places = newCustomer.FavoritePlaces;
+            Assert.True(((JToken)places).Count() == 2, "The new customer should have 2 favorite places");
 
-            var addedLink = results.value[4];
-            Assert.Equal("http://localhost/odata/DeltaCustomers(10)", addedLink.source.Value);
-            Assert.Equal("http://localhost/odata/DeltaOrders(1)", addedLink.target.Value);
-            Assert.Equal("Orders", addedLink.relationship.Value);
+            var place1 = places[0];
+            Assert.True(((JToken)place1).Count() == 2, "The first favorite place should have 2 properties written.");
+            Assert.True(place1.State.Value == "State", "The first favorite place's state should be 'State'.");
+            Assert.True(place1.ZipCode.Value == (int?)null, "The first favorite place's Address.ZipCode should be null.");
+
+            var place2 = places[1];
+            Assert.True(((JToken)place2).Count() == 3, "The second favorite place should have 3 properties written.");
+            Assert.True(place2.City.Value == "City2", "The second favorite place's Address.City should be 'City2'.");
+            Assert.True(place2.State.Value == "State2", "The second favorite place's Address.State should be 'State2'.");
+            Assert.True(place2.ZipCode.Value == 12345, "The second favorite place's Address.ZipCode should be 12345.");
+
+            var newOrder = results.value[2];
+            Assert.True(((JToken)newOrder).Count() == 3, "The new order should have 2 properties plus context written");
+            string newOrderContext = newOrder["@odata.context"].Value as string;
+            Assert.True(newOrderContext != null, "The new order should have a context written");
+            Assert.True(newOrderContext.Contains("$metadata#TestOrders"), "The new order should come from the TestOrders entity set");
+            Assert.True(newOrder.Id.Value == 27, "The ID of the new order should be 27");
+            Assert.True(newOrder.Amount.Value == 100, "The amount of the new order should be 100");
+
+            var deletedEntity = results.value[3];
+            Assert.True(deletedEntity.id.Value == "7", "The ID of the deleted customer should be 7");
+            Assert.True(deletedEntity.reason.Value == "changed", "The reason for the deleted customer should be 'changed'");
+
+            var deletedOrder = results.value[4];
+            string deletedOrderContext = deletedOrder["@odata.context"].Value as string;
+            Assert.True(deletedOrderContext != null, "The deleted order should have a context written");
+            Assert.True(deletedOrderContext.Contains("$metadata#TestOrders"), "The deleted order should come from the TestOrders entity set");
+            Assert.True(deletedOrder.id.Value == "12", "The ID of the deleted order should be 12");
+            Assert.True(deletedOrder.reason.Value == "deleted", "The reason for the deleted order should be 'deleted'");
+
+            var deletedLink = results.value[5];
+            Assert.True(deletedLink.source.Value == "http://localhost/odata/DeltaCustomers(1)", "The source of the deleted link should be 'http://localhost/odata/DeltaCustomers(1)'");
+            Assert.True(deletedLink.target.Value == "http://localhost/odata/DeltaOrders(12)", "The target of the deleted link should be 'http://localhost/odata/DeltaOrders(12)'");
+            Assert.True(deletedLink.relationship.Value == "Orders", "The relationship of the deleted link should be 'Orders'");
+
+            var addedLink = results.value[6];
+            Assert.True(addedLink.source.Value == "http://localhost/odata/DeltaCustomers(10)", "The source of the added link should be 'http://localhost/odata/DeltaCustomers(10)'");
+            Assert.True(addedLink.target.Value == "http://localhost/odata/DeltaOrders(27)", "The target of the added link should be 'http://localhost/odata/DeltaOrders(27)'");
+            Assert.True(addedLink.relationship.Value == "Orders", "The relationship of the added link should be 'Orders'");
         }
     }
 
@@ -101,43 +140,68 @@ namespace WebStack.QA.Test.OData
 
         public IHttpActionResult Get()
         {
-            List<IEdmChangedObject> changedObjects = new List<IEdmChangedObject>();
-            IEdmEntityType entityType = Request.ODataProperties().Model.FindDeclaredType("WebStack.QA.Test.OData.TestCustomer") as IEdmEntityType;
+            IEdmEntityType customerType = Request.ODataProperties().Model.FindDeclaredType("WebStack.QA.Test.OData.TestCustomer") as IEdmEntityType;
+            IEdmEntityType customerWithAddressType = Request.ODataProperties().Model.FindDeclaredType("WebStack.QA.Test.OData.TestCustomerWithAddress") as IEdmEntityType;
             IEdmComplexType addressType = Request.ODataProperties().Model.FindDeclaredType("WebStack.QA.Test.OData.TestAddress") as IEdmComplexType;
+            IEdmEntityType orderType = Request.ODataProperties().Model.FindDeclaredType("WebStack.QA.Test.OData.TestOrder") as IEdmEntityType;
+            IEdmEntitySet ordersSet = Request.ODataProperties().Model.FindDeclaredEntitySet("TestOrders") as IEdmEntitySet;
+            EdmChangedObjectCollection changedObjects = new EdmChangedObjectCollection(customerType);
 
             EdmDeltaComplexObject a = new EdmDeltaComplexObject(addressType);
             a.TrySetPropertyValue("State", "State");
             a.TrySetPropertyValue("ZipCode", null);
 
-            EdmDeltaEntityObject changedEntity = new EdmDeltaEntityObject(entityType);
+            EdmDeltaEntityObject changedEntity = new EdmDeltaEntityObject(customerWithAddressType);
             changedEntity.TrySetPropertyValue("Id", 1);
             changedEntity.TrySetPropertyValue("Name", "Name");
             changedEntity.TrySetPropertyValue("Address", a);
+            changedEntity.TrySetPropertyValue("PhoneNumbers", new List<String> { "123-4567", "765-4321" });
             changedObjects.Add(changedEntity);
 
-            var newEntity = new EdmDeltaEntityObject(entityType);
-            newEntity.TrySetPropertyValue("Id", 10);
-            newEntity.TrySetPropertyValue("Name", "NewCustomer");
-            changedObjects.Add(newEntity);
+            EdmComplexObjectCollection places = new EdmComplexObjectCollection(new EdmCollectionTypeReference(new EdmCollectionType(new EdmComplexTypeReference(addressType,true))));
+            EdmDeltaComplexObject b = new EdmDeltaComplexObject(addressType);
+            b.TrySetPropertyValue("City", "City2");
+            b.TrySetPropertyValue("State", "State2");
+            b.TrySetPropertyValue("ZipCode", 12345);
+            places.Add(a);
+            places.Add(b);
 
-            var deletedEntity = new EdmDeltaDeletedEntityObject(entityType);
-            deletedEntity.Id = "7";
-            deletedEntity.Reason = DeltaDeletedEntryReason.Changed;
-            changedObjects.Add(deletedEntity);
+            var newCustomer = new EdmDeltaEntityObject(customerType);
+            newCustomer.TrySetPropertyValue("Id", 10);
+            newCustomer.TrySetPropertyValue("Name", "NewCustomer");
+            newCustomer.TrySetPropertyValue("FavoritePlaces", places);
+            changedObjects.Add(newCustomer);
+            
+            var newOrder = new EdmDeltaEntityObject(orderType);
+            newOrder.NavigationSource = ordersSet;
+            newOrder.TrySetPropertyValue("Id", 27);
+            newOrder.TrySetPropertyValue("Amount", 100);
+            changedObjects.Add(newOrder);
 
-            var deletedLink = new EdmDeltaDeletedLink(entityType);
+            var deletedCustomer = new EdmDeltaDeletedEntityObject(customerType);
+            deletedCustomer.Id = "7";
+            deletedCustomer.Reason = DeltaDeletedEntryReason.Changed;
+            changedObjects.Add(deletedCustomer);
+
+            var deletedOrder = new EdmDeltaDeletedEntityObject(orderType);
+            deletedOrder.NavigationSource = ordersSet;
+            deletedOrder.Id = "12";
+            deletedOrder.Reason = DeltaDeletedEntryReason.Deleted;
+            changedObjects.Add(deletedOrder);
+
+            var deletedLink = new EdmDeltaDeletedLink(customerType);
             deletedLink.Source = new Uri("http://localhost/odata/DeltaCustomers(1)");
-            deletedLink.Target = new Uri("http://localhost/odata/DeltaOrders(1)");
+            deletedLink.Target = new Uri("http://localhost/odata/DeltaOrders(12)");
             deletedLink.Relationship = "Orders";
             changedObjects.Add(deletedLink);
 
-            var addedLink = new EdmDeltaLink(entityType);
+            var addedLink = new EdmDeltaLink(customerType);
             addedLink.Source = new Uri("http://localhost/odata/DeltaCustomers(10)");
-            addedLink.Target = new Uri("http://localhost/odata/DeltaOrders(1)");
+            addedLink.Target = new Uri("http://localhost/odata/DeltaOrders(27)");
             addedLink.Relationship = "Orders";
             changedObjects.Add(addedLink);
 
-            return Ok(new EdmChangedObjectCollection(entityType, changedObjects));
+            return Ok(changedObjects);
         }
     }
 
@@ -146,7 +210,13 @@ namespace WebStack.QA.Test.OData
         public int Id { get; set; }
         public string Name { get; set; }
         public int Age { get; set; }
+        public virtual IList<string> PhoneNumbers {get; set;}
         public virtual IList<TestOrder> Orders { get; set; }
+        public virtual IList<TestAddress> FavoritePlaces { get; set; }
+    }
+
+    public class TestCustomerWithAddress : TestCustomer
+    {
         public virtual TestAddress Address { get; set; }
     }
 

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
@@ -162,6 +162,7 @@
     <Compile Include="DateAndTimeOfDay\DateAndTimeOfDayTest.cs" />
     <Compile Include="DateAndTimeOfDay\DateAndTimeOfDayWithEfTest.cs" />
     <Compile Include="DateAndTimeOfDay\DateWithEfTest.cs" />
+    <Compile Include="DeltaQueryTests\DeltaQueryTests.cs" />
     <Compile Include="DollarLevels\DollarLevelsController.cs" />
     <Compile Include="DollarLevels\DollarLevelsDataModel.cs" />
     <Compile Include="DollarLevels\DollarLevelsEdmModel.cs" />

--- a/OData/test/UnitTest/System.Web.OData.Test/EdmTypeExtensionsTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/EdmTypeExtensionsTest.cs
@@ -38,5 +38,49 @@ namespace System.Web.OData
 
             Assert.False(_edmTypeReference.Definition.IsDeltaFeed());
         }
+        [Fact]
+        public void IsDeltaObject_ThrowsArgumentNull_Type()
+        {
+            IEdmObject instance = null;
+            Assert.ThrowsArgumentNull(
+                () => instance.IsDeltaResource(),
+                "resource");
+        }
+
+        [Fact]
+        public void EdmDeltaEntityObject_IsDeltaObject_ReturnsTrueForDeltaObject()
+        {
+            IEdmEntityType _type = new EdmEntityType("NS", "Entity");
+            EdmDeltaEntityObject _edmObject = new EdmDeltaEntityObject(_type);
+
+            Assert.True(_edmObject.IsDeltaResource());
+        }
+
+        [Fact]
+        public void EdmDeltaComplexObject_IsDeltaObject_ReturnsTrueForDeltaObject()
+        {
+            IEdmComplexType _type = new EdmComplexType("NS", "Entity");
+            EdmDeltaComplexObject _edmObject = new EdmDeltaComplexObject(_type);
+
+            Assert.True(_edmObject.IsDeltaResource());
+        }
+
+        [Fact]
+        public void EdmEntityObject_IsDeltaFeed_ReturnsFalseForNonDeltaObject()
+        {
+            IEdmEntityType _type = new EdmEntityType("NS", "Entity");
+            EdmEntityObject _edmObject = new EdmEntityObject(_type);
+
+            Assert.False(_edmObject.IsDeltaResource());
+        }
+
+        [Fact]
+        public void EdmComplexObject_IsDeltaFeed_ReturnsFalseForNonDeltaObject()
+        {
+            IEdmComplexType _type = new EdmComplexType("NS", "Entity");
+            EdmComplexObject _edmObject = new EdmComplexObject(_type);
+
+            Assert.False(_edmObject.IsDeltaResource());
+        }
     }
 }

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/NavigationSourceLinkBuilderAnnotationTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/NavigationSourceLinkBuilderAnnotationTest.cs
@@ -83,7 +83,7 @@ namespace System.Web.OData.Builder
                 Assert.Null(generatedIdLink);
             }
         }
-
+        
         [Theory]
         [InlineData(true, ODataMetadataLevel.FullMetadata)]
         [InlineData(true, ODataMetadataLevel.MinimalMetadata)]

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/Models/Customer.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/Models/Customer.cs
@@ -20,6 +20,7 @@ namespace System.Web.OData.Formatter.Serialization.Models
         public string City { get; set; }
         public IList<Order> Orders { get; set; }
         public SimpleEnum SimpleEnum { get; set; }
+        public Address HomeAddress { get; set; }
     }
 
     public class SpecialCustomer : Customer

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataDeltaFeedSerializerTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataDeltaFeedSerializerTests.cs
@@ -38,6 +38,11 @@ namespace System.Web.OData.Formatter.Serialization
                     FirstName = "Foo",
                     LastName = "Bar",
                     ID = 10,
+                    HomeAddress = new Address()
+                    {
+                        Street="Street",
+                        ZipCode=null,
+                    }
                 },
                 new Customer()
                 {
@@ -51,6 +56,10 @@ namespace System.Web.OData.Formatter.Serialization
             EdmDeltaEntityObject newCustomer = new EdmDeltaEntityObject(_customerSet.EntityType());
             newCustomer.TrySetPropertyValue("ID", 10);
             newCustomer.TrySetPropertyValue("FirstName", "Foo");
+            EdmDeltaComplexObject newCustomerAddress = new EdmDeltaComplexObject(_model.FindType("Default.Address") as IEdmComplexType);
+            newCustomerAddress.TrySetPropertyValue("Street", "Street");
+            newCustomerAddress.TrySetPropertyValue("ZipCode", null);
+            newCustomer.TrySetPropertyValue("HomeAddress", newCustomerAddress);
             _deltaFeedCustomers.Add(newCustomer);
 
              _customersType = _model.GetEdmTypeReference(typeof(Customer[])).AsCollection();

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataDeltaFeedSerializerTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataDeltaFeedSerializerTests.cs
@@ -318,7 +318,7 @@ namespace System.Web.OData.Formatter.Serialization
         }
 
         [Fact]
-        public void WriteDeltaFeedInline_Sets_DeltaLink_OnWriteEnd()
+        public void WriteDeltaFeedInline_Sets_DeltaLink()
         {
             // Arrange
             IEnumerable instance = new object[0];
@@ -328,7 +328,7 @@ namespace System.Web.OData.Formatter.Serialization
             serializer.Setup(s => s.CreateODataDeltaFeed(instance, _customersType, _writeContext)).Returns(deltafeed);
             var mockWriter = new Mock<ODataDeltaWriter>();
 
-            mockWriter.Setup(m => m.WriteStart(It.Is<ODataDeltaFeed>(f => f.NextPageLink == null))).Verifiable();
+            mockWriter.Setup(m => m.WriteStart(deltafeed));
             mockWriter
                 .Setup(m => m.WriteEnd())
                 .Callback(() =>

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataDeltaFeedSerializerTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataDeltaFeedSerializerTests.cs
@@ -318,6 +318,34 @@ namespace System.Web.OData.Formatter.Serialization
         }
 
         [Fact]
+        public void WriteDeltaFeedInline_Sets_DeltaLink_OnWriteEnd()
+        {
+            // Arrange
+            IEnumerable instance = new object[0];
+            ODataDeltaFeed deltafeed = new ODataDeltaFeed { DeltaLink = new Uri("http://deltalink.com/") };
+            Mock<ODataDeltaFeedSerializer> serializer = new Mock<ODataDeltaFeedSerializer>(new DefaultODataSerializerProvider());
+            serializer.CallBase = true;
+            serializer.Setup(s => s.CreateODataDeltaFeed(instance, _customersType, _writeContext)).Returns(deltafeed);
+            var mockWriter = new Mock<ODataDeltaWriter>();
+
+            mockWriter.Setup(m => m.WriteStart(It.Is<ODataDeltaFeed>(f => f.NextPageLink == null))).Verifiable();
+            mockWriter
+                .Setup(m => m.WriteEnd())
+                .Callback(() =>
+                {
+                    Assert.Equal("http://deltalink.com/", deltafeed.DeltaLink.AbsoluteUri);
+                })
+                .Verifiable();
+
+            // Act
+            serializer.Object.WriteDeltaFeedInline(instance, _customersType, mockWriter.Object, _writeContext);
+
+            // Assert
+            mockWriter.Verify();
+        }
+
+
+        [Fact]
         public void CreateODataDeltaFeed_Sets_CountValueForPageResult()
         {
             // Arrange

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataFeedSerializerTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataFeedSerializerTests.cs
@@ -380,6 +380,23 @@ namespace System.Web.OData.Formatter.Serialization
         }
 
         [Fact]
+        public void CreateODataFeed_Sets_DeltaLinkFromContext()
+        {
+            // Arrange
+            ODataFeedSerializer serializer = new ODataFeedSerializer(new DefaultODataSerializerProvider());
+            Uri expectedDeltaLink = new Uri("http://deltalink.com");
+            HttpRequestMessage request = new HttpRequestMessage();
+            request.ODataProperties().DeltaLink = expectedDeltaLink;
+            var result = new object[0];
+
+            // Act
+            ODataFeed feed = serializer.CreateODataFeed(result, _customersType, new ODataSerializerContext { Request = request });
+
+            // Assert
+            Assert.Equal(expectedDeltaLink, feed.DeltaLink);
+        }
+
+        [Fact]
         public void CreateODataFeed_Ignores_NextPageLink_ForInnerFeeds()
         {
             // Arrange

--- a/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -1757,6 +1757,7 @@ public sealed class System.Web.OData.Extensions.UrlHelperExtensions {
 
 public class System.Web.OData.Extensions.HttpRequestMessageProperties {
 	Microsoft.OData.Core.UriParser.Aggregation.ApplyClause ApplyClause  { public get; public set; }
+	System.Uri DeltaLink  { public get; public set; }
 	Microsoft.OData.Edm.IEdmModel Model  { public get; public set; }
 	System.Uri NextLink  { public get; public set; }
 	ODataPath Path  { public get; public set; }

--- a/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -268,6 +268,7 @@ public class System.Web.OData.EdmDeltaDeletedEntityObject : EdmEntityObject, IDy
 
 	EdmDeltaEntityKind DeltaKind  { public virtual get; }
 	string Id  { public virtual get; public virtual set; }
+	Microsoft.OData.Edm.IEdmNavigationSource NavigationSource  { public get; public set; }
 	Microsoft.OData.Core.DeltaDeletedEntryReason Reason  { public virtual get; public virtual set; }
 }
 
@@ -294,6 +295,7 @@ public class System.Web.OData.EdmDeltaEntityObject : EdmEntityObject, IDynamicMe
 	public EdmDeltaEntityObject (Microsoft.OData.Edm.IEdmEntityType entityType, bool isNullable)
 
 	EdmDeltaEntityKind DeltaKind  { public virtual get; }
+	Microsoft.OData.Edm.IEdmNavigationSource NavigationSource  { public get; public set; }
 }
 
 [

--- a/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -171,6 +171,11 @@ public sealed class System.Web.OData.EdmTypeExtensions {
 	ExtensionAttribute(),
 	]
 	public static bool IsDeltaFeed (Microsoft.OData.Edm.IEdmType type)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static bool IsDeltaResource (IEdmObject resource)
 }
 
 public sealed class System.Web.OData.ODataUriFunctions {
@@ -242,6 +247,15 @@ public class System.Web.OData.EdmComplexObjectCollection : System.Collections.Ob
 	public EdmComplexObjectCollection (Microsoft.OData.Edm.IEdmCollectionTypeReference edmType, System.Collections.Generic.IList`1[[System.Web.OData.IEdmComplexObject]] list)
 
 	public virtual Microsoft.OData.Edm.IEdmTypeReference GetEdmType ()
+}
+
+[
+NonValidatingParameterBindingAttribute(),
+]
+public class System.Web.OData.EdmDeltaComplexObject : EdmComplexObject, IDynamicMetaObjectProvider, IDelta, IEdmComplexObject, IEdmObject, IEdmStructuredObject {
+	public EdmDeltaComplexObject (Microsoft.OData.Edm.IEdmComplexType edmType)
+	public EdmDeltaComplexObject (Microsoft.OData.Edm.IEdmComplexTypeReference edmType)
+	public EdmDeltaComplexObject (Microsoft.OData.Edm.IEdmComplexType edmType, bool isNullable)
 }
 
 [
@@ -950,7 +964,7 @@ public abstract class System.Web.OData.Builder.ProcedureConfiguration {
 	string Namespace  { public get; public set; }
 	NavigationSourceConfiguration NavigationSource  { public get; public set; }
 	bool OptionalReturn  { public get; public set; }
-	System.Collections.Generic.IEnumerable`1[[System.Web.OData.Builder.ParameterConfiguration]] Parameters  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[System.Web.OData.Builder.ParameterConfiguration]] Parameters  { [IteratorStateMachineAttribute(),]public virtual get; }
 	ProcedureLinkBuilder ProcedureLinkBuilder  { protected get; protected set; }
 	IEdmTypeConfiguration ReturnType  { public get; public set; }
 	string Title  { public get; public set; }
@@ -2589,21 +2603,81 @@ public class System.Web.OData.Routing.ODataPathSegmentTranslator : Microsoft.ODa
 	public ODataPathSegmentTranslator (Microsoft.OData.Edm.IEdmModel model, bool enableUriTemplateParsing, System.Collections.Generic.IDictionary`2[[System.String],[Microsoft.OData.Core.UriParser.Semantic.SingleValueNode]] parameterAliasNodes)
 
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.BatchReferenceSegment segment)
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.BatchSegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.CountSegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.EntitySetSegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.KeySegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.MetadataSegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.NavigationPropertyLinkSegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.NavigationPropertySegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.OpenPropertySegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.OperationImportSegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.OperationSegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.PathTemplateSegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.PropertySegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.SingletonSegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.TypeSegment segment)
+
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Web.OData.Routing.ODataPathSegment]] Translate (Microsoft.OData.Core.UriParser.Semantic.ValueSegment segment)
+
 	public static ODataPath TranslateODataLibPathToWebApiPath (Microsoft.OData.Core.UriParser.Semantic.ODataPath path, Microsoft.OData.Edm.IEdmModel model, UnresolvedPathSegment unresolvedPathSegment, Microsoft.OData.Core.UriParser.Semantic.KeySegment id, bool enableUriTemplateParsing, System.Collections.Generic.IDictionary`2[[System.String],[Microsoft.OData.Core.UriParser.Semantic.SingleValueNode]] parameterAliasNodes)
 }
 
@@ -2818,7 +2892,11 @@ public class System.Web.OData.Formatter.Deserialization.ODataCollectionDeseriali
 	public ODataCollectionDeserializer (ODataDeserializerProvider deserializerProvider)
 
 	public virtual object Read (Microsoft.OData.Core.ODataMessageReader messageReader, System.Type type, ODataDeserializerContext readContext)
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.IEnumerable ReadCollectionValue (Microsoft.OData.Core.ODataCollectionValue collectionValue, Microsoft.OData.Edm.IEdmTypeReference elementType, ODataDeserializerContext readContext)
+
 	public virtual object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, ODataDeserializerContext readContext)
 }
 
@@ -2877,7 +2955,11 @@ public class System.Web.OData.Formatter.Deserialization.ODataEnumDeserializer : 
 public class System.Web.OData.Formatter.Deserialization.ODataFeedDeserializer : ODataEdmTypeDeserializer {
 	public ODataFeedDeserializer (ODataDeserializerProvider deserializerProvider)
 
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.IEnumerable ReadFeed (ODataFeedWithEntries feed, Microsoft.OData.Edm.IEdmEntityTypeReference elementType, ODataDeserializerContext readContext)
+
 	public virtual object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, ODataDeserializerContext readContext)
 }
 

--- a/OData/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
+++ b/OData/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
@@ -343,6 +343,7 @@
     <Compile Include="PublicApi\PublicApiTest.cs" />
     <Compile Include="Resources.cs" />
     <Compile Include="TestCommon\CustomersModelWithInheritance.cs" />
+    <Compile Include="OData\EdmDeltaComplexObjectTest.cs" />
     <Compile Include="TestCommon\SimpleOpenAddress.cs" />
     <Compile Include="TestCommon\ODataModelBuilderMocks.cs" />
     <Compile Include="TestCommon\SimpleOpenCustomer.cs" />


### PR DESCRIPTION
### Issues
*This pull request fixes issue #857*  
*This pull request fixes issue #900*  

### Description
*Serializes only changed properties in a Delta response when using EdmDeltaEntityObject*
*Adds EdmDeltaComplexObject for serializing only changed properties of a complex type*
*Adds support for writing DeltaLink to WebAPI OData*

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
*We could certainly use some examples for Delta*
*Need to apply similar changes to WebAPI60, but refactoring makes it more difficult*
