### PR TITLE
Fixes for writing Delta Responses - OData 60

### DIFF
--- a/OData/src/System.Web.OData/Extensions/HttpRequestMessageProperties.cs
+++ b/OData/src/System.Web.OData/Extensions/HttpRequestMessageProperties.cs
@@ -23,6 +23,7 @@ namespace System.Web.OData.Extensions
     {
         // Maintain the System.Web.OData. prefix in any new properties to avoid conflicts with user properties
         // and those of the v3 assembly.
+        private const string DeltaLinkKey = "System.Web.OData.DeltaLink";
         private const string NextLinkKey = "System.Web.OData.NextLink";
         private const string PathKey = "System.Web.OData.Path";
         private const string RouteNameKey = "System.Web.OData.RouteName";
@@ -143,6 +144,22 @@ namespace System.Web.OData.Extensions
             set
             {
                 _request.Properties[NextLinkKey] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the delta link for the OData response.
+        /// </summary>
+        /// <value><c>null</c> if no delta link should be sent back to the client.</value>
+        public Uri DeltaLink
+        {
+            get
+            {
+                return GetValueOrNull<Uri>(DeltaLinkKey);
+            }
+            set
+            {
+                _request.Properties[DeltaLinkKey] = value;
             }
         }
 

--- a/OData/src/System.Web.OData/OData/EdmDeltaComplexObject.cs
+++ b/OData/src/System.Web.OData/OData/EdmDeltaComplexObject.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Diagnostics.Contracts;
+using Microsoft.OData.Edm;
+
+namespace System.Web.OData
+{
+    /// <summary>
+    /// Represents an <see cref="IEdmChangedObject"/> with no backing CLR <see cref="Type"/>.
+    /// Used to hold the Entry object in the Delta Feed Payload.
+    /// </summary>
+    [NonValidatingParameterBinding]
+    public class EdmDeltaComplexObject : EdmComplexObject
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmDeltaComplexObject"/> class.
+        /// </summary>
+        /// <param name="edmType">The <see cref="IEdmComplexType"/> of this object.</param>
+        public EdmDeltaComplexObject(IEdmComplexType edmType)
+            : this(edmType, isNullable: false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmDeltaComplexObject"/> class.
+        /// </summary>
+        /// <param name="edmType">The <see cref="IEdmComplexTypeReference"/> of this object.</param>
+        public EdmDeltaComplexObject(IEdmComplexTypeReference edmType)
+            : this(edmType.ComplexDefinition(), edmType.IsNullable)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmDeltaComplexObject"/> class.
+        /// </summary>
+        /// <param name="edmType">The <see cref="IEdmComplexType"/> of this object.</param>
+        /// <param name="isNullable">true if this object can be nullable; otherwise, false.</param>
+        public EdmDeltaComplexObject(IEdmComplexType edmType, bool isNullable)
+            : base(edmType, isNullable)
+        {
+        }
+    }
+}

--- a/OData/src/System.Web.OData/OData/EdmDeltaDeletedEntityObject.cs
+++ b/OData/src/System.Web.OData/OData/EdmDeltaDeletedEntityObject.cs
@@ -17,6 +17,7 @@ namespace System.Web.OData
         private string _id;
         private DeltaDeletedEntryReason _reason;
         private EdmDeltaType _edmType;
+        private IEdmNavigationSource _navigationSource;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmDeltaDeletedEntityObject"/> class.
@@ -80,6 +81,21 @@ namespace System.Web.OData
             {
                 Contract.Assert(_edmType != null);
                 return _edmType.DeltaKind;
+            }
+        }
+
+        /// <summary>
+        /// The navigation source of the deleted entity. If null, then the deleted entity is from the current feed.
+        /// </summary>
+        public IEdmNavigationSource NavigationSource
+        {
+            get
+            {
+                return _navigationSource;
+            }
+            set
+            {
+                _navigationSource = value;
             }
         }
     }

--- a/OData/src/System.Web.OData/OData/EdmDeltaEntityObject.cs
+++ b/OData/src/System.Web.OData/OData/EdmDeltaEntityObject.cs
@@ -14,6 +14,7 @@ namespace System.Web.OData
     public class EdmDeltaEntityObject : EdmEntityObject, IEdmChangedObject
     {
         private EdmDeltaType _edmType;
+        private IEdmNavigationSource _navigationSource;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmDeltaEntityObject"/> class.
@@ -51,6 +52,21 @@ namespace System.Web.OData
             {
                 Contract.Assert(_edmType != null);
                 return _edmType.DeltaKind;
+            }
+        }
+
+        /// <summary>
+        /// The navigation source of the entity. If null, then the entity is from the current feed.
+        /// </summary>
+        public IEdmNavigationSource NavigationSource
+        {
+            get
+            {
+                return _navigationSource;
+            }
+            set
+            {
+                _navigationSource = value;
             }
         }
     }

--- a/OData/src/System.Web.OData/OData/EdmEntityObject.cs
+++ b/OData/src/System.Web.OData/OData/EdmEntityObject.cs
@@ -12,7 +12,7 @@ namespace System.Web.OData
     public class EdmEntityObject : EdmStructuredObject, IEdmEntityObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="EdmStructuredObject"/> class.
+        /// Initializes a new instance of the <see cref="EdmEntityObject"/> class.
         /// </summary>
         /// <param name="edmType">The <see cref="IEdmEntityType"/> of this object.</param>
         public EdmEntityObject(IEdmEntityType edmType)
@@ -21,7 +21,7 @@ namespace System.Web.OData
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EdmStructuredObject"/> class.
+        /// Initializes a new instance of the <see cref="EdmEntityObject"/> class.
         /// </summary>
         /// <param name="edmType">The <see cref="IEdmEntityTypeReference"/> of this object.</param>
         public EdmEntityObject(IEdmEntityTypeReference edmType)
@@ -30,7 +30,7 @@ namespace System.Web.OData
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EdmStructuredObject"/> class.
+        /// Initializes a new instance of the <see cref="EdmEntityObject"/> class.
         /// </summary>
         /// <param name="edmType">The <see cref="IEdmEntityType"/> of this object.</param>
         /// <param name="isNullable">true if this object can be nullable; otherwise, false.</param>

--- a/OData/src/System.Web.OData/OData/EdmTypeExtensions.cs
+++ b/OData/src/System.Web.OData/OData/EdmTypeExtensions.cs
@@ -12,7 +12,7 @@ namespace System.Web.OData
     public static class EdmTypeExtensions
     {
         /// <summary>
-        /// Method to determine whether the current type is containing a Delta Feed
+        /// Method to determine whether the current type is a Delta Feed
         /// </summary>
         /// <param name="type">IEdmType to be compared</param>
         /// <returns>True or False if type is same as <see cref="EdmDeltaCollectionType"/></returns>
@@ -23,6 +23,20 @@ namespace System.Web.OData
                 throw Error.ArgumentNull("type");
             }
             return (type.GetType() == typeof(EdmDeltaCollectionType));
+        }
+        
+        /// <summary>
+        /// Method to determine whether the current Edm object is a Delta Entry
+        /// </summary>
+        /// <param name="resource">IEdmObject to be compared</param>
+        /// <returns>True or False if type is same as <see cref="EdmDeltaEntityObject"/> or <see cref="EdmDeltaComplexObject"/></returns>
+        public static bool IsDeltaResource(this IEdmObject resource)
+        {
+            if (resource == null)
+            {
+                throw Error.ArgumentNull("resource");
+            }
+            return (resource is EdmDeltaEntityObject || resource is EdmDeltaComplexObject);
         }
     }
 }

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
@@ -268,18 +268,10 @@ namespace System.Web.OData.Formatter.Serialization
             ODataDeltaDeletedEntry deltaDeletedEntry = new ODataDeltaDeletedEntry(
                edmDeltaDeletedEntity.Id, edmDeltaDeletedEntity.Reason);
 
-            ODataDeltaSerializationInfo serializationInfo = null;
             if (edmDeltaDeletedEntity.NavigationSource != null)
             {
-                if (serializationInfo == null)
-                {
-                    serializationInfo = new ODataDeltaSerializationInfo();
-                }
+                ODataDeltaSerializationInfo serializationInfo = new ODataDeltaSerializationInfo();
                 serializationInfo.NavigationSourceName = edmDeltaDeletedEntity.NavigationSource.Name;
-            }
-
-            if (serializationInfo != null)
-            {
                 deltaDeletedEntry.SetSerializationInfo(serializationInfo);
             }
 

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
@@ -114,8 +114,6 @@ namespace System.Web.OData.Formatter.Serialization
 
             if (elementType.IsComplex())
             {
-                elementType = elementType.AsComplex();
-
                 ODataResourceSet resourceSet = new ODataResourceSet()
                 {
                     TypeName = feedType.FullName()
@@ -137,8 +135,6 @@ namespace System.Web.OData.Formatter.Serialization
             }
             else
             {
-                elementType = elementType.AsEntity();
-
                 ODataDeltaResourceSet deltaFeed = CreateODataDeltaFeed(enumerable, feedType.AsCollection(), writeContext);
                 if (deltaFeed == null)
                 {
@@ -271,6 +267,21 @@ namespace System.Web.OData.Formatter.Serialization
 
             ODataDeltaDeletedEntry deltaDeletedEntry = new ODataDeltaDeletedEntry(
                edmDeltaDeletedEntity.Id, edmDeltaDeletedEntity.Reason);
+
+            ODataDeltaSerializationInfo serializationInfo = null;
+            if (edmDeltaDeletedEntity.NavigationSource != null)
+            {
+                if (serializationInfo == null)
+                {
+                    serializationInfo = new ODataDeltaSerializationInfo();
+                }
+                serializationInfo.NavigationSourceName = edmDeltaDeletedEntity.NavigationSource.Name;
+            }
+
+            if (serializationInfo != null)
+            {
+                deltaDeletedEntry.SetSerializationInfo(serializationInfo);
+            }
 
             if (deltaDeletedEntry != null)
             {

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
@@ -58,7 +58,7 @@ namespace System.Web.OData.Formatter.Serialization
             IEdmTypeReference feedType = writeContext.GetEdmType(graph, type);
             Contract.Assert(feedType != null);
 
-            IEdmEntityTypeReference entityType = GetEntityType(feedType);
+            IEdmEntityTypeReference entityType = GetResourceType(feedType).AsEntity();
             ODataDeltaWriter writer = messageWriter.CreateODataDeltaWriter(entitySet, entityType.EntityDefinition());
 
             WriteDeltaFeedInline(graph, feedType, writer, writeContext);
@@ -110,70 +110,99 @@ namespace System.Web.OData.Formatter.Serialization
             Contract.Assert(enumerable != null);
             Contract.Assert(feedType != null);
 
-            ODataDeltaResourceSet deltaFeed = CreateODataDeltaFeed(enumerable, feedType.AsCollection(), writeContext);
-            if (deltaFeed == null)
+            IEdmStructuredTypeReference elementType = GetResourceType(feedType);
+
+            if (elementType.IsComplex())
             {
-                throw new SerializationException(Error.Format(SRResources.CannotSerializerNull, DeltaFeed));
+                elementType = elementType.AsComplex();
+
+                ODataResourceSet resourceSet = new ODataResourceSet()
+                {
+                    TypeName = feedType.FullName()
+                };
+
+                writer.WriteStart(resourceSet);
+
+                ODataResourceSerializer entrySerializer = SerializerProvider.GetEdmTypeSerializer(elementType) as ODataResourceSerializer;
+                if (entrySerializer == null)
+                {
+                    throw new SerializationException(
+                        Error.Format(SRResources.TypeCannotBeSerialized, elementType.FullName(), typeof(ODataMediaTypeFormatter).Name));
+                }
+
+                foreach (object entry in enumerable)
+                {
+                    entrySerializer.WriteDeltaObjectInline(entry, elementType, writer, writeContext);
+                }
             }
-
-            // save this for later to support JSON odata.streaming.
-            Uri nextPageLink = deltaFeed.NextPageLink;
-            deltaFeed.NextPageLink = null;
-
-            //Start writing of the Delta Feed
-            writer.WriteStart(deltaFeed);
-
-            //Iterate over all the entries present and select the appropriate write method.
-            //Write method creates ODataDeltaDeletedEntry / ODataDeltaDeletedLink / ODataDeltaLink or ODataEntry.
-            foreach (object entry in enumerable)
+            else
             {
-                if (entry == null)
+                elementType = elementType.AsEntity();
+
+                ODataDeltaResourceSet deltaFeed = CreateODataDeltaFeed(enumerable, feedType.AsCollection(), writeContext);
+                if (deltaFeed == null)
                 {
-                    throw new SerializationException(SRResources.NullElementInCollection);
+                    throw new SerializationException(Error.Format(SRResources.CannotSerializerNull, DeltaFeed));
                 }
 
-                IEdmChangedObject edmChangedObject = entry as IEdmChangedObject;
-                if (edmChangedObject == null)
-                {
-                    throw new SerializationException(Error.Format(SRResources.CannotWriteType, GetType().Name, enumerable.GetType().FullName));
-                }
+                // save this for later to support JSON odata.streaming.
+                Uri nextPageLink = deltaFeed.NextPageLink;
+                deltaFeed.NextPageLink = null;
 
-                switch (edmChangedObject.DeltaKind)
+                //Start writing of the Delta Feed
+                writer.WriteStart(deltaFeed);
+
+                //Iterate over all the entries present and select the appropriate write method.
+                //Write method creates ODataDeltaDeletedEntry / ODataDeltaDeletedLink / ODataDeltaLink or ODataEntry.
+                foreach (object entry in enumerable)
                 {
-                    case EdmDeltaEntityKind.DeletedEntry:
-                        WriteDeltaDeletedEntry(entry, writer, writeContext);
-                        break;
-                    case EdmDeltaEntityKind.DeletedLinkEntry:
-                        WriteDeltaDeletedLink(entry, writer, writeContext);
-                        break;
-                    case EdmDeltaEntityKind.LinkEntry:
-                        WriteDeltaLink(entry, writer, writeContext);
-                        break;
-                    case EdmDeltaEntityKind.Entry:
-                        {
-                            IEdmEntityTypeReference elementType = GetEntityType(feedType);
-                            ODataResourceSerializer entrySerializer = SerializerProvider.GetEdmTypeSerializer(elementType) as ODataResourceSerializer;
-                            if (entrySerializer == null)
-                            {
-                                throw new SerializationException(
-                                    Error.Format(SRResources.TypeCannotBeSerialized, elementType.FullName(), typeof(ODataMediaTypeFormatter).Name));
-                            }
-                            entrySerializer.WriteDeltaObjectInline(entry, elementType, writer, writeContext);
+                    if (entry == null)
+                    {
+                        throw new SerializationException(SRResources.NullElementInCollection);
+                    }
+
+                    IEdmChangedObject edmChangedObject = entry as IEdmChangedObject;
+                    if (edmChangedObject == null)
+                    {
+                        throw new SerializationException(Error.Format(SRResources.CannotWriteType, GetType().Name, enumerable.GetType().FullName));
+                    }
+
+                    switch (edmChangedObject.DeltaKind)
+                    {
+                        case EdmDeltaEntityKind.DeletedEntry:
+                            WriteDeltaDeletedEntry(entry, writer, writeContext);
                             break;
-                        }
-                    default:
-                        break;
+                        case EdmDeltaEntityKind.DeletedLinkEntry:
+                            WriteDeltaDeletedLink(entry, writer, writeContext);
+                            break;
+                        case EdmDeltaEntityKind.LinkEntry:
+                            WriteDeltaLink(entry, writer, writeContext);
+                            break;
+                        case EdmDeltaEntityKind.Entry:
+                            {
+                                ODataResourceSerializer entrySerializer = SerializerProvider.GetEdmTypeSerializer(elementType) as ODataResourceSerializer;
+                                if (entrySerializer == null)
+                                {
+                                    throw new SerializationException(
+                                        Error.Format(SRResources.TypeCannotBeSerialized, elementType.FullName(), typeof(ODataMediaTypeFormatter).Name));
+                                }
+                                entrySerializer.WriteDeltaObjectInline(entry, elementType, writer, writeContext);
+                                break;
+                            }
+                        default:
+                            break;
+                    }
                 }
-            }
 
-            // Subtle and surprising behavior: If the NextPageLink property is set before calling WriteStart(feed),
-            // the next page link will be written early in a manner not compatible with odata.streaming=true. Instead, if
-            // the next page link is not set when calling WriteStart(feed) but is instead set later on that feed
-            // object before calling WriteEnd(), the next page link will be written at the end, as required for
-            // odata.streaming=true support.
-            if (nextPageLink != null)
-            {
-                deltaFeed.NextPageLink = nextPageLink;
+                // Subtle and surprising behavior: If the NextPageLink property is set before calling WriteStart(feed),
+                // the next page link will be written early in a manner not compatible with odata.streaming=true. Instead, if
+                // the next page link is not set when calling WriteStart(feed) but is instead set later on that feed
+                // object before calling WriteEnd(), the next page link will be written at the end, as required for
+                // odata.streaming=true support.
+                if (nextPageLink != null)
+                {
+                    deltaFeed.NextPageLink = nextPageLink;
+                }
             }
 
             //End Writing of the Delta Feed
@@ -301,14 +330,14 @@ namespace System.Web.OData.Formatter.Serialization
             }
         }
 
-        private static IEdmEntityTypeReference GetEntityType(IEdmTypeReference feedType)
+        private static IEdmStructuredTypeReference GetResourceType(IEdmTypeReference feedType)
         {
             if (feedType.IsCollection())
             {
                 IEdmTypeReference elementType = feedType.AsCollection().ElementType();
-                if (elementType.IsEntity())
+                if (elementType.IsEntity() || elementType.IsComplex())
                 {
-                    return elementType.AsEntity();
+                    return elementType.AsStructured();
                 }
             }
 

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
@@ -204,6 +204,7 @@ namespace System.Web.OData.Formatter.Serialization
                 else if (writeContext.Request != null)
                 {
                     feed.NextPageLink = writeContext.Request.ODataProperties().NextLink;
+                    feed.DeltaLink = writeContext.Request.ODataProperties().DeltaLink;
 
                     long? countValue = writeContext.Request.ODataProperties().TotalCount;
                     if (countValue.HasValue)

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -395,13 +395,9 @@ namespace System.Web.OData.Formatter.Serialization
                 Properties = CreateStructuralPropertyBag(selectExpandNode.SelectedStructuralProperties, resourceContext),
             };
 
-            ODataResourceSerializationInfo serializationInfo = null;
-            if (resourceContext.NavigationSource != null)
+            if (resourceContext.EdmObject is EdmDeltaEntityObject && resourceContext.NavigationSource != null)
             {
-                if (serializationInfo == null)
-                {
-                    serializationInfo = new ODataResourceSerializationInfo();
-                }
+                ODataResourceSerializationInfo serializationInfo = new ODataResourceSerializationInfo();
                 serializationInfo.NavigationSourceName = resourceContext.NavigationSource.Name;
                 serializationInfo.NavigationSourceKind = resourceContext.NavigationSource.NavigationSourceKind();
                 IEdmEntityType sourceType = resourceContext.NavigationSource.EntityType();
@@ -409,10 +405,6 @@ namespace System.Web.OData.Formatter.Serialization
                 {
                     serializationInfo.NavigationSourceEntityTypeName = sourceType.Name;
                 }
-            }
-
-            if (serializationInfo != null)
-            {
                 resource.SetSerializationInfo(serializationInfo);
             }
 

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -211,9 +211,16 @@ namespace System.Web.OData.Formatter.Serialization
                 //     throw new SerializationException(
                 //         Error.Format(SRResources.TypeCannotBeSerialized, edmProperty.Type.ToTraceString(), typeof(ODataResourceSerializer).Name));
                 // }
-                // serializer.WriteDeltaObjectInline(propertyValue, edmProperty.Type, writer, nestedWriteContext);
-
-                WriteDeltaObjectInline(propertyValue, edmProperty.Type, writer, nestedWriteContext);
+                if (edmProperty.Type.IsCollection())
+                {
+                    ODataDeltaFeedSerializer serializer = new ODataDeltaFeedSerializer(SerializerProvider);
+                    serializer.WriteDeltaFeedInline(propertyValue, edmProperty.Type, writer, nestedWriteContext);
+                }
+                else
+                {
+                    ODataResourceSerializer serializer = new ODataResourceSerializer(SerializerProvider);
+                    serializer.WriteDeltaObjectInline(propertyValue, edmProperty.Type, writer, nestedWriteContext);
+                }
             }
         }
 

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -491,7 +491,11 @@ namespace System.Web.OData.Formatter.Serialization
             }
 
             bool nullDynamicPropertyEnabled = false;
-            if (resourceContext.Request != null)
+            if (resourceContext.EdmObject is EdmDeltaComplexObject || resourceContext.EdmObject is EdmDeltaEntityObject)
+            {
+                nullDynamicPropertyEnabled = true;
+            }
+            else if (resourceContext.Request != null)
             {
                 HttpConfiguration configuration = resourceContext.Request.GetConfiguration();
                 if (configuration != null)

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -118,6 +118,12 @@ namespace System.Web.OData.Formatter.Serialization
 
             IEdmStructuredTypeReference structuredType = GetResourceType(graph, writeContext);
             ResourceContext resourceContext = new ResourceContext(writeContext, structuredType, graph);
+            EdmDeltaEntityObject deltaResource = graph as EdmDeltaEntityObject;
+            if (deltaResource != null && deltaResource.NavigationSource != null)
+            {
+                resourceContext.NavigationSource = deltaResource.NavigationSource;
+            }
+
             SelectExpandNode selectExpandNode = CreateSelectExpandNode(resourceContext);
             if (selectExpandNode != null)
             {
@@ -388,6 +394,27 @@ namespace System.Web.OData.Formatter.Serialization
                 TypeName = typeName,
                 Properties = CreateStructuralPropertyBag(selectExpandNode.SelectedStructuralProperties, resourceContext),
             };
+
+            ODataResourceSerializationInfo serializationInfo = null;
+            if (resourceContext.NavigationSource != null)
+            {
+                if (serializationInfo == null)
+                {
+                    serializationInfo = new ODataResourceSerializationInfo();
+                }
+                serializationInfo.NavigationSourceName = resourceContext.NavigationSource.Name;
+                serializationInfo.NavigationSourceKind = resourceContext.NavigationSource.NavigationSourceKind();
+                IEdmEntityType sourceType = resourceContext.NavigationSource.EntityType();
+                if (sourceType != null)
+                {
+                    serializationInfo.NavigationSourceEntityTypeName = sourceType.Name;
+                }
+            }
+
+            if (serializationInfo != null)
+            {
+                resource.SetSerializationInfo(serializationInfo);
+            }
 
             // Try to add the dynamic properties if the structural type is open.
             AppendDynamicProperties(resource, selectExpandNode, resourceContext);
@@ -1109,6 +1136,18 @@ namespace System.Web.OData.Formatter.Serialization
                 {
                     // we are in dynamic complex.
                     return null;
+                }
+
+                // figure out the type from the navigation source
+                if (serializerContext.NavigationSource != null)
+                {
+                    IEdmType edmType = serializerContext.NavigationSource.EntityType();
+                    if (edmType.TypeKind == EdmTypeKind.Collection)
+                    {
+                        edmType = (edmType as IEdmCollectionType).ElementType.Definition;
+                    }
+
+                    return edmType as IEdmStructuredType;
                 }
 
                 // figure out the type from the path.

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -1130,31 +1130,34 @@ namespace System.Web.OData.Formatter.Serialization
                     return null;
                 }
 
+                IEdmType edmType = null;
+
                 // figure out the type from the navigation source
                 if (serializerContext.NavigationSource != null)
                 {
-                    IEdmType edmType = serializerContext.NavigationSource.EntityType();
+                    edmType = serializerContext.NavigationSource.EntityType();
                     if (edmType.TypeKind == EdmTypeKind.Collection)
                     {
                         edmType = (edmType as IEdmCollectionType).ElementType.Definition;
                     }
-
-                    return edmType as IEdmStructuredType;
                 }
 
                 // figure out the type from the path.
                 if (serializerContext.Path != null)
                 {
-                    IEdmType edmType = serializerContext.Path.EdmType;
-                    if (edmType.TypeKind == EdmTypeKind.Collection)
+                    // Note: The navigation source may be different from the path if the instance has redefined the context
+                    // (for example, in a flattended delta response)
+                    if (serializerContext.NavigationSource == null || serializerContext.NavigationSource == serializerContext.Path.NavigationSource)
                     {
-                        edmType = (edmType as IEdmCollectionType).ElementType.Definition;
+                        edmType = serializerContext.Path.EdmType;
+                        if (edmType.TypeKind == EdmTypeKind.Collection)
+                        {
+                            edmType = (edmType as IEdmCollectionType).ElementType.Definition;
+                        }
                     }
-
-                    return edmType as IEdmStructuredType;
                 }
 
-                return null;
+                return edmType as IEdmStructuredType;
             }
         }
 

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSetSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSetSerializer.cs
@@ -216,6 +216,7 @@ namespace System.Web.OData.Formatter.Serialization
                 else if (writeContext.Request != null)
                 {
                     resourceSet.NextPageLink = writeContext.Request.ODataProperties().NextLink;
+                    resourceSet.DeltaLink = writeContext.Request.ODataProperties().DeltaLink;
 
                     long? countValue = writeContext.Request.ODataProperties().TotalCount;
                     if (countValue.HasValue)

--- a/OData/src/System.Web.OData/OData/Query/TopQueryOption.cs
+++ b/OData/src/System.Web.OData/OData/Query/TopQueryOption.cs
@@ -101,7 +101,7 @@ namespace System.Web.OData.Query
                         throw new ODataException(Error.Format(
                             SRResources.SkipTopLimitExceeded,
                             Int32.MaxValue,
-                            AllowedQueryOptions.Skip,
+                            AllowedQueryOptions.Top,
                             RawValue));
                     }
 

--- a/OData/src/System.Web.OData/System.Web.OData.csproj
+++ b/OData/src/System.Web.OData/System.Web.OData.csproj
@@ -106,6 +106,7 @@
     <Compile Include="OData\Builder\Conventions\Attributes\DataContractAttributeEnumTypeConvention.cs" />
     <Compile Include="OData\Builder\Conventions\Attributes\MediaTypeAttributeConvention.cs" />
     <Compile Include="OData\Builder\BindingPathHelper.cs" />
+    <Compile Include="OData\EdmDeltaComplexObject.cs" />
     <Compile Include="OData\Formatter\Deserialization\ODataDeserializerProviderProxy.cs" />
     <Compile Include="OData\Formatter\ODataModelBinderConverter.cs" />
     <Compile Include="OData\Formatter\Serialization\ODataSerializerProviderProxy.cs" />

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/Common/ODataTestExtension.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/Common/ODataTestExtension.cs
@@ -21,7 +21,7 @@ namespace WebStack.QA.Test.OData.Common
     {
         public static void ClearRepository(this IODataTestBase test, string entityName)
         {
-            test.Client.DeleteAsync(test.BaseAddress + "/api/" + entityName + "/Delete").Wait();
+            test.Client.DeleteAsync(test.BaseAddress + "/" + entityName).Wait();
         }
 
         public static void EnableODataSupport(this HttpConfiguration configuration, IEdmModel model, string routePrefix)

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DeltaQueryTests/DeltaQueryTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DeltaQueryTests/DeltaQueryTests.cs
@@ -58,35 +58,39 @@ namespace WebStack.QA.Test.OData
         }
 
         [Fact]
-        public void DeltaContainsExpectedProperties()
+        public void DeltaVerifyReslt()
         {
             HttpRequestMessage get = new HttpRequestMessage(HttpMethod.Get, BaseAddress + "/odata/TestCustomers?$deltaToken=abc");
+            get.Headers.Add("Accept", "application/json;odata.metadata=minimal");
             HttpResponseMessage response = Client.SendAsync(get).Result;
             Assert.True(response.IsSuccessStatusCode);
             dynamic results = response.Content.ReadAsAsync<JObject>().Result;
 
-            Assert.True(results.value.Count == 5, "There should be 5 entries in the response");
+            Assert.True(results.value.Count == 7, "There should be 7 entries in the response");
 
             var changeEntity = results.value[0];
-            Assert.True(((JToken)changeEntity).Count() == 4, "The changed entity should have 4 properties written.");
-            Assert.True(changeEntity.Id.Value == 1, "The ID Of changed entity should be 1.");
-            Assert.True(changeEntity.Name.Value == "Name", "The Name of changed entity should be 'Name'");
+            Assert.True(((JToken)changeEntity).Count() == 5, "The changed customer should have 4 properties plus type written.");
+            string changeEntityType = changeEntity["@odata.type"].Value as string;
+            Assert.True(changeEntityType != null, "The changed customer should have type written");
+            Assert.True(changeEntityType.Contains("#WebStack.QA.Test.OData.TestCustomerWithAddress"), "The changed order should be a TestCustomerWithAddress");
+            Assert.True(changeEntity.Id.Value == 1, "The ID Of changed customer should be 1.");
+            Assert.True(changeEntity.Name.Value == "Name", "The Name of changed customer should be 'Name'");
             Assert.True(((JToken)changeEntity.Address).Count() == 2, "The changed entity's Address should have 2 properties written.");
-            Assert.True(changeEntity.Address.State.Value == "State", "The changed entity's Address.State should be 'State'.");
-            Assert.True(changeEntity.Address.ZipCode.Value == (int?)null, "The changed entity's Address.ZipCode should be null.");
+            Assert.True(changeEntity.Address.State.Value == "State", "The changed customer's Address.State should be 'State'.");
+            Assert.True(changeEntity.Address.ZipCode.Value == (int?)null, "The changed customer's Address.ZipCode should be null.");
 
             var phoneNumbers = changeEntity.PhoneNumbers;
-            Assert.True(((JToken)phoneNumbers).Count() == 2, "The changed entity should have 2 phone numbers");
+            Assert.True(((JToken)phoneNumbers).Count() == 2, "The changed customer should have 2 phone numbers");
             Assert.True(phoneNumbers[0].Value == "123-4567", "The first phone number should be '123-4567'");
             Assert.True(phoneNumbers[1].Value == "765-4321", "The second phone number should be '765-4321'");
 
-            var newEntity = results.value[1];
-            Assert.True(((JToken)newEntity).Count() == 3, "The new entity should have 3 properties written");
-            Assert.True(newEntity.Id.Value == 10, "The ID of the new entity should be 10");
-            Assert.True(newEntity.Name.Value == "NewCustomer", "The name of the new entity should be 'NewCustomer'");
+            var newCustomer = results.value[1];
+            Assert.True(((JToken)newCustomer).Count() == 3, "The new customer should have 3 properties written");
+            Assert.True(newCustomer.Id.Value == 10, "The ID of the new customer should be 10");
+            Assert.True(newCustomer.Name.Value == "NewCustomer", "The name of the new customer should be 'NewCustomer'");
 
-            var places = newEntity.FavoritePlaces;
-            Assert.True(((JToken)places).Count() == 2, "The new entity should have 2 favorite places");
+            var places = newCustomer.FavoritePlaces;
+            Assert.True(((JToken)places).Count() == 2, "The new customer should have 2 favorite places");
 
             var place1 = places[0];
             Assert.True(((JToken)place1).Count() == 2, "The first favorite place should have 2 properties written.");
@@ -99,18 +103,33 @@ namespace WebStack.QA.Test.OData
             Assert.True(place2.State.Value == "State2", "The second favorite place's Address.State should be 'State2'.");
             Assert.True(place2.ZipCode.Value == 12345, "The second favorite place's Address.ZipCode should be 12345.");
 
-            var deletedEntity = results.value[2];
-            Assert.True(deletedEntity.id.Value == "7", "The ID of the deleted entity should be 7");
-            Assert.True(deletedEntity.reason.Value == "changed", "The reason for the deleted entity shoudl be 'changed'");
+            var newOrder = results.value[2];
+            Assert.True(((JToken)newOrder).Count() == 3, "The new order should have 2 properties plus context written");
+            string newOrderContext = newOrder["@odata.context"].Value as string;
+            Assert.True(newOrderContext != null, "The new order should have a context written");
+            Assert.True(newOrderContext.Contains("$metadata#TestOrders"), "The new order should come from the TestOrders entity set");
+            Assert.True(newOrder.Id.Value == 27, "The ID of the new order should be 27");
+            Assert.True(newOrder.Amount.Value == 100, "The amount of the new order should be 100");
 
-            var deletedLink = results.value[3];
+            var deletedEntity = results.value[3];
+            Assert.True(deletedEntity.id.Value == "7", "The ID of the deleted customer should be 7");
+            Assert.True(deletedEntity.reason.Value == "changed", "The reason for the deleted customer should be 'changed'");
+
+            var deletedOrder = results.value[4];
+            string deletedOrderContext = deletedOrder["@odata.context"].Value as string;
+            Assert.True(deletedOrderContext != null, "The deleted order should have a context written");
+            Assert.True(deletedOrderContext.Contains("$metadata#TestOrders"), "The deleted order should come from the TestOrders entity set");
+            Assert.True(deletedOrder.id.Value == "12", "The ID of the deleted order should be 12");
+            Assert.True(deletedOrder.reason.Value == "deleted", "The reason for the deleted order should be 'deleted'");
+
+            var deletedLink = results.value[5];
             Assert.True(deletedLink.source.Value == "http://localhost/odata/DeltaCustomers(1)", "The source of the deleted link should be 'http://localhost/odata/DeltaCustomers(1)'");
-            Assert.True(deletedLink.target.Value == "http://localhost/odata/DeltaOrders(1)", "The target of the deleted link should be 'http://localhost/odata/DeltaOrders(1)'");
+            Assert.True(deletedLink.target.Value == "http://localhost/odata/DeltaOrders(12)", "The target of the deleted link should be 'http://localhost/odata/DeltaOrders(12)'");
             Assert.True(deletedLink.relationship.Value == "Orders", "The relationship of the deleted link should be 'Orders'");
 
-            var addedLink = results.value[4];
+            var addedLink = results.value[6];
             Assert.True(addedLink.source.Value == "http://localhost/odata/DeltaCustomers(10)", "The source of the added link should be 'http://localhost/odata/DeltaCustomers(10)'");
-            Assert.True(addedLink.target.Value == "http://localhost/odata/DeltaOrders(1)", "The target of the added link should be 'http://localhost/odata/DeltaOrders(1)'");
+            Assert.True(addedLink.target.Value == "http://localhost/odata/DeltaOrders(27)", "The target of the added link should be 'http://localhost/odata/DeltaOrders(27)'");
             Assert.True(addedLink.relationship.Value == "Orders", "The relationship of the added link should be 'Orders'");
         }
     }
@@ -120,15 +139,18 @@ namespace WebStack.QA.Test.OData
 
         public IHttpActionResult Get()
         {
-            IEdmEntityType entityType = Request.GetModel().FindDeclaredType("WebStack.QA.Test.OData.TestCustomer") as IEdmEntityType;
+            IEdmEntityType customerType = Request.GetModel().FindDeclaredType("WebStack.QA.Test.OData.TestCustomer") as IEdmEntityType;
+            IEdmEntityType customerWithAddressType = Request.GetModel().FindDeclaredType("WebStack.QA.Test.OData.TestCustomerWithAddress") as IEdmEntityType;
             IEdmComplexType addressType = Request.GetModel().FindDeclaredType("WebStack.QA.Test.OData.TestAddress") as IEdmComplexType;
-            EdmChangedObjectCollection changedObjects = new EdmChangedObjectCollection(entityType);
+            IEdmEntityType orderType = Request.GetModel().FindDeclaredType("WebStack.QA.Test.OData.TestOrder") as IEdmEntityType;
+            IEdmEntitySet ordersSet = Request.GetModel().FindDeclaredEntitySet("TestOrders") as IEdmEntitySet;
+            EdmChangedObjectCollection changedObjects = new EdmChangedObjectCollection(customerType);
 
             EdmDeltaComplexObject a = new EdmDeltaComplexObject(addressType);
             a.TrySetPropertyValue("State", "State");
             a.TrySetPropertyValue("ZipCode", null);
 
-            EdmDeltaEntityObject changedEntity = new EdmDeltaEntityObject(entityType);
+            EdmDeltaEntityObject changedEntity = new EdmDeltaEntityObject(customerWithAddressType);
             changedEntity.TrySetPropertyValue("Id", 1);
             changedEntity.TrySetPropertyValue("Name", "Name");
             changedEntity.TrySetPropertyValue("Address", a);
@@ -143,26 +165,38 @@ namespace WebStack.QA.Test.OData
             places.Add(a);
             places.Add(b);
 
-            var newEntity = new EdmDeltaEntityObject(entityType);
-            newEntity.TrySetPropertyValue("Id", 10);
-            newEntity.TrySetPropertyValue("Name", "NewCustomer");
-            newEntity.TrySetPropertyValue("FavoritePlaces", places);
-            changedObjects.Add(newEntity);
+            var newCustomer = new EdmDeltaEntityObject(customerType);
+            newCustomer.TrySetPropertyValue("Id", 10);
+            newCustomer.TrySetPropertyValue("Name", "NewCustomer");
+            newCustomer.TrySetPropertyValue("FavoritePlaces", places);
+            changedObjects.Add(newCustomer);
+            
+            var newOrder = new EdmDeltaEntityObject(orderType);
+            newOrder.NavigationSource = ordersSet;
+            newOrder.TrySetPropertyValue("Id", 27);
+            newOrder.TrySetPropertyValue("Amount", 100);
+            changedObjects.Add(newOrder);
 
-            var deletedEntity = new EdmDeltaDeletedEntityObject(entityType);
-            deletedEntity.Id = "7";
-            deletedEntity.Reason = DeltaDeletedEntryReason.Changed;
-            changedObjects.Add(deletedEntity);
+            var deletedCustomer = new EdmDeltaDeletedEntityObject(customerType);
+            deletedCustomer.Id = "7";
+            deletedCustomer.Reason = DeltaDeletedEntryReason.Changed;
+            changedObjects.Add(deletedCustomer);
 
-            var deletedLink = new EdmDeltaDeletedLink(entityType);
+            var deletedOrder = new EdmDeltaDeletedEntityObject(orderType);
+            deletedOrder.NavigationSource = ordersSet;
+            deletedOrder.Id = "12";
+            deletedOrder.Reason = DeltaDeletedEntryReason.Deleted;
+            changedObjects.Add(deletedOrder);
+
+            var deletedLink = new EdmDeltaDeletedLink(customerType);
             deletedLink.Source = new Uri("http://localhost/odata/DeltaCustomers(1)");
-            deletedLink.Target = new Uri("http://localhost/odata/DeltaOrders(1)");
+            deletedLink.Target = new Uri("http://localhost/odata/DeltaOrders(12)");
             deletedLink.Relationship = "Orders";
             changedObjects.Add(deletedLink);
 
-            var addedLink = new EdmDeltaLink(entityType);
+            var addedLink = new EdmDeltaLink(customerType);
             addedLink.Source = new Uri("http://localhost/odata/DeltaCustomers(10)");
-            addedLink.Target = new Uri("http://localhost/odata/DeltaOrders(1)");
+            addedLink.Target = new Uri("http://localhost/odata/DeltaOrders(27)");
             addedLink.Relationship = "Orders";
             changedObjects.Add(addedLink);
 
@@ -177,8 +211,12 @@ namespace WebStack.QA.Test.OData
         public int Age { get; set; }
         public virtual IList<string> PhoneNumbers {get; set;}
         public virtual IList<TestOrder> Orders { get; set; }
-        public virtual TestAddress Address { get; set; }
         public virtual IList<TestAddress> FavoritePlaces { get; set; }
+    }
+
+    public class TestCustomerWithAddress : TestCustomer
+    {
+        public virtual TestAddress Address { get; set; }
     }
 
     public class TestOrder

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DeltaQueryTests/DeltaQueryTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DeltaQueryTests/DeltaQueryTests.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Net.Http;
+using System.Web.Http;
+using System.Web.OData;
+using System.Web.OData.Builder;
+using System.Web.OData.Extensions;
+using System.Web.OData.Routing;
+using System.Web.OData.Routing.Conventions;
+using Microsoft.OData.Edm;
+using Newtonsoft.Json.Linq;
+using Nuwa;
+using Xunit;
+using Microsoft.OData;
+
+namespace WebStack.QA.Test.OData
+{
+    [NuwaFramework]
+    [NuwaHttpClientConfiguration(MessageLog = false)]
+    public class DeltaQueryTests
+    {
+        private string baseAddress = null;
+
+        [NuwaBaseAddress]
+        public string BaseAddress
+        {
+            get
+            {
+                return baseAddress;
+            }
+            set
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    this.baseAddress = value.Replace("localhost", Environment.MachineName);
+                }
+            }
+        }
+
+        [NuwaHttpClient]
+        public HttpClient Client { get; set; }
+
+        [NuwaConfiguration]
+        public static void UpdateConfiguration(HttpConfiguration config)
+        {
+            config.Routes.Clear();
+            config.MapODataServiceRoute("odata", "odata", GetModel(), new DefaultODataPathHandler(), ODataRoutingConventions.CreateDefault());
+        }
+
+        private static IEdmModel GetModel()
+        {
+            ODataModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<TestCustomer>("TestCustomers");
+            builder.EntitySet<TestOrder>("TestOrders");
+            return builder.GetEdmModel();
+        }
+
+        [Fact]
+        public void DeltaContainsExpectedProperties()
+        {
+            HttpRequestMessage get = new HttpRequestMessage(HttpMethod.Get, BaseAddress + "/odata/TestCustomers?$deltaToken=abc");
+            HttpResponseMessage response = Client.SendAsync(get).Result;
+            Assert.True(response.IsSuccessStatusCode);
+            dynamic results = response.Content.ReadAsAsync<JObject>().Result;
+
+            Assert.True(results.value.Count == 5);
+
+            var changeEntity = results.value[0];
+            Assert.Equal(3, ((JToken)changeEntity).Count());
+            Assert.Equal(1, changeEntity.Id.Value);
+            Assert.Equal("Name", changeEntity.Name.Value);
+            Assert.Equal(2, ((JToken)changeEntity.Address).Count());
+            Assert.Equal("State", changeEntity.Address.State.Value);
+            Assert.True(changeEntity.Address.ZipCode.Value == (int?)null);
+
+            var newEntity = results.value[1];
+            Assert.Equal(10, newEntity.Id.Value);
+            Assert.Equal("NewCustomer", newEntity.Name.Value);
+            Assert.Equal(2, ((JToken)newEntity).Count());
+
+            var deletedEntity = results.value[2];
+            Assert.Equal("7", deletedEntity.id.Value);
+            Assert.Equal("changed", deletedEntity.reason.Value);
+
+            var deletedLink = results.value[3];
+            Assert.Equal("http://localhost/odata/DeltaCustomers(1)", deletedLink.source.Value);
+            Assert.Equal("http://localhost/odata/DeltaOrders(1)", deletedLink.target.Value);
+            Assert.Equal("Orders", deletedLink.relationship.Value);
+
+            var addedLink = results.value[4];
+            Assert.Equal("http://localhost/odata/DeltaCustomers(10)", addedLink.source.Value);
+            Assert.Equal("http://localhost/odata/DeltaOrders(1)", addedLink.target.Value);
+            Assert.Equal("Orders", addedLink.relationship.Value);
+        }
+    }
+
+    public class TestCustomersController : ODataController
+    {
+
+        public IHttpActionResult Get()
+        {
+            List<IEdmChangedObject> changedObjects = new List<IEdmChangedObject>();
+            IEdmEntityType entityType = Request.GetModel().FindDeclaredType("WebStack.QA.Test.OData.TestCustomer") as IEdmEntityType;
+            IEdmComplexType addressType = Request.GetModel().FindDeclaredType("WebStack.QA.Test.OData.TestAddress") as IEdmComplexType;
+
+            EdmDeltaComplexObject a = new EdmDeltaComplexObject(addressType);
+            a.TrySetPropertyValue("State", "State");
+            a.TrySetPropertyValue("ZipCode", null);
+
+            EdmDeltaEntityObject changedEntity = new EdmDeltaEntityObject(entityType);
+            changedEntity.TrySetPropertyValue("Id", 1);
+            changedEntity.TrySetPropertyValue("Name", "Name");
+            changedEntity.TrySetPropertyValue("Address", a);
+            changedObjects.Add(changedEntity);
+
+            var newEntity = new EdmDeltaEntityObject(entityType);
+            newEntity.TrySetPropertyValue("Id", 10);
+            newEntity.TrySetPropertyValue("Name", "NewCustomer");
+            changedObjects.Add(newEntity);
+
+            var deletedEntity = new EdmDeltaDeletedEntityObject(entityType);
+            deletedEntity.Id = "7";
+            deletedEntity.Reason = DeltaDeletedEntryReason.Changed;
+            changedObjects.Add(deletedEntity);
+
+            var deletedLink = new EdmDeltaDeletedLink(entityType);
+            deletedLink.Source = new Uri("http://localhost/odata/DeltaCustomers(1)");
+            deletedLink.Target = new Uri("http://localhost/odata/DeltaOrders(1)");
+            deletedLink.Relationship = "Orders";
+            changedObjects.Add(deletedLink);
+
+            var addedLink = new EdmDeltaLink(entityType);
+            addedLink.Source = new Uri("http://localhost/odata/DeltaCustomers(10)");
+            addedLink.Target = new Uri("http://localhost/odata/DeltaOrders(1)");
+            addedLink.Relationship = "Orders";
+            changedObjects.Add(addedLink);
+
+            return Ok(new EdmChangedObjectCollection(entityType, changedObjects));
+        }
+    }
+
+    public class TestCustomer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int Age { get; set; }
+        public virtual IList<TestOrder> Orders { get; set; }
+        public virtual TestAddress Address { get; set; }
+    }
+
+    public class TestOrder
+    {
+        public int Id { get; set; }
+        public int Amount { get; set; }
+    }
+
+    public class TestAddress
+    {
+        public string State { get; set; }
+        public string City { get; set; }
+        public int? ZipCode { get; set; }
+    }
+}

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/DeltaQueryTests/DeltaQueryTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/DeltaQueryTests/DeltaQueryTests.cs
@@ -69,11 +69,13 @@ namespace WebStack.QA.Test.OData
             Assert.True(results.value.Count == 7, "There should be 7 entries in the response");
 
             var changeEntity = results.value[0];
-            Assert.True(((JToken)changeEntity).Count() == 5, "The changed customer should have 4 properties plus type written.");
+            Assert.True(((JToken)changeEntity).Count() == 7, "The changed customer should have 6 properties plus type written.");
             string changeEntityType = changeEntity["@odata.type"].Value as string;
             Assert.True(changeEntityType != null, "The changed customer should have type written");
             Assert.True(changeEntityType.Contains("#WebStack.QA.Test.OData.TestCustomerWithAddress"), "The changed order should be a TestCustomerWithAddress");
             Assert.True(changeEntity.Id.Value == 1, "The ID Of changed customer should be 1.");
+            Assert.True(changeEntity.OpenProperty.Value == 10, "The OpenProperty property of changed customer should be 10.");
+            Assert.True(changeEntity.NullOpenProperty.Value == null, "The NullOpenProperty property of changed customer should be null.");
             Assert.True(changeEntity.Name.Value == "Name", "The Name of changed customer should be 'Name'");
             Assert.True(((JToken)changeEntity.Address).Count() == 2, "The changed entity's Address should have 2 properties written.");
             Assert.True(changeEntity.Address.State.Value == "State", "The changed customer's Address.State should be 'State'.");
@@ -98,10 +100,12 @@ namespace WebStack.QA.Test.OData
             Assert.True(place1.ZipCode.Value == (int?)null, "The first favorite place's Address.ZipCode should be null.");
 
             var place2 = places[1];
-            Assert.True(((JToken)place2).Count() == 3, "The second favorite place should have 3 properties written.");
+            Assert.True(((JToken)place2).Count() == 5, "The second favorite place should have 5 properties written.");
             Assert.True(place2.City.Value == "City2", "The second favorite place's Address.City should be 'City2'.");
             Assert.True(place2.State.Value == "State2", "The second favorite place's Address.State should be 'State2'.");
             Assert.True(place2.ZipCode.Value == 12345, "The second favorite place's Address.ZipCode should be 12345.");
+            Assert.True(place2.OpenProperty.Value == 10, "The second favorite place's Address.OpenProperty should be 10.");
+            Assert.True(place2.NullOpenProperty.Value == null, "The second favorite place's Address.NullOpenProperty should be null.");
 
             var newOrder = results.value[2];
             Assert.True(((JToken)newOrder).Count() == 3, "The new order should have 2 properties plus context written");
@@ -155,6 +159,8 @@ namespace WebStack.QA.Test.OData
             changedEntity.TrySetPropertyValue("Name", "Name");
             changedEntity.TrySetPropertyValue("Address", a);
             changedEntity.TrySetPropertyValue("PhoneNumbers", new List<String> { "123-4567", "765-4321" });
+            changedEntity.TrySetPropertyValue("OpenProperty", 10);
+            changedEntity.TrySetPropertyValue("NullOpenProperty", null);
             changedObjects.Add(changedEntity);
 
             EdmComplexObjectCollection places = new EdmComplexObjectCollection(new EdmCollectionTypeReference(new EdmCollectionType(new EdmComplexTypeReference(addressType,true))));
@@ -162,6 +168,8 @@ namespace WebStack.QA.Test.OData
             b.TrySetPropertyValue("City", "City2");
             b.TrySetPropertyValue("State", "State2");
             b.TrySetPropertyValue("ZipCode", 12345);
+            b.TrySetPropertyValue("OpenProperty", 10);
+            b.TrySetPropertyValue("NullOpenProperty", null);
             places.Add(a);
             places.Add(b);
 
@@ -212,6 +220,7 @@ namespace WebStack.QA.Test.OData
         public virtual IList<string> PhoneNumbers {get; set;}
         public virtual IList<TestOrder> Orders { get; set; }
         public virtual IList<TestAddress> FavoritePlaces { get; set; }
+        public IDictionary<string, object> DynamicProperties { get; set; }
     }
 
     public class TestCustomerWithAddress : TestCustomer
@@ -230,5 +239,6 @@ namespace WebStack.QA.Test.OData
         public string State { get; set; }
         public string City { get; set; }
         public int? ZipCode { get; set; }
+        public IDictionary<string, object> DynamicProperties { get; set; }
     }
 }

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/Formatter/JsonLight/JsonLightInheritanceTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/Formatter/JsonLight/JsonLightInheritanceTests.cs
@@ -75,6 +75,7 @@ namespace WebStack.QA.Test.OData.Formatter.JsonLight
             configuration.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
 
             var conventions = ODataRoutingConventions.CreateDefault();
+            conventions.Insert(0, new DeleteAllRoutingConvention());
             conventions.Insert(0, new NavigationRoutingConvention2());
             conventions.Insert(0, new LinkRoutingConvention2());
 

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
@@ -163,6 +163,7 @@
     <Compile Include="DateAndTimeOfDay\DateAndTimeOfDayTest.cs" />
     <Compile Include="DateAndTimeOfDay\DateAndTimeOfDayWithEfTest.cs" />
     <Compile Include="DateAndTimeOfDay\DateWithEfTest.cs" />
+    <Compile Include="DeltaQueryTests\DeltaQueryTests.cs" />
     <Compile Include="DependencyInjection\CustomizeCountQueryValidatorTest.cs" />
     <Compile Include="DependencyInjection\CustomizeSerializerTest.cs" />
     <Compile Include="DependencyInjection\DependencyInjectionController.cs" />

--- a/OData/test/UnitTest/System.Web.OData.Test/EdmTypeExtensionsTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/EdmTypeExtensionsTest.cs
@@ -17,7 +17,6 @@ namespace System.Web.OData
                 "type");
         }
 
-
         [Fact]
         public void CollectionType_IsDeltaFeed_ReturnsTrueForDeltaCollectionType()
         {
@@ -36,6 +35,51 @@ namespace System.Web.OData
             IEdmCollectionTypeReference _edmTypeReference = new EdmCollectionTypeReference(_edmType);
 
             Assert.False(_edmTypeReference.Definition.IsDeltaFeed());
+        }
+
+        [Fact]
+        public void IsDeltaObject_ThrowsArgumentNull_Type()
+        {
+            IEdmObject instance = null;
+            Assert.ThrowsArgumentNull(
+                () => instance.IsDeltaResource(),
+                "resource");
+        }
+
+        [Fact]
+        public void EdmDeltaEntityObject_IsDeltaObject_ReturnsTrueForDeltaObject()
+        {
+            IEdmEntityType _type = new EdmEntityType("NS", "Entity");
+            EdmDeltaEntityObject _edmObject = new EdmDeltaEntityObject(_type);
+
+            Assert.True(_edmObject.IsDeltaResource());
+        }
+
+        [Fact]
+        public void EdmDeltaComplexObject_IsDeltaObject_ReturnsTrueForDeltaObject()
+        {
+            IEdmComplexType _type = new EdmComplexType("NS", "Entity");
+            EdmDeltaComplexObject _edmObject = new EdmDeltaComplexObject(_type);
+
+            Assert.True(_edmObject.IsDeltaResource());
+        }
+
+        [Fact]
+        public void EdmEntityObject_IsDeltaFeed_ReturnsFalseForNonDeltaObject()
+        {
+            IEdmEntityType _type = new EdmEntityType("NS", "Entity");
+            EdmEntityObject _edmObject = new EdmEntityObject(_type);
+
+            Assert.False(_edmObject.IsDeltaResource());
+        }
+
+        [Fact]
+        public void EdmComplexObject_IsDeltaFeed_ReturnsFalseForNonDeltaObject()
+        {
+            IEdmComplexType _type = new EdmComplexType("NS", "Entity");
+            EdmComplexObject _edmObject = new EdmComplexObject(_type);
+
+            Assert.False(_edmObject.IsDeltaResource());
         }
     }
 }

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/EdmDeltaComplexObjectTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/EdmDeltaComplexObjectTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.OData.Edm;
+using Microsoft.TestCommon;
+
+namespace System.Web.OData
+{
+    public class EdmDeltaComplexObjectTest
+    {
+        [Fact]
+        public void Ctor_ThrowsArgumentNull_EdmTypeOfTypeIEdmComplexType()
+        {
+            Assert.ThrowsArgumentNull(() => new EdmDeltaComplexObject((IEdmComplexType)null), "edmType");
+        }
+
+        [Fact]
+        public void Ctor_ThrowsArgumentNull_EdmTypeOfTypeIEdmComplexTypeReference()
+        {
+            Assert.ThrowsArgumentNull(() => new EdmDeltaComplexObject((IEdmComplexTypeReference)null), "type");
+        }
+
+        [Fact]
+        public void Property_IsNullable()
+        {
+            EdmDeltaComplexObject edmObject = new EdmDeltaComplexObject(new EdmComplexType("NS", "Complex"));
+
+            Assert.Reflection.BooleanProperty(edmObject, e => e.IsNullable, expectedDefaultValue: false);
+        }
+    }
+}

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/Models/Customer.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/Models/Customer.cs
@@ -20,6 +20,7 @@ namespace System.Web.OData.Formatter.Serialization.Models
         public string City { get; set; }
         public IList<Order> Orders { get; set; }
         public SimpleEnum SimpleEnum { get; set; }
+        public Address HomeAddress { get; set; }
     }
 
     public class SpecialCustomer : Customer

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataResourceSetSerializerTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Formatter/Serialization/ODataResourceSetSerializerTests.cs
@@ -491,6 +491,23 @@ namespace System.Web.OData.Formatter.Serialization
         }
 
         [Fact]
+        public void CreateODataFeed_Sets_DeltaLinkFromContext()
+        {
+            // Arrange
+            ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(_serializerProvider);
+            Uri expectedDeltaLink = new Uri("http://deltalink.com");
+            HttpRequestMessage request = new HttpRequestMessage();
+            request.ODataProperties().DeltaLink = expectedDeltaLink;
+            var result = new object[0];
+
+            // Act
+            ODataResourceSet feed = serializer.CreateResourceSet(result, _customersType, new ODataSerializerContext { Request = request });
+
+            // Assert
+            Assert.Equal(expectedDeltaLink, feed.DeltaLink);
+        }
+
+        [Fact]
         public void CreateResource_Ignores_NextPageLink_ForInnerResourceSets()
         {
             // Arrange

--- a/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -162,6 +162,11 @@ public sealed class System.Web.OData.EdmTypeExtensions {
 	ExtensionAttribute(),
 	]
 	public static bool IsDeltaFeed (Microsoft.OData.Edm.IEdmType type)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static bool IsDeltaResource (IEdmObject resource)
 }
 
 public sealed class System.Web.OData.ODataUriFunctions {
@@ -241,6 +246,15 @@ public class System.Web.OData.EdmComplexObjectCollection : System.Collections.Ob
 	public EdmComplexObjectCollection (Microsoft.OData.Edm.IEdmCollectionTypeReference edmType, System.Collections.Generic.IList`1[[System.Web.OData.IEdmComplexObject]] list)
 
 	public virtual Microsoft.OData.Edm.IEdmTypeReference GetEdmType ()
+}
+
+[
+NonValidatingParameterBindingAttribute(),
+]
+public class System.Web.OData.EdmDeltaComplexObject : EdmComplexObject, IDynamicMetaObjectProvider, IDelta, IEdmComplexObject, IEdmObject, IEdmStructuredObject {
+	public EdmDeltaComplexObject (Microsoft.OData.Edm.IEdmComplexType edmType)
+	public EdmDeltaComplexObject (Microsoft.OData.Edm.IEdmComplexTypeReference edmType)
+	public EdmDeltaComplexObject (Microsoft.OData.Edm.IEdmComplexType edmType, bool isNullable)
 }
 
 [
@@ -931,7 +945,7 @@ public abstract class System.Web.OData.Builder.OperationConfiguration {
 	NavigationSourceConfiguration NavigationSource  { public get; public set; }
 	OperationLinkBuilder OperationLinkBuilder  { protected get; protected set; }
 	bool OptionalReturn  { public get; public set; }
-	System.Collections.Generic.IEnumerable`1[[System.Web.OData.Builder.ParameterConfiguration]] Parameters  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[System.Web.OData.Builder.ParameterConfiguration]] Parameters  { [IteratorStateMachineAttribute(),]public virtual get; }
 	IEdmTypeConfiguration ReturnType  { public get; public set; }
 	string Title  { public get; public set; }
 
@@ -1919,6 +1933,7 @@ public sealed class System.Web.OData.Extensions.UrlHelperExtensions {
 
 public class System.Web.OData.Extensions.HttpRequestMessageProperties {
 	Microsoft.OData.UriParser.Aggregation.ApplyClause ApplyClause  { public get; public set; }
+	System.Uri DeltaLink  { public get; public set; }
 	System.Uri NextLink  { public get; public set; }
 	ODataPath Path  { public get; public set; }
 	string RouteName  { public get; public set; }
@@ -2902,7 +2917,11 @@ public class System.Web.OData.Formatter.Deserialization.ODataCollectionDeseriali
 	public ODataCollectionDeserializer (ODataDeserializerProvider deserializerProvider)
 
 	public virtual object Read (Microsoft.OData.ODataMessageReader messageReader, System.Type type, ODataDeserializerContext readContext)
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.IEnumerable ReadCollectionValue (Microsoft.OData.ODataCollectionValue collectionValue, Microsoft.OData.Edm.IEdmTypeReference elementType, ODataDeserializerContext readContext)
+
 	public virtual object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, ODataDeserializerContext readContext)
 }
 
@@ -2962,6 +2981,9 @@ public class System.Web.OData.Formatter.Deserialization.ODataResourceSetDeserial
 
 	public virtual object Read (Microsoft.OData.ODataMessageReader messageReader, System.Type type, ODataDeserializerContext readContext)
 	public virtual object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, ODataDeserializerContext readContext)
+	[
+	IteratorStateMachineAttribute(),
+	]
 	public virtual System.Collections.IEnumerable ReadResourceSet (ODataResourceSetWrapper resourceSet, Microsoft.OData.Edm.IEdmStructuredTypeReference elementType, ODataDeserializerContext readContext)
 }
 

--- a/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -267,6 +267,7 @@ public class System.Web.OData.EdmDeltaDeletedEntityObject : EdmEntityObject, IDy
 
 	EdmDeltaEntityKind DeltaKind  { public virtual get; }
 	string Id  { public virtual get; public virtual set; }
+	Microsoft.OData.Edm.IEdmNavigationSource NavigationSource  { public get; public set; }
 	Microsoft.OData.DeltaDeletedEntryReason Reason  { public virtual get; public virtual set; }
 }
 
@@ -293,6 +294,7 @@ public class System.Web.OData.EdmDeltaEntityObject : EdmEntityObject, IDynamicMe
 	public EdmDeltaEntityObject (Microsoft.OData.Edm.IEdmEntityType entityType, bool isNullable)
 
 	EdmDeltaEntityKind DeltaKind  { public virtual get; }
+	Microsoft.OData.Edm.IEdmNavigationSource NavigationSource  { public get; public set; }
 }
 
 [

--- a/OData/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
+++ b/OData/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
@@ -151,6 +151,7 @@
     <Compile Include="OData\Builder\TestModels\PropertyAlias.cs" />
     <Compile Include="OData\Builder\TestModels\SpecialOrderLine.cs" />
     <Compile Include="OData\ClrPropertyInfoAnnotationTest.cs" />
+    <Compile Include="OData\EdmDeltaComplexObjectTest.cs" />
     <Compile Include="OData\MockContainer.cs" />
     <Compile Include="OData\DependencyInjectionHelper.cs" />
     <Compile Include="OData\DateAndTimeOfDayTest.cs" />


### PR DESCRIPTION
### Issues
*This pull request fixes issue #857*  
*This pull request fixes issue #900*  

### Description
*Serializes only changed properties in a Delta response when using EdmDeltaEntityObject*
*Adds EdmDeltaComplexObject for serializing only changed properties of a complex type*
*Adds support for writing DeltaLink to WebAPI OData*
*Adds support for setting NavigationSource for related EdmDeltaEntityObjects and EdmDeltaDeletedEntityObjects in a flattened result*
*Fixes bug where null values weren't being written for dynamic properties in a delta feed*

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
*We could certainly use some examples for Delta*
*We should consider refactoring; currently ODataDeltaWriter doesn't inherit from ODataWriter which is causing us to duplicate a lot of code that could be shared.*
*Added a DeleteAllConvention to fix some tests to properly clear cache when delete is called on entityset, but other tests that may be dependent upon clearing the cache need similar conventions added.*
*Need to re-run baseline with VS 2013*