### PR TITLE
PageResultOf: Use of IQueryable instead of IEnumerable

### DIFF
--- a/OData/src/System.Web.Http.OData/OData/PageResultOfT.cs
+++ b/OData/src/System.Web.Http.OData/OData/PageResultOfT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System.Collections;
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using System.Linq;
+using System.Linq.Expressions;
 
 namespace System.Web.Http.OData
 {
@@ -20,8 +22,92 @@ namespace System.Web.Http.OData
     [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "Collection suffix not appropriate")]
     [DataContract]
     [JsonObject]
-    public class PageResult<T> : PageResult, IEnumerable<T>
+    public class PageResult<T> : PageResult, IQueryable<T>
     {
+        private IQueryable<T> _items;
+        [NonSerialized]
+        private Type _elementType;
+        [NonSerialized]
+        private Expression _expression;
+        [NonSerialized]
+        private IQueryProvider _provider;
+
+        /// <summary>
+        /// Gets the collection of entities for this feed.
+        /// </summary>
+        [DataMember]
+        public IQueryable<T> Items
+        {
+            get
+            {
+                return _items;
+            }
+            private set
+            {
+                _items = value;
+                _elementType = _items.ElementType;
+                _expression = _items.Expression;
+                _provider = _items.Provider;
+            }
+        }
+
+        /// <summary>
+        /// Gets the type of the element(s) that are returned when the expression tree associated
+        ///     with this instance of System.Linq.IQueryable is executed.
+        /// </summary>
+        [JsonIgnore]
+        [IgnoreDataMember]
+        public Type ElementType
+        {
+            get
+            {
+                return _elementType;
+            }
+        }
+
+        /// <summary>
+        /// Gets the expression tree that is associated with the instance of System.Linq.IQueryable.
+        /// </summary>
+        [JsonIgnore]
+        [IgnoreDataMember]
+        public Expression Expression
+        {
+            get
+            {
+                return _expression;
+            }
+        }
+
+        /// <summary>
+        /// Gets the query provider that is associated with this data source.
+        /// </summary>
+        [JsonIgnore]
+        [IgnoreDataMember]
+        public IQueryProvider Provider
+        {
+            get
+            {
+                return _provider;
+            }
+        }
+
+        /// <summary>
+        /// Creates a partial set of results - used when server driven paging is enabled.
+        /// </summary>
+        /// <param name="items">The subset of matching results that should be serialized in this page.</param>
+        /// <param name="nextPageLink">A link to the next page of matching results (if more exists).</param>
+        /// <param name="count">A total count of matching results so clients can know the number of matches on the server.</param>
+        public PageResult(IQueryable<T> items, Uri nextPageLink, long? count)
+            : base(nextPageLink, count)
+        {
+            if (items == null)
+            {
+                throw Error.ArgumentNull("data");
+            }
+
+            Items = items;
+        }
+
         /// <summary>
         /// Creates a partial set of results - used when server driven paging is enabled.
         /// </summary>
@@ -36,14 +122,8 @@ namespace System.Web.Http.OData
                 throw Error.ArgumentNull("data");
             }
 
-            Items = items;
+            Items = items.AsQueryable();
         }
-
-        /// <summary>
-        /// Gets the collection of entities for this feed.
-        /// </summary>
-        [DataMember]
-        public IEnumerable<T> Items { get; private set; }
 
         /// <summary>
         /// Returns an enumerator that iterates through a collection.


### PR DESCRIPTION
### Issues
*This pull request fixes issue #898 .*  

### Description
* PageResultOf: Use of IQueryable instead of IEnumerable enable entity framework integration gets filters and others interactions reflected. *
* When i do a GET on a collection with filters, it download full database and then filter using Linq to Objects. This will solves this problem. *


### Checklist
- [ x ] Test cases added (Not Applicable - Used same tests)
- [ x ] Build and test with one-click build and test script passed
