### PR TITLE
Virtual Property Count

### DIFF
--- a/OData/src/System.Web.OData/OData/Query/Expressions/AggregationBinder.cs
+++ b/OData/src/System.Web.OData/OData/Query/Expressions/AggregationBinder.cs
@@ -173,11 +173,18 @@ namespace System.Web.OData.Query.Expressions
 
         private Expression CreateAggregationExpression(ParameterExpression accum, AggregateExpression expression)
         {
-            LambdaExpression propertyLambda = Expression.Lambda(BindAccessor(expression.Expression),
-                this._lambdaParameter);
             // I substitute the element type for all generic arguments.                                                
             var asQuerableMethod = ExpressionHelperMethods.QueryableAsQueryable.MakeGenericMethod(this._elementType);
             Expression asQuerableExpression = Expression.Call(null, asQuerableMethod, accum);
+
+            // $count is a virtual property, so there's not a propertyLambda to create.
+            if (expression.Method == AggregationMethod.VirtualPropertyCount)
+            {
+                var countMethod = ExpressionHelperMethods.QueryableCountGeneric.MakeGenericMethod(this._elementType);
+                return Expression.Call(null, countMethod, asQuerableExpression);
+            }
+
+            LambdaExpression propertyLambda = Expression.Lambda(BindAccessor(expression.Expression), this._lambdaParameter);
 
             Expression aggregationExpression;
 

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/Aggregation/AggregationTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/Aggregation/AggregationTests.cs
@@ -9,6 +9,9 @@ using Nuwa;
 using WebStack.QA.Test.OData.Common;
 using Xunit;
 using Xunit.Extensions;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace WebStack.QA.Test.OData.Aggregation
 {
@@ -162,6 +165,64 @@ namespace WebStack.QA.Test.OData.Aggregation
             var results = result["value"] as JArray;
             Assert.Equal(1, results.Count);
             Assert.Equal("4500", results[0]["TotalAmount"].ToString());
+        }
+
+        [Fact]
+        public void AggregateVirtualCountWorks()
+        {
+            // Arrange
+            string queryUrl =
+                string.Format(
+                    AggregationTestBaseUrl + "?$apply=aggregate($count as Count)",
+                    BaseAddress);
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = new HttpClient();
+
+            // Act
+            HttpResponseMessage response = client.SendAsync(request).Result;
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            JObject json = JObject.Parse(response.Content.ReadAsStringAsync().Result);
+            JToken value = json["value"].Children().First();
+
+            var anonymousResponse = new { Count = 0 };
+            var responseObj = JsonConvert.DeserializeAnonymousType(value.ToString(), anonymousResponse);
+
+            Assert.Equal(9, responseObj.Count);
+        }
+
+        [Fact]
+        public void GroupByVirtualCountWorks()
+        {
+            // Arrange
+            string queryUrl =
+                string.Format(
+                    AggregationTestBaseUrl + "?$apply=groupby((Name), aggregate($count as Count))",
+                    BaseAddress);
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = new HttpClient();
+
+            // Act
+            HttpResponseMessage response = client.SendAsync(request).Result;
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            JObject json = JObject.Parse(response.Content.ReadAsStringAsync().Result);
+            IList<JToken> value = json["value"].Children().ToList();
+
+            var responseObj = new { Name = "", Count = 0 };
+            var dict = value
+                .Select(x => JsonConvert.DeserializeAnonymousType(x.ToString(), responseObj))
+                .ToDictionary(x => x.Name);
+
+            dict.TryGetValue("Customer1", out responseObj);
+            Assert.Equal(responseObj.Count, 5);
+
+            dict.TryGetValue("Customer0", out responseObj);
+            Assert.Equal(responseObj.Count, 4);
         }
 
         [Theory]

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/ApplyQueryOptionTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/ApplyQueryOptionTest.cs
@@ -28,6 +28,13 @@ namespace System.Web.OData.Test.OData.Query
                 return new TheoryDataSet<string, List<Dictionary<string, object>>>
                 {
                     {
+                        "aggregate($count as Count)",
+                        new List<Dictionary<string, object>>
+                        {
+                            new Dictionary<string, object> { { "Count", 4L} }
+                        }
+                    },
+                    {
                         "aggregate(CustomerId with sum as CustomerId)",
                         new List<Dictionary<string, object>>
                         {
@@ -92,6 +99,15 @@ namespace System.Web.OData.Test.OData.Query
                             new Dictionary<string, object> { { "Name", "Lowest"}, { "Total", 5} },
                             new Dictionary<string, object> { { "Name", "Highest"}, { "Total", 2} },
                             new Dictionary<string, object> { { "Name", "Middle"}, { "Total", 3 } }
+                        }
+                    },
+                    {
+                        "groupby((Name), aggregate($count as Count))",
+                        new List<Dictionary<string, object>>
+                        {
+                            new Dictionary<string, object> { { "Name", "Lowest"}, { "Count", 2L} },
+                            new Dictionary<string, object> { { "Name", "Highest"}, { "Count", 1L} },
+                            new Dictionary<string, object> { { "Name", "Middle"}, { "Count", 1L} }
                         }
                     },
                     {


### PR DESCRIPTION
### Issues
*This pull request fixes issue [#773](https://github.com/OData/WebApi/issues/773) of WebAPI project.*  

### Checklist (Uncheck if it is not completed)
- [x] Test cases added
- [x] Build and test with one-click build and test script passed

### Additional comments
This is a pretty simple (maybe hackery) way of implementing the $count virtual property for aggregate clauses. If there are better options, we should consider changing the design.

Every time we find the `$count as alias` keyword inside a aggregate clause, we just map it to a method call of the form `attr with InternalCount as alias`, where attr is just a hardcoded string in the code that won't be used (but must be defined because is checked several times for nulls) and InternalCount is a method that counts objects (is a subroutine of `countdistinct`).