### PR TITLE
Custom Aggregation Methods

### DIFF
--- a/OData/src/System.Web.OData/OData/CustomAggregateMethodAnnotation.cs
+++ b/OData/src/System.Web.OData/OData/CustomAggregateMethodAnnotation.cs
@@ -31,7 +31,7 @@ namespace System.Web.OData
         }
 
         /// <summary>
-        /// Get an implementation of a method with the specifieds returnType and methodToken.
+        /// Get an implementation of a method with the specifies returnType and methodToken.
         /// If there's no method that matches the requirements, returns null.
         /// </summary>
         public bool GetMethodInfo(string methodToken, Type returnType, out MethodInfo method)

--- a/OData/src/System.Web.OData/OData/CustomAggregateMethodAnnotation.cs
+++ b/OData/src/System.Web.OData/OData/CustomAggregateMethodAnnotation.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Reflection;
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Reflection;
 
 namespace System.Web.OData
 {
@@ -12,14 +14,15 @@ namespace System.Web.OData
     /// </summary>
     public class CustomAggregateMethodAnnotation 
     {
-
         private Dictionary<string, IDictionary<Type, MethodInfo>> _tokenToMethodMap 
             = new Dictionary<string, IDictionary<Type, MethodInfo>>();
 
         /// <summary>
         /// CustomAggregateMethodAnnotation simple constructor.
         /// </summary>
-        public CustomAggregateMethodAnnotation() { }
+        public CustomAggregateMethodAnnotation()
+        {
+        }
 
         /// <summary>
         /// Adds all implementations of a method that share the same methodToken.

--- a/OData/src/System.Web.OData/OData/CustomAggregateMethodAnnotation.cs
+++ b/OData/src/System.Web.OData/OData/CustomAggregateMethodAnnotation.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+
+
+namespace System.Web.OData
+{
+    /// <summary>
+    /// Allows client to tell OData which are the custom aggregation methods defined.
+    /// In order to do it it must receive a methodToken - that is the full identifier
+    /// of the method in the OData URL - and an IDictionary that maps the input type
+    /// of the aggregation method to it's MethodInfo.
+    /// </summary>
+    public class CustomAggregateMethodAnnotation 
+    {
+
+        private Dictionary<string, IDictionary<Type, MethodInfo>> _tokenToMethodMap 
+            = new Dictionary<string, IDictionary<Type, MethodInfo>>();
+
+        /// <summary>
+        /// CustomAggregateMethodAnnotation simple constructor.
+        /// </summary>
+        public CustomAggregateMethodAnnotation() { }
+
+        /// <summary>
+        /// Adds all implementations of a method that share the same methodToken.
+        /// </summary>
+        public CustomAggregateMethodAnnotation AddMethod(string methodToken, IDictionary<Type, MethodInfo> methods)
+        {
+            _tokenToMethodMap.Add(methodToken, methods);
+            return this;
+        }
+
+        /// <summary>
+        /// Get an implementation of a method with the specifieds returnType and methodToken.
+        /// If there's no method that matches the requirements, returns null.
+        /// </summary>
+        public bool GetMethodInfo(string methodToken, Type returnType, out MethodInfo method)
+        {
+            IDictionary<Type, MethodInfo> methodWrapper;
+            method = null;
+
+            if (_tokenToMethodMap.TryGetValue(methodToken, out methodWrapper))
+            {
+                return methodWrapper.TryGetValue(returnType, out method);
+            }
+
+            return false;
+        }
+    }
+}

--- a/OData/src/System.Web.OData/OData/Query/Expressions/AggregationBinder.cs
+++ b/OData/src/System.Web.OData/OData/Query/Expressions/AggregationBinder.cs
@@ -297,7 +297,6 @@ namespace System.Web.OData.Query.Expressions
                     throw new ODataException(Error.Format(SRResources.AggregationMethodNotSupported, expression.Method));
             }
 
-
             return aggregationExpression;
         }
 

--- a/OData/src/System.Web.OData/System.Web.OData.csproj
+++ b/OData/src/System.Web.OData/System.Web.OData.csproj
@@ -129,6 +129,7 @@
     <Compile Include="OData\DefaultContainerBuilder.cs" />
     <Compile Include="OData\Builder\QueryConfiguration.cs" />
     <Compile Include="OData\Query\ExpandAttribute.cs" />
+    <Compile Include="OData\CustomAggregateMethodAnnotation.cs" />
     <Compile Include="OData\ODataSwaggerUtilities.cs" />
     <Compile Include="OData\ODataSwaggerConverter.cs" />
     <Compile Include="OData\EdmEnumObjectCollection.cs" />

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/Aggregation/AggregationEdmModel.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/Aggregation/AggregationEdmModel.cs
@@ -1,18 +1,42 @@
 ﻿using System.Web.Http;
 using System.Web.OData.Builder;
 using Microsoft.OData.Edm;
+using System.Collections.Generic;
+using System;
+using System.Reflection;
+using System.Linq;
+using System.Web.OData;
+using System.Data.Entity;
 
 namespace WebStack.QA.Test.OData.Aggregation
 {
     public class AggregationEdmModel
     {
+        public const string stdDevMethodToken = "Custom.StdDev";
+        public const string stdDevMethodLabel = "StandardDeviation";
+
         public static IEdmModel GetEdmModel(HttpConfiguration configuration)
         {
             var builder = new ODataConventionModelBuilder(configuration);
             builder.EntitySet<Customer>("Customers");
             builder.EntitySet<Order>("Orders");
             IEdmModel model = builder.GetEdmModel();
+
+            var stdDevMethods = getCustomMethods(typeof(DbFunctions), stdDevMethodLabel);
+            CustomAggregateMethodAnnotation customMethods = new CustomAggregateMethodAnnotation();
+            customMethods.AddMethod(stdDevMethodToken, stdDevMethods);
+
+            model.SetAnnotationValue(model, customMethods);
+
             return model;
+        }
+
+        private static Dictionary<Type, MethodInfo> getCustomMethods(Type customMethodsContainer, string methodName)
+        {
+            return customMethodsContainer.GetMethods()
+                .Where(m => m.Name == methodName)
+                .Where(m => m.GetParameters().Count() == 1)
+                .ToDictionary(m => m.GetParameters().First().ParameterType.GetGenericArguments().First());
         }
     }
 }

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/Aggregation/AggregationEdmModel.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/Aggregation/AggregationEdmModel.cs
@@ -1,12 +1,12 @@
-﻿using System.Web.Http;
-using System.Web.OData.Builder;
-using Microsoft.OData.Edm;
-using System.Collections.Generic;
+﻿using Microsoft.OData.Edm;
 using System;
-using System.Reflection;
-using System.Linq;
-using System.Web.OData;
+using System.Collections.Generic;
 using System.Data.Entity;
+using System.Linq;
+using System.Reflection;
+using System.Web.Http;
+using System.Web.OData;
+using System.Web.OData.Builder;
 
 namespace WebStack.QA.Test.OData.Aggregation
 {

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/Aggregation/AggregationTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/Aggregation/AggregationTests.cs
@@ -234,7 +234,6 @@ namespace WebStack.QA.Test.OData.Aggregation
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-            // TODO assert that error message says that custom methods were not found.
         }
 
         [Theory]
@@ -257,7 +256,6 @@ namespace WebStack.QA.Test.OData.Aggregation
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-            // TODO assert that error message says that methods were not found.
         }
 
         [Theory]

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/Aggregation/AggregationTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/Aggregation/AggregationTests.cs
@@ -193,6 +193,74 @@ namespace WebStack.QA.Test.OData.Aggregation
         }
 
         [Theory]
+        [InlineData("?$apply=groupby((Name), aggregate(Order/Price with Custom.StdDev as PriceStdDev))")]
+        [InlineData("?$apply=groupby((Address/Name), aggregate(Id with Custom.StdDev as IdStdDev))")]
+        [InlineData("?$apply=groupby((Order/Name), aggregate(Id with Custom.StdDev as IdStdDev))")]
+        public void CustomAggregateStdDevWorks(string query)
+        {
+            // Arrange
+            string queryUrl =
+                string.Format(
+                    AggregationTestBaseUrl + query,
+                    BaseAddress);
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = new HttpClient();
+
+            // Act
+            HttpResponseMessage response = client.SendAsync(request).Result;
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("?$apply=groupby((Name), aggregate(Order/Price with Custom.Sum as PriceStdDev))")]
+        [InlineData("?$apply=groupby((Address/Name), aggregate(Id with Custom.OtherMethod as IdStdDev))")]
+        [InlineData("?$apply=groupby((Order/Name), aggregate(Id with Custom.YetAnotherMethod as IdStdDev))")]
+        public void CustomAggregateNotDefinedHaveAppropriateAnswer(string query)
+        {
+            // Arrange
+            string queryUrl =
+                string.Format(
+                    AggregationTestBaseUrl + query,
+                    BaseAddress);
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = new HttpClient();
+
+            // Act
+            HttpResponseMessage response = client.SendAsync(request).Result;
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            // TODO assert that error message says that custom methods were not found.
+        }
+
+        [Theory]
+        [InlineData("?$apply=groupby((Name), aggregate(Order/Price with StdDev as PriceStdDev))")]
+        [InlineData("?$apply=groupby((Address/Name), aggregate(Id with OtherMethod as IdStdDev))")]
+        [InlineData("?$apply=groupby((Order/Name), aggregate(Id with YetAnotherMethod as IdStdDev))")]
+        public void MethodsNotDefinedHaveAppropriateAnswer(string query)
+        {
+            // Arrange
+            string queryUrl =
+                string.Format(
+                    AggregationTestBaseUrl + query,
+                    BaseAddress);
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = new HttpClient();
+
+            // Act
+            HttpResponseMessage response = client.SendAsync(request).Result;
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            // TODO assert that error message says that methods were not found.
+        }
+
+        [Theory]
         [InlineData("?$apply=aggregate(Order/Price with sum as Result)", "4500")]
         [InlineData("?$apply=aggregate(Order/Price with min as Result)", "100")]
         [InlineData("?$apply=aggregate(Order/Price with max as Result)", "900")]

--- a/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -181,6 +181,13 @@ public class System.Web.OData.ClrTypeAnnotation {
 	System.Type ClrType  { public get; }
 }
 
+public class System.Web.OData.CustomAggregateMethodAnnotation {
+	public CustomAggregateMethodAnnotation ()
+
+	public CustomAggregateMethodAnnotation AddMethod (string methodToken, System.Collections.Generic.IDictionary`2[[System.Type],[System.Reflection.MethodInfo]] methods)
+	public bool GetMethodInfo (string methodToken, System.Type returnType, out System.Reflection.MethodInfo& method)
+}
+
 public class System.Web.OData.DefaultContainerBuilder : IContainerBuilder {
 	public DefaultContainerBuilder ()
 


### PR DESCRIPTION
### Description
*Creating CustomAggregateMethodAnnotation class that allows client to notify OData about implemented custom aggregate methods. Modifying AggregationBinder to support Custom Aggregation Methods according to OData 4.0 spec. Right now only methods that return doubles are supported*

### Checklist (Uncheck if it is not completed)
- [x] Test cases added
- [x] Build and test with one-click build and test script passed

### Additional work necessary
*Basics tests are implemented, maybe it would be nice to have more thorough tests.*
*The clients have no way to know which custom aggregation methods are implemented by the server. To allow them to do it, we must add these methods in the metadata.*