### PR TITLE
O data60 context url

### DIFF
--- a/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/ODataMediaTypeFormatter.cs
@@ -501,7 +501,7 @@ namespace System.Web.OData.Formatter
                 // TODO: 1604 Convert webapi.odata's ODataPath to ODL's ODataPath, or use ODL's ODataPath.
                 SelectAndExpand = Request.ODataProperties().SelectExpandClause,
                 Apply = Request.ODataProperties().ApplyClause,
-                Path = (path == null || IsOperationPath(path)) ? null : path.ODLPath,
+                Path = (path == null ? null : path.ODLPath),
             };
 
             MediaTypeHeaderValue contentType = null;

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/Formatter/ContextUrlTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/Formatter/ContextUrlTests.cs
@@ -1,0 +1,323 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Web.Http;
+using System.Web.OData;
+using System.Web.OData.Builder;
+using System.Web.OData.Extensions;
+using System.Web.OData.Routing;
+using System.Web.OData.Routing.Conventions;
+using Nuwa;
+using Microsoft.OData.Edm;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Extensions;
+using Newtonsoft.Json.Linq;
+using Microsoft.OData;
+using System.Collections.Generic;
+
+namespace WebStack.QA.Test.OData.Formatter
+{
+    [NuwaFramework]
+    [NuwaHttpClientConfiguration(MessageLog = false)]
+    public class ContextUriTests
+    {
+        [Theory]
+        //[InlineData("Businesses", "#Businesses")]
+        //[InlineData("Businesses(0)", "#Businesses/$entity")]
+        [InlineData("unboundSetImport()", "#AppointmentSet")]
+        //[InlineData("unboundNoSetImport()", "#Collection(WebStack.QA.Test.OData.Formatter.Appointment)")]
+        //[InlineData("Businesses(0)/Appointments", "#Businesses(0)/Appointments")]
+        //[InlineData("Businesses(0)/Manager/Appointments", "#Businesses(0)/Manager/Appointments")]
+        //[InlineData("Businesses(0)/Default.boundEntity()", "#Businesses(0)/Appointments")]
+        //[InlineData("Businesses(0)/Default.boundNavPath()", "#Businesses(0)/Manager/Appointments")]
+        //[InlineData("Businesses(0)/Default.boundSet()", "#AppointmentSet")]
+        //[InlineData("Businesses(0)/Default.boundNoSet()", "#Collection(WebStack.QA.Test.OData.Formatter.Appointment)")]
+        public void VerifyContextUrl(string query, string contextFragment)
+        {
+            string contextUrl = GetContextUrl(BaseAddress + "/odata/" + query);
+            Assert.True(contextUrl.Contains(contextFragment), String.Format("Context URL for query {0} should contain {1} but is instead {2}", query, contextFragment, contextUrl));
+        }
+
+        private string GetContextUrl(string request)
+        {
+            HttpRequestMessage get = new HttpRequestMessage(HttpMethod.Get, request);
+            get.Headers.Add("Accept", "application/json;odata.metadata=minimal");
+            HttpResponseMessage response = Client.SendAsync(get).Result;
+            Assert.True(response.IsSuccessStatusCode);
+            dynamic results = response.Content.ReadAsAsync<JObject>().Result;
+            return results["@odata.context"].Value as string;
+        }
+
+        #region Nuwa
+
+        private string baseAddress = null;
+
+        [NuwaBaseAddress]
+        public string BaseAddress
+        {
+            get
+            {
+                return baseAddress;
+            }
+            set
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    this.baseAddress = value.Replace("localhost", Environment.MachineName);
+                }
+            }
+        }
+
+        [NuwaHttpClient]
+        public HttpClient Client { get; set; }
+
+        [NuwaConfiguration]
+        public static void UpdateConfiguration(HttpConfiguration config)
+        {
+            config.Routes.Clear();
+            config.Services.Replace(
+                typeof(System.Web.Http.Dispatcher.IAssembliesResolver),
+                new Common.TestAssemblyResolver(typeof(ContextUrlTestController), typeof(MetadataController)));
+            config.MapODataServiceRoute("odata", "odata", GetModel(), new DefaultODataPathHandler(), ODataRoutingConventions.CreateDefaultWithAttributeRouting("odata", config));
+        }
+
+        #endregion Nuwa
+
+        #region Model
+        private static IEdmModel GetModel()
+        {
+            ODataModelBuilder builder = new ODataConventionModelBuilder();
+            builder.Namespace = "Default";
+
+            var appointmentType = builder.EntityType<Appointment>();
+            var businessType = builder.EntityType<Business>();
+            var managerType = builder.EntityType<Manager>();
+
+            var function1 = businessType.Function("boundEntity");
+            function1.ReturnsCollectionViaEntitySetPath<Appointment>("bindingParameter/Appointments");
+            function1.OptionalReturn = false;
+
+            var function2 = businessType.Function("boundNavPath");
+            function2.ReturnsCollectionViaEntitySetPath<Appointment>("bindingParameter/Manager/Appointments");
+            function2.OptionalReturn = false;
+
+            var function3 = businessType.Function("boundSet");
+            function3.ReturnsCollectionFromEntitySet<Appointment>("AppointmentSet");
+            function3.OptionalReturn = false;
+
+            var function4 = businessType.Function("boundNoSet");
+            function4.ReturnsCollection<Appointment>();
+            function4.OptionalReturn = false;
+
+            var function5 = builder.Function("unboundSet");
+            function5.ReturnsCollectionFromEntitySet<Appointment>("AppointmentSet");
+            function5.OptionalReturn = false;
+
+            var function6 = builder.Function("unboundNoSet");
+            function6.ReturnsCollection<Appointment>();
+            function6.OptionalReturn = false;
+
+            builder.EntitySet<Business>("Businesses");
+            builder.EntitySet<Appointment>("AppointmentSet");
+
+            IEdmModel edmModel = builder.GetEdmModel();
+            var container = edmModel.EntityContainer as EdmEntityContainer;
+            var unboundSet = edmModel.FindOperations("Default.unboundSet").FirstOrDefault() as IEdmFunction;
+            var unboundNoSet = edmModel.FindOperations("Default.unboundNoSet").FirstOrDefault() as IEdmFunction;
+            container.AddFunctionImport("unboundSetImport", unboundSet,new EdmPathExpression("AppointmentSet")); 
+            container.AddFunctionImport("unboundNoSetImport", unboundNoSet);
+
+            return edmModel;
+        }
+    }
+
+    #endregion Model
+
+    #region model classes
+
+    public class Business
+    {
+        [Key]
+        public int Id
+        {
+            get;
+            set;
+        }
+
+        [Contained]
+        public Manager Manager
+        {
+            get;
+            set;
+        }
+
+        [Contained]
+        [ActionOnDelete(EdmOnDeleteAction.Cascade)]
+        public Appointment[] Appointments
+        {
+            get;
+            set;
+        }
+    }
+
+    public class Manager
+    {
+        [Key]
+        public int Id
+        {
+            get;
+            set;
+        }
+
+        [Contained]
+        public Appointment[] Appointments
+        {
+            get;
+            set;
+        }
+    }
+
+    public class Appointment
+    {
+        [Key]
+        public string Id
+        {
+            get;
+            set;
+        }
+    }
+
+    #endregion model classes
+
+    #region Controllers
+    public class ContextUrlTestController : ODataController
+    {
+        public int BusinessId => this.GetUrlParameter();
+        public string function => this.Request.RequestUri.Segments.Last();
+
+        #region business methods
+
+        [ODataRoute("Businesses")]
+        public IQueryable<Business> Get() =>
+                Enumerable.Range(0, 5).Select(i =>
+                    new Business
+                    {
+                        Id = i,
+                    }).AsQueryable();
+
+
+        [EnableQuery]
+        [ODataRoute("Businesses({BusinessId})")]
+        public SingleResult<Business> GetBusiness([FromODataUri]int BusinessId)
+        {
+            var business = new Business { Id = BusinessId };
+            return business.AsSingleResult();
+        }
+
+        #endregion
+
+        #region navigation methods
+
+        [ODataRoute("Businesses({BusinessId})/Appointments")]
+        public IQueryable<Appointment> GetBusinessAppointments([FromODataUri]int BusinessId) =>
+                Enumerable.Range(0, 5).Select(i =>
+                    new Appointment
+                    {
+                        Id = BusinessId + "." + i.ToString(),
+                    }).AsQueryable();
+
+
+        [EnableQuery]
+        [ODataRoute("Businesses({BusinessId})/Appointments({AppointmentId})")]
+        public SingleResult<Appointment> GetBusinessAppointment([FromODataUri]int BusinessId,[FromODataUri]string AppointmentId)
+        {
+            var appointment = new Appointment { Id = AppointmentId };
+            return appointment.AsSingleResult();
+        }
+
+        [ODataRoute("Businesses({BusinessId})/Manager/Appointments")]
+        public IQueryable<Appointment> GetBusinessManagerAppointments([FromODataUri]int BusinessId) =>
+                Enumerable.Range(0, 5).Select(i =>
+                    new Appointment
+                    {
+                        Id = BusinessId + "." + i.ToString(),
+                    }).AsQueryable();
+        #endregion
+
+        #region functions
+
+        [HttpGet]
+        [ODataRoute("Businesses({BusinessId})/Default.boundEntity()")]
+        public IHttpActionResult boundEntity([FromODataUri]int BusinessId)
+        {
+            return Ok(getAppointments());
+        }
+
+        [HttpGet]
+        [ODataRoute("Businesses({BusinessId})/Default.boundNavPath()")]
+        public IQueryable<Appointment> boundNavPath([FromODataUri]int BusinessId)
+        {
+            return getAppointments();
+        }
+
+        [HttpGet]
+        [ODataRoute("Businesses({BusinessId})/Default.boundSet()")]
+        public IQueryable<Appointment> boundSet([FromODataUri]int BusinessId)
+        {
+            return getAppointments();
+        }
+
+        [HttpGet]
+        [ODataRoute("Businesses({BusinessId})/Default.boundNoSet()")]
+        public IQueryable<Appointment> boundNoSet([FromODataUri]int BusinessId)
+        {
+            return getAppointments();
+        }
+
+        #endregion Functions
+
+        #region FunctionImports
+
+        [HttpGet]
+        [EnableQuery]
+        [ODataRoute("unboundSetImport()")]
+        public IQueryable<Appointment> unboundSetImport()
+        {
+            return getAppointments();
+        }
+
+        [HttpGet]
+        [EnableQuery]
+        [ODataRoute("unboundNoSetImport()")]
+        public IQueryable<Appointment> unboundNoSetImport()
+        {
+            return getAppointments();
+        }
+
+        private IQueryable<Appointment> getAppointments()
+        {
+            return Enumerable.Range(2, 4).Select(i =>
+                 new Appointment
+                 {
+                     Id = function + "." + i.ToString(),
+                 }).AsQueryable();
+        }
+    }
+    #endregion FunctionImports
+
+    #endregion Controller
+
+    public static class ExtensionMethods
+    {
+        public static int GetUrlParameter(this ApiController controller, [CallerMemberName]string parameterName = null) =>
+           (int)controller.RequestContext.RouteData.Values[parameterName] ;
+
+        public static SingleResult<T> AsSingleResult<T>(this T value) =>
+            new[] { value }.AsSingleResult();
+
+        public static SingleResult<T> AsSingleResult<T>(this T[] values) =>
+            new SingleResult<T>(values.AsQueryable());
+    }
+}

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
@@ -97,6 +97,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data.Linq" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -171,6 +172,7 @@
     <Compile Include="DollarLevels\DollarLevelsDataModel.cs" />
     <Compile Include="DollarLevels\DollarLevelsEdmModel.cs" />
     <Compile Include="DollarLevels\DollarLevelsTest.cs" />
+    <Compile Include="Formatter\ContextUrlTests.cs" />
     <Compile Include="ModelBoundQuerySettings\CombinedTest\CombinedController.cs" />
     <Compile Include="ModelBoundQuerySettings\CombinedTest\CombinedEdmModel.cs" />
     <Compile Include="ModelBoundQuerySettings\CombinedTest\CombinedTest.cs" />


### PR DESCRIPTION
### Issues
*This pull request fixes issue #917.*  

### Description
*Passes Operation Path down to ODL so that it can correctly generate a ContextUrl.*
*Relies on PR776 from OData.net (https://github.com/OData/odata.net/pull/776)*

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
*No Docs Needed.*
*Commented test code validates appending key lookup to function invocation which is apparently not supported in WebAPI OData today.
