### PR TITLE
Fix ETags on Singletons

### DIFF
--- a/OData/src/System.Web.OData/Extensions/HttpRequestMessageExtensions.cs
+++ b/OData/src/System.Web.OData/Extensions/HttpRequestMessageExtensions.cs
@@ -141,10 +141,10 @@ namespace System.Web.OData.Extensions
                 // get property names from request
                 ODataPath odataPath = request.ODataProperties().Path;
                 IEdmModel model = request.GetModel();
-                IEdmEntitySet entitySet = odataPath.NavigationSource as IEdmEntitySet;
-                if (model != null && entitySet != null)
+                IEdmNavigationSource source = odataPath.NavigationSource;
+                if (model != null && source != null)
                 {
-                    IList<IEdmStructuralProperty> concurrencyProperties = model.GetConcurrencyProperties(entitySet).ToList();
+                    IList<IEdmStructuralProperty> concurrencyProperties = model.GetConcurrencyProperties(source).ToList();
                     IList<string> concurrencyPropertyNames = concurrencyProperties.OrderBy(c => c.Name).Select(c => c.Name).AsList();
                     ETag etag = new ETag();
 

--- a/OData/src/System.Web.OData/OData/Builder/EdmModelHelperMethods.cs
+++ b/OData/src/System.Web.OData/OData/Builder/EdmModelHelperMethods.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
-using Microsoft.OData.Edm;
-using Microsoft.OData.Edm.Csdl;
-using Microsoft.OData.Edm.Validation;
-using Microsoft.OData.Edm.Vocabularies;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
@@ -14,6 +10,10 @@ using System.Text;
 using System.Web.Http;
 using System.Web.OData.Properties;
 using System.Web.OData.Query;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm.Vocabularies;
 
 namespace System.Web.OData.Builder
 {

--- a/OData/src/System.Web.OData/OData/Builder/EdmModelHelperMethods.cs
+++ b/OData/src/System.Web.OData/OData/Builder/EdmModelHelperMethods.cs
@@ -12,6 +12,8 @@ using System.Web.OData.Properties;
 using System.Web.OData.Query;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OData.Edm.Csdl;
 
 namespace System.Web.OData.Builder
 {
@@ -45,10 +47,15 @@ namespace System.Web.OData.Builder
             IDictionary<string, EdmNavigationSource> navigationSourceMap = model.GetNavigationSourceMap(edmMap, navigationSources);
 
             // Add the core vocabulary annotations
-            model.AddCoreVocabularyAnnotations(entitySets, edmMap);
+            model.AddCoreVocabularyAnnotations(navigationSources, edmMap);
+
+            // TODO: support etags on contained nav props
+            // Support for this in 5.x adds annotations to navigation properties. Ideally would add annotations to entity set/singleton for
+            // containing type(s) with nav paths to the contained nav property.
+            // model.AddNavPropAnnotations(builder, edmMap);  // implemented in EdmModelHelperMethods.cs of 5.x branch
 
             // Add the capabilities vocabulary annotations
-            model.AddCapabilitiesVocabularyAnnotations(entitySets, edmMap);
+            model.AddCapabilitiesVocabularyAnnotations(navigationSources, edmMap);
 
             // add operations
             model.AddOperations(builder.Operations, container, edmTypeMap, navigationSourceMap);
@@ -541,38 +548,38 @@ namespace System.Web.OData.Builder
             }
         }
 
-        private static void AddCoreVocabularyAnnotations(this EdmModel model, NavigationSourceAndAnnotations[] entitySets, EdmTypeMap edmTypeMap)
+        private static void AddCoreVocabularyAnnotations(this EdmModel model, IEnumerable<NavigationSourceAndAnnotations> navigationSources, EdmTypeMap edmTypeMap)
         {
             Contract.Assert(model != null);
             Contract.Assert(edmTypeMap != null);
 
-            if (entitySets == null)
+            if (navigationSources == null)
             {
                 return;
             }
 
-            foreach (NavigationSourceAndAnnotations source in entitySets)
+            foreach (NavigationSourceAndAnnotations source in navigationSources)
             {
-                IEdmEntitySet entitySet = source.NavigationSource as IEdmEntitySet;
-                if (entitySet == null)
+                IEdmVocabularyAnnotatable navigationSource = source.NavigationSource as IEdmVocabularyAnnotatable;
+                if (navigationSource == null)
                 {
                     continue;
                 }
 
-                EntitySetConfiguration entitySetConfig = source.Configuration as EntitySetConfiguration;
-                if (entitySetConfig == null)
+                NavigationSourceConfiguration navigationSourceConfig = source.Configuration as NavigationSourceConfiguration;
+                if (navigationSourceConfig == null)
                 {
                     continue;
                 }
 
-                model.AddOptimisticConcurrencyAnnotation(entitySet, entitySetConfig, edmTypeMap);
+                model.AddOptimisticConcurrencyAnnotation(navigationSource, navigationSourceConfig, edmTypeMap);
             }
         }
 
-        private static void AddOptimisticConcurrencyAnnotation(this EdmModel model, IEdmEntitySet target,
-            EntitySetConfiguration entitySetConfiguration, EdmTypeMap edmTypeMap)
+        private static void AddOptimisticConcurrencyAnnotation(this EdmModel model, IEdmVocabularyAnnotatable target,
+            NavigationSourceConfiguration navigationSourceConfiguration, EdmTypeMap edmTypeMap)
         {
-            EntityTypeConfiguration entityTypeConfig = entitySetConfiguration.EntityType;
+            EntityTypeConfiguration entityTypeConfig = navigationSourceConfiguration.EntityType;
 
             IEnumerable<StructuralPropertyConfiguration> concurrencyPropertyies =
                 entityTypeConfig.Properties.OfType<StructuralPropertyConfiguration>().Where(property => property.ConcurrencyToken);
@@ -594,21 +601,25 @@ namespace System.Web.OData.Builder
 
             if (edmProperties.Any())
             {
-                model.SetOptimisticConcurrencyAnnotation(target, edmProperties);
+                IEdmCollectionExpression collectionExpression = new EdmCollectionExpression(edmProperties.Select(p => new EdmPropertyPathExpression(p.Name)).ToArray());
+                IEdmTerm term = Microsoft.OData.Edm.Vocabularies.V1.CoreVocabularyModel.ConcurrencyTerm;
+                EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(target, term, collectionExpression);
+                annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
+                model.SetVocabularyAnnotation(annotation);
             }
         }
 
-        private static void AddCapabilitiesVocabularyAnnotations(this EdmModel model, NavigationSourceAndAnnotations[] entitySets, EdmTypeMap edmTypeMap)
+        private static void AddCapabilitiesVocabularyAnnotations(this EdmModel model, IEnumerable<NavigationSourceAndAnnotations> navigationSources, EdmTypeMap edmTypeMap)
         {
             Contract.Assert(model != null);
             Contract.Assert(edmTypeMap != null);
 
-            if (entitySets == null)
+            if (navigationSources == null)
             {
                 return;
             }
 
-            foreach (NavigationSourceAndAnnotations source in entitySets)
+            foreach (NavigationSourceAndAnnotations source in navigationSources)
             {
                 IEdmEntitySet entitySet = source.NavigationSource as IEdmEntitySet;
                 if (entitySet == null)

--- a/OData/src/System.Web.OData/OData/Builder/EdmModelHelperMethods.cs
+++ b/OData/src/System.Web.OData/OData/Builder/EdmModelHelperMethods.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm.Vocabularies;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
@@ -10,10 +14,6 @@ using System.Text;
 using System.Web.Http;
 using System.Web.OData.Properties;
 using System.Web.OData.Query;
-using Microsoft.OData.Edm;
-using Microsoft.OData.Edm.Validation;
-using Microsoft.OData.Edm.Vocabularies;
-using Microsoft.OData.Edm.Csdl;
 
 namespace System.Web.OData.Builder
 {

--- a/OData/src/System.Web.OData/OData/ETagMessageHandler.cs
+++ b/OData/src/System.Web.OData/OData/ETagMessageHandler.cs
@@ -116,12 +116,11 @@ namespace System.Web.OData
             IETagHandler handler)
         {
             IEdmModel model = resourceContext.EdmModel;
-            IEdmEntitySet entitySet = resourceContext.NavigationSource as IEdmEntitySet;
-
+ 
             IEnumerable<IEdmStructuralProperty> concurrencyProperties;
-            if (model != null && entitySet != null)
+            if (model != null && resourceContext.NavigationSource != null)
             {
-                concurrencyProperties = model.GetConcurrencyProperties(entitySet).OrderBy(c => c.Name);
+                concurrencyProperties = model.GetConcurrencyProperties(resourceContext.NavigationSource).OrderBy(c => c.Name);
             }
             else
             {

--- a/OData/src/System.Web.OData/OData/Formatter/EdmLibHelpers.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/EdmLibHelpers.cs
@@ -31,7 +31,7 @@ namespace System.Web.OData.Formatter
 
         private static readonly IAssembliesResolver _defaultAssemblyResolver = new DefaultAssembliesResolver();
 
-        private static ConcurrentDictionary<IEdmEntitySet, IEnumerable<IEdmStructuralProperty>> _concurrencyProperties;
+        private static ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>> _concurrencyProperties;
 
         private static readonly Dictionary<Type, IEdmPrimitiveType> _builtInTypesMapping =
             new[]
@@ -768,39 +768,43 @@ namespace System.Web.OData.Formatter
             return String.Format(CultureInfo.InvariantCulture, "{0}.{1}", clrType.Namespace, clrType.EdmName());
         }
 
-        public static IEnumerable<IEdmStructuralProperty> GetConcurrencyProperties(this IEdmModel model, IEdmEntitySet entitySet)
+        public static IEnumerable<IEdmStructuralProperty> GetConcurrencyProperties(this IEdmModel model, IEdmNavigationSource navigationSource)
         {
             Contract.Assert(model != null);
-            Contract.Assert(entitySet != null);
+            Contract.Assert(navigationSource != null);
 
             IEnumerable<IEdmStructuralProperty> cachedProperties;
-            if (_concurrencyProperties != null && _concurrencyProperties.TryGetValue(entitySet, out cachedProperties))
+            if (_concurrencyProperties != null && _concurrencyProperties.TryGetValue(navigationSource, out cachedProperties))
             {
                 return cachedProperties;
             }
 
             IList<IEdmStructuralProperty> results = new List<IEdmStructuralProperty>();
-            IEdmEntityType entityType = entitySet.EntityType();
-            var annotations = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(entitySet, CoreVocabularyModel.ConcurrencyTerm);
-            IEdmVocabularyAnnotation annotation = annotations.FirstOrDefault();
-            if (annotation != null)
+            IEdmEntityType entityType = navigationSource.EntityType();
+            IEdmVocabularyAnnotatable annotatable = navigationSource as IEdmVocabularyAnnotatable;
+            if (annotatable != null)
             {
-                IEdmCollectionExpression properties = annotation.Value as IEdmCollectionExpression;
-                if (properties != null)
+                var annotations = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(annotatable, CoreVocabularyModel.ConcurrencyTerm);
+                IEdmVocabularyAnnotation annotation = annotations.FirstOrDefault();
+                if (annotation != null)
                 {
-                    foreach (var property in properties.Elements)
+                    IEdmCollectionExpression properties = annotation.Value as IEdmCollectionExpression;
+                    if (properties != null)
                     {
-                        IEdmPathExpression pathExpression = property as IEdmPathExpression;
-                        if (pathExpression != null)
+                        foreach (var property in properties.Elements)
                         {
-                            // So far, we only consider the single path, because only the direct properties from declaring type are used.
-                            // However we have an issue tracking on: https://github.com/OData/WebApi/issues/472
-                            string propertyName = pathExpression.PathSegments.First();
-                            IEdmProperty edmProperty = entityType.FindProperty(propertyName);
-                            IEdmStructuralProperty structuralProperty = edmProperty as IEdmStructuralProperty;
-                            if (structuralProperty != null)
+                            IEdmPathExpression pathExpression = property as IEdmPathExpression;
+                            if (pathExpression != null)
                             {
-                                results.Add(structuralProperty);
+                                // So far, we only consider the single path, because only the direct properties from declaring type are used.
+                                // However we have an issue tracking on: https://github.com/OData/WebApi/issues/472
+                                string propertyName = pathExpression.PathSegments.First();
+                                IEdmProperty edmProperty = entityType.FindProperty(propertyName);
+                                IEdmStructuralProperty structuralProperty = edmProperty as IEdmStructuralProperty;
+                                if (structuralProperty != null)
+                                {
+                                    results.Add(structuralProperty);
+                                }
                             }
                         }
                     }
@@ -809,10 +813,10 @@ namespace System.Web.OData.Formatter
 
             if (_concurrencyProperties == null)
             {
-                _concurrencyProperties = new ConcurrentDictionary<IEdmEntitySet, IEnumerable<IEdmStructuralProperty>>();
+                _concurrencyProperties = new ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>>();
             }
 
-            _concurrencyProperties[entitySet] = results;
+            _concurrencyProperties[navigationSource] = results;
             return results;
         }
 

--- a/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Serialization/ODataResourceSerializer.cs
@@ -615,12 +615,12 @@ namespace System.Web.OData.Formatter.Serialization
                 }
 
                 IEdmModel model = resourceContext.EdmModel;
-                IEdmEntitySet entitySet = resourceContext.NavigationSource as IEdmEntitySet;
+                IEdmNavigationSource navigationSource = resourceContext.NavigationSource;
 
                 IEnumerable<IEdmStructuralProperty> concurrencyProperties;
-                if (model != null && entitySet != null)
+                if (model != null && navigationSource != null)
                 {
-                    concurrencyProperties = model.GetConcurrencyProperties(entitySet).OrderBy(c => c.Name);
+                    concurrencyProperties = model.GetConcurrencyProperties(navigationSource).OrderBy(c => c.Name);
                 }
                 else
                 {

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/ETags/DerivedETagTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/ETags/DerivedETagTests.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.OData.Edm;
+using Newtonsoft.Json.Linq;
+using Nuwa;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.OData;
+using System.Web.OData.Builder;
+using System.Web.OData.Extensions;
+using System.Web.OData.Routing;
+using System.Web.OData.Routing.Conventions;
+using Xunit;
+
+namespace WebStack.QA.Test.OData.ETags
+{
+    [NuwaFramework]
+    public class DerivedETagTests
+    {
+        [NuwaBaseAddress]
+        public string BaseAddress { get; set; }
+
+        [NuwaHttpClient]
+        public HttpClient Client { get; set; }
+
+        [NuwaConfiguration]
+        public static void UpdateConfiguration(HttpConfiguration configuration)
+        {
+            configuration.Routes.Clear();
+            configuration.Count().Filter().OrderBy().Expand().Select().MaxTop(null);
+            configuration.MapODataServiceRoute("odata", "odata", GetEdmModel(), new DefaultODataPathHandler(), ODataRoutingConventions.CreateDefault());
+            configuration.MessageHandlers.Add(new ETagMessageHandler());
+        }
+
+        private static IEdmModel GetEdmModel()
+        {
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            EntitySetConfiguration<ETagsCustomer> eTagsCustomersSet = builder.EntitySet<ETagsCustomer>("ETagsCustomers");
+            eTagsCustomersSet.HasRequiredBinding(c => c.RelatedCustomer, eTagsCustomersSet);
+            eTagsCustomersSet.HasRequiredBinding(c => c.ContainedCustomer, eTagsCustomersSet);
+            EntitySetConfiguration<ETagsCustomer> eTagsDerivedCustomersSet = builder.EntitySet<ETagsCustomer>("ETagsDerivedCustomers");
+            eTagsDerivedCustomersSet.HasRequiredBinding(c => c.RelatedCustomer, eTagsCustomersSet);
+            eTagsDerivedCustomersSet.HasRequiredBinding(c => c.ContainedCustomer, eTagsCustomersSet);
+            SingletonConfiguration<ETagsCustomer> eTagsCustomerSingleton = builder.Singleton<ETagsCustomer>("ETagsDerivedCustomersSingleton");
+            eTagsCustomerSingleton.HasRequiredBinding(c => c.RelatedCustomer, eTagsCustomersSet);
+            eTagsCustomerSingleton.HasRequiredBinding(c => c.ContainedCustomer, eTagsCustomersSet);
+            return builder.GetEdmModel();
+        }
+
+        [Fact]
+        public void DerivedTypesHaveSameETagsTest()
+        {
+            string requestUri = this.BaseAddress + "/odata/ETagsCustomers?$select=Id";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Accept.ParseAdd("application/json");
+            HttpResponseMessage response = this.Client.SendAsync(request).Result;
+            Assert.True(response.IsSuccessStatusCode);
+            var jsonResult = response.Content.ReadAsAsync<JObject>().Result;
+            var jsonETags = jsonResult.GetValue("value").Select(e => e["@odata.etag"].ToString());
+
+            requestUri = this.BaseAddress + "/odata/ETagsDerivedCustomers?$select=Id";
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Accept.ParseAdd("application/json");
+            response = this.Client.SendAsync(request).Result;
+            Assert.True(response.IsSuccessStatusCode);
+            jsonResult = response.Content.ReadAsAsync<JObject>().Result;
+            var derivedEtags = jsonResult.GetValue("value").Select(e => e["@odata.etag"].ToString());
+            
+            Assert.True(String.Concat(jsonETags) == String.Concat(derivedEtags), "Derived Types has different etags than base type");
+        }
+
+        [Fact]
+        public void SingletonsHaveSameETagsTest()
+        {
+            string requestUri = this.BaseAddress + "/odata/ETagsCustomers?$select=Id";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Accept.ParseAdd("application/json");
+            HttpResponseMessage response = this.Client.SendAsync(request).Result;
+            Assert.True(response.IsSuccessStatusCode);
+            var jsonResult = response.Content.ReadAsAsync<JObject>().Result;
+            var jsonETags = jsonResult.GetValue("value").Select(e => e["@odata.etag"].ToString());
+
+            requestUri = this.BaseAddress + "/odata/ETagsDerivedCustomersSingleton?$select=Id";
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Accept.ParseAdd("application/json");
+            response = this.Client.SendAsync(request).Result;
+            Assert.True(response.IsSuccessStatusCode);
+            jsonResult = response.Content.ReadAsAsync<JObject>().Result;
+            var singletonEtag = jsonResult.GetValue("@odata.etag").ToString();
+
+            Assert.True(jsonETags.FirstOrDefault() == singletonEtag, "Singleton has different etags than Set");
+        }
+    }
+}

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/ETags/ETagsModel.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/ETags/ETagsModel.cs
@@ -1,9 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Web.OData.Builder;
 
 namespace WebStack.QA.Test.OData.ETags
 {
+    public class ETagsDerivedCustomer : ETagsCustomer
+    {
+        public string Role { get; set; }
+    }
+
     public class ETagsCustomer
     {
         public int Id { get; set; }
@@ -25,5 +31,8 @@ namespace WebStack.QA.Test.OData.ETags
         public DateTimeOffset DateTimeOffsetProperty { get; set; }
         [ConcurrencyCheck]
         public string StringWithConcurrencyCheckAttributeProperty { get; set; }
+        public ETagsCustomer RelatedCustomer { get; set; }
+        [Contained]
+        public ETagsCustomer ContainedCustomer { get; set; }
     }
 }

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/ETags/JsonETagsTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/ETags/JsonETagsTests.cs
@@ -68,6 +68,7 @@ namespace WebStack.QA.Test.OData.ETags
         {
             string expectMetadata =
                 "<EntitySet Name=\"ETagsCustomers\" EntityType=\"WebStack.QA.Test.OData.ETags.ETagsCustomer\">\r\n" +
+                "          <NavigationPropertyBinding Path=\"RelatedCustomer\" Target=\"ETagsCustomers\" />\r\n" +
                 "          <Annotation Term=\"Org.OData.Core.V1.OptimisticConcurrency\">\r\n" +
                 "            <Collection>\r\n" +
                 "              <PropertyPath>Id</PropertyPath>\r\n" +

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
@@ -172,6 +172,7 @@
     <Compile Include="DollarLevels\DollarLevelsDataModel.cs" />
     <Compile Include="DollarLevels\DollarLevelsEdmModel.cs" />
     <Compile Include="DollarLevels\DollarLevelsTest.cs" />
+    <Compile Include="ETags\DerivedETagTests.cs" />
     <Compile Include="ModelBoundQuerySettings\CombinedTest\CombinedController.cs" />
     <Compile Include="ModelBoundQuerySettings\CombinedTest\CombinedEdmModel.cs" />
     <Compile Include="ModelBoundQuerySettings\CombinedTest\CombinedTest.cs" />


### PR DESCRIPTION
### Description
*This pull request fixes the ability to return etags on singletons, and sets up for etags on navigation properties*

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
*This sets us up for being able to have etags on containment navigation properties, but does not actually implement that functionality.  To enable, we need to call model.AddNavPropAnnotations(builder, edmMap);, from the commented location in EdmModelHelperMethods.cs -- implementation can be found in EdmModelHelperMethods.cs of 5.x branch (added in PR #926).  However, that implementation adds the annotation to the navigation property, and better would be to add the annotation to the containing entityset/singleton with a property to the containment navigation property.*
