### PR TITLE
Cleanup Code Analysis build failures and test failues.

### DIFF
--- a/OData/src/System.Web.OData/OData/Builder/EdmModelHelperMethods.cs
+++ b/OData/src/System.Web.OData/OData/Builder/EdmModelHelperMethods.cs
@@ -576,6 +576,8 @@ namespace System.Web.OData.Builder
             }
         }
 
+        [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling",
+            Justification = "Relies on many ODataLib classes.")]
         private static void AddOptimisticConcurrencyAnnotation(this EdmModel model, IEdmVocabularyAnnotatable target,
             NavigationSourceConfiguration navigationSourceConfiguration, EdmTypeMap edmTypeMap)
         {

--- a/OData/src/System.Web.OData/OData/Formatter/Deserialization/DeserializationHelpers.cs
+++ b/OData/src/System.Web.OData/OData/Formatter/Deserialization/DeserializationHelpers.cs
@@ -383,7 +383,7 @@ namespace System.Web.OData.Formatter.Deserialization
                 return doubleValue;
             }
 
-            if (!value.StartsWith("\"") || !value.EndsWith("\""))
+            if (!value.StartsWith("\"", StringComparison.Ordinal) || !value.EndsWith("\"", StringComparison.Ordinal))
             {
                 throw new ODataException(Error.Format(SRResources.InvalidODataUntypedValue, value));
             }

--- a/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -947,7 +947,7 @@ public abstract class System.Web.OData.Builder.OperationConfiguration {
 	NavigationSourceConfiguration NavigationSource  { public get; public set; }
 	OperationLinkBuilder OperationLinkBuilder  { protected get; protected set; }
 	bool OptionalReturn  { public get; public set; }
-	System.Collections.Generic.IEnumerable`1[[System.Web.OData.Builder.ParameterConfiguration]] Parameters  { [IteratorStateMachineAttribute(),]public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[System.Web.OData.Builder.ParameterConfiguration]] Parameters  { public virtual get; }
 	IEdmTypeConfiguration ReturnType  { public get; public set; }
 	string Title  { public get; public set; }
 
@@ -2919,11 +2919,7 @@ public class System.Web.OData.Formatter.Deserialization.ODataCollectionDeseriali
 	public ODataCollectionDeserializer (ODataDeserializerProvider deserializerProvider)
 
 	public virtual object Read (Microsoft.OData.ODataMessageReader messageReader, System.Type type, ODataDeserializerContext readContext)
-	[
-	IteratorStateMachineAttribute(),
-	]
 	public virtual System.Collections.IEnumerable ReadCollectionValue (Microsoft.OData.ODataCollectionValue collectionValue, Microsoft.OData.Edm.IEdmTypeReference elementType, ODataDeserializerContext readContext)
-
 	public virtual object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, ODataDeserializerContext readContext)
 }
 
@@ -2983,9 +2979,6 @@ public class System.Web.OData.Formatter.Deserialization.ODataResourceSetDeserial
 
 	public virtual object Read (Microsoft.OData.ODataMessageReader messageReader, System.Type type, ODataDeserializerContext readContext)
 	public virtual object ReadInline (object item, Microsoft.OData.Edm.IEdmTypeReference edmType, ODataDeserializerContext readContext)
-	[
-	IteratorStateMachineAttribute(),
-	]
 	public virtual System.Collections.IEnumerable ReadResourceSet (ODataResourceSetWrapper resourceSet, Microsoft.OData.Edm.IEdmStructuredTypeReference elementType, ODataDeserializerContext readContext)
 }
 


### PR DESCRIPTION
### Description
Update PublicApi.bsl to remove IteratorStateMachineAttribute added by VS2015 csc.exe

Cleanup code analysis errors:
  Fix CA1506:  Microsoft.Maintainability in EdmModelHelperMethods.cs.
  Fix CA1307: Microsoft.Globalization in DeserializationHelpers.cs.

### Checklist (Uncheck if it is not completed)
- [   ] Test cases added
- [ x ] Build and test with one-click build and test script passed
