### PR TITLE
Recursive Complex Type Support

### DIFF
--- a/OData/src/System.Web.OData/OData/Builder/StructuralTypeConfiguration.cs
+++ b/OData/src/System.Web.OData/OData/Builder/StructuralTypeConfiguration.cs
@@ -346,11 +346,6 @@ namespace System.Web.OData.Builder
                 throw Error.Argument("propertyInfo", SRResources.PropertyDoesNotBelongToType, propertyInfo.Name, ClrType.FullName);
             }
 
-            if (propertyInfo.PropertyType == ClrType)
-            {
-                throw Error.Argument("propertyInfo", SRResources.RecursiveComplexTypesNotAllowed, ClrType.FullName, propertyInfo.Name);
-            }
-
             ValidatePropertyNotAlreadyDefinedInBaseTypes(propertyInfo);
             ValidatePropertyNotAlreadyDefinedInDerivedTypes(propertyInfo);
 
@@ -408,15 +403,6 @@ namespace System.Web.OData.Builder
             {
                 propertyConfiguration = new CollectionPropertyConfiguration(propertyInfo, this);
                 ExplicitProperties[propertyInfo] = propertyConfiguration;
-
-                // If the ElementType is the same as this type this is recursive complex type nesting
-                if (propertyConfiguration.ElementType == ClrType)
-                {
-                    throw Error.Argument("propertyInfo",
-                        SRResources.RecursiveComplexTypesNotAllowed,
-                        ClrType.Name,
-                        propertyConfiguration.Name);
-                }
 
                 // If the ElementType is not primitive or enum treat as a ComplexType and Add to the model.
                 IEdmPrimitiveTypeReference edmType =

--- a/OData/src/System.Web.OData/Properties/SRResources.Designer.cs
+++ b/OData/src/System.Web.OData/Properties/SRResources.Designer.cs
@@ -1744,15 +1744,6 @@ namespace System.Web.OData.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The complex type &apos;{0}&apos; has a reference to itself through the property &apos;{1}&apos;. A recursive loop of complex types is not allowed..
-        /// </summary>
-        internal static string RecursiveComplexTypesNotAllowed {
-            get {
-                return ResourceManager.GetString("RecursiveComplexTypesNotAllowed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; property &apos;{1}&apos; is already configured to have a relationship with &apos;{2}&apos; property &apos;{3}&apos; in the referential constraint..
         /// </summary>
         internal static string ReferentialConstraintAlreadyConfigured {

--- a/OData/src/System.Web.OData/Properties/SRResources.resx
+++ b/OData/src/System.Web.OData/Properties/SRResources.resx
@@ -252,9 +252,6 @@
   <data name="EnumTypeDoesNotExist" xml:space="preserve">
     <value>The enum type '{0}' does not exist.</value>
   </data>
-  <data name="RecursiveComplexTypesNotAllowed" xml:space="preserve">
-    <value>The complex type '{0}' has a reference to itself through the property '{1}'. A recursive loop of complex types is not allowed.</value>
-  </data>
   <data name="DeserializerDoesNotSupportRead" xml:space="preserve">
     <value>'{0}' does not support Read.</value>
   </data>
@@ -655,11 +652,11 @@
   <data name="ParameterAliasMustBeInCurlyBraces" xml:space="preserve">
     <value>Parameter alias '{0}' in segment '{1}' does not start with '{{' or ends with '}}'.</value>
   </data>
-  <data name="EmptyKeyTemplate" xml:space="preserve"> 
-    <value>Key template value in key segment '{0}' is empty.</value> 
+  <data name="EmptyKeyTemplate" xml:space="preserve">
+    <value>Key template value in key segment '{0}' is empty.</value>
   </data>
-  <data name="KeyTemplateMustBeInCurlyBraces" xml:space="preserve"> 
-    <value>Key template value in key segment '{0}' does not start with '{{' or ends with '}}'.</value> 
+  <data name="KeyTemplateMustBeInCurlyBraces" xml:space="preserve">
+    <value>Key template value in key segment '{0}' does not start with '{{' or ends with '}}'.</value>
   </data>
   <data name="UnresolvedPathSegmentInTemplate" xml:space="preserve">
     <value>Found an unresolved path segment '{0}' in the OData path template '{1}'.</value>


### PR DESCRIPTION
### Issues
*This pull request fixes issue #437 .*  

### Description
*Removed checks/exceptions for recursive complex types as OData V4 supports complex types.  This restriction appears to have been carried over from the OData V3 and is not necessary.*

### Checklist (Uncheck if it is not completed)
- [  ] Test cases added
- [  ] Build and test with one-click build and test script passed
