### PR TITLE
ODataConventionModelBuilder.GetEdmModel Stack Overflow Fix For Recursive Complex Types

### DIFF
--- a/OData/src/System.Web.OData/OData/Builder/NavigationPropertyExtensions.cs
+++ b/OData/src/System.Web.OData/OData/Builder/NavigationPropertyExtensions.cs
@@ -65,6 +65,11 @@ namespace System.Web.OData.Builder
 
             foreach (var property in configuration.Properties)
             {
+                if (path.Any(p => p == property.PropertyInfo))
+                {
+                    continue;
+                }
+
                 path.Push(property.PropertyInfo);
 
                 NavigationPropertyConfiguration nav = property as NavigationPropertyConfiguration;

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/Conventions/ODataConventionModelBuilderTests.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Builder/Conventions/ODataConventionModelBuilderTests.cs
@@ -26,6 +26,49 @@ namespace System.Web.OData.Builder.Conventions
     {
         private const int _totalExpectedSchemaTypesForVehiclesModel = 10;
 
+        public sealed class Rule
+        {
+            [Key]
+            public int Id { get; set; }
+
+            public Expression Expression { get; set; }
+        }
+
+        public abstract class Expression
+        {
+        }
+
+        public sealed class ExpressionBinaryOperation : Expression
+        {
+            [Required]
+            public Expression FirstOperand { get; set; }
+
+            [Required]
+            public Expression SecondOperand { get; set; }
+        }
+
+        public sealed class ExpressionUnaryOperation : Expression
+        {
+            [Required]
+            public Expression Operand { get; set; }
+        }
+
+        public sealed class ExpressionVariable : Expression
+        {
+            [Required]
+            public int RuleVariableId { get; set; }
+        }
+
+        [Fact]
+        public void ComplexTypes_In_RecursiveInheritance_AreRecursed()
+        {
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<Rule>("rules");
+
+            IEdmModel model = builder.GetEdmModel();
+            Assert.Equal(6, model.SchemaElements.Count());
+        }
+
         [Fact]
         public void Ctor_ThrowsForNullConfiguration()
         {


### PR DESCRIPTION
### Issues
This pull request fixes issues #930 #892.

### Description
When finding navigation properties add check to ensure we don't revisit any property types that have already been traversed.

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
None.
