### PR TITLE
Working/fix apply enumerable.5x

### DIFF
--- a/OData/src/System.Web.OData/OData/EnableQueryAttribute.cs
+++ b/OData/src/System.Web.OData/OData/EnableQueryAttribute.cs
@@ -549,7 +549,7 @@ namespace System.Web.OData
 
             // apply the query
             IEnumerable enumerable = response as IEnumerable;
-            if (enumerable == null)
+            if (enumerable == null || (response is string) == true || (response is byte[]) == true)
             {
                 // response is not a collection; we only support $select and $expand on single entities.
                 ValidateSelectExpandOnly(queryOptions);

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/EnableQueryAttributeTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/EnableQueryAttributeTest.cs
@@ -1054,12 +1054,15 @@ namespace System.Web.OData.Query
         [Fact]
         public void OnActionExecuted_StringValue()
         {
+            // Arrange
             string stringResult = "foo";
             EnableQueryAttribute attribute = new EnableQueryAttribute();
             HttpActionExecutedContext actionExecutedContext = GetActionExecutedContext("http://localhost/Suppliers(1)/CompanyName?customqueryoption=bar", stringResult);
 
+            // Act
             attribute.OnActionExecuted(actionExecutedContext);
 
+            // Assert
             Assert.Equal(HttpStatusCode.OK, actionExecutedContext.Response.StatusCode);
             Assert.Equal(stringResult, ((ObjectContent)actionExecutedContext.Response.Content).Value);
         }
@@ -1067,12 +1070,15 @@ namespace System.Web.OData.Query
         [Fact]
         public void OnActionExecuted_ByteArrayValue()
         {
+            // Arrange
             byte[] bytesResult = BitConverter.GetBytes(42);
             EnableQueryAttribute attribute = new EnableQueryAttribute();
             HttpActionExecutedContext actionExecutedContext = GetActionExecutedContext("http://localhost/Suppliers(1)/Version?customqueryoption=bar", bytesResult);
 
+            // Act
             attribute.OnActionExecuted(actionExecutedContext);
 
+            // Assert
             Assert.Equal(HttpStatusCode.OK, actionExecutedContext.Response.StatusCode);
             Assert.Equal(bytesResult, ((ObjectContent)actionExecutedContext.Response.Content).Value);
         }

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/EnableQueryAttributeTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/EnableQueryAttributeTest.cs
@@ -1051,6 +1051,32 @@ namespace System.Web.OData.Query
             Assert.Equal(customer, ((ObjectContent)actionExecutedContext.Response.Content).Value);
         }
 
+        [Fact]
+        public void OnActionExecuted_StringValue()
+        {
+            string stringResult = "foo";
+            EnableQueryAttribute attribute = new EnableQueryAttribute();
+            HttpActionExecutedContext actionExecutedContext = GetActionExecutedContext("http://localhost/Suppliers(1)/CompanyName?customqueryoption=bar", stringResult);
+
+            attribute.OnActionExecuted(actionExecutedContext);
+
+            Assert.Equal(HttpStatusCode.OK, actionExecutedContext.Response.StatusCode);
+            Assert.Equal(stringResult, ((ObjectContent)actionExecutedContext.Response.Content).Value);
+        }
+
+        [Fact]
+        public void OnActionExecuted_ByteArrayValue()
+        {
+            byte[] bytesResult = BitConverter.GetBytes(42);
+            EnableQueryAttribute attribute = new EnableQueryAttribute();
+            HttpActionExecutedContext actionExecutedContext = GetActionExecutedContext("http://localhost/Suppliers(1)/Version?customqueryoption=bar", bytesResult);
+
+            attribute.OnActionExecuted(actionExecutedContext);
+
+            Assert.Equal(HttpStatusCode.OK, actionExecutedContext.Response.StatusCode);
+            Assert.Equal(bytesResult, ((ObjectContent)actionExecutedContext.Response.Content).Value);
+        }
+
         private void SomeAction()
         {
         }


### PR DESCRIPTION
### Issues
This pull request fixes issue #970.

### Description
Handle for case when property value is either a string or a byte array.

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
No docs needs.
