### PR TITLE
Users/kokosins/agg for dynamic

### DIFF
--- a/src/System.Web.OData/OData/ExpressionHelperMethods.cs
+++ b/src/System.Web.OData/OData/ExpressionHelperMethods.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -72,6 +73,8 @@ namespace System.Web.OData
         };
 
         private static MethodInfo _enumerableCountMethod = GenericMethodOf(_ => Enumerable.LongCount<int>(default(IEnumerable<int>)));
+
+        private static MethodInfo _safeConvertToDecimalMethod = typeof(ExpressionHelperMethods).GetMethod("SafeConvertToDecimal");
 
         public static MethodInfo QueryableOrderByGeneric
         {
@@ -246,6 +249,33 @@ namespace System.Web.OData
         public static MethodInfo EnumerableCountGeneric
         {
             get { return _enumerableCountMethod; }
+        }
+
+        public static MethodInfo ConvertToDecimal
+        {
+            get { return _safeConvertToDecimalMethod; }
+        }
+
+        public static decimal? SafeConvertToDecimal(object value)
+        {
+            if (value == null || value == DBNull.Value)
+            {
+                return null;
+            }
+
+            var type = value.GetType();
+            type = Nullable.GetUnderlyingType(type) ?? type;
+            if (type == typeof(Int16)
+                || type == typeof(Int32)
+                || type == typeof(Int64)
+                || type == typeof(Decimal)
+                || type == typeof(Double)
+                || type == typeof(float))
+            {
+                return (decimal?)Convert.ChangeType(value, typeof(decimal), CultureInfo.InvariantCulture);
+            }
+            
+            return null;
         }
 
         private static MethodInfo GenericMethodOf<TReturn>(Expression<Func<object, TReturn>> expression)

--- a/src/System.Web.OData/OData/Query/Expressions/AggregationBinder.cs
+++ b/src/System.Web.OData/OData/Query/Expressions/AggregationBinder.cs
@@ -174,7 +174,8 @@ namespace System.Web.OData.Query.Expressions
 
         private Expression CreateAggregationExpression(ParameterExpression accum, AggregateExpression expression)
         {
-            LambdaExpression propertyLambda = Expression.Lambda(BindAccessor(expression.Expression),
+            Expression propertyAccessor = BindAccessor(expression.Expression);
+            LambdaExpression propertyLambda = Expression.Lambda(propertyAccessor,
                 this._lambdaParameter);
             // I substitute the element type for all generic arguments.                                                
             var asQuerableMethod = ExpressionHelperMethods.QueryableAsQueryable.MakeGenericMethod(this._elementType);
@@ -185,72 +186,101 @@ namespace System.Web.OData.Query.Expressions
             switch (expression.Method)
             {
                 case AggregationMethod.Min:
-                {
-                    var minMethod = ExpressionHelperMethods.QueryableMin.MakeGenericMethod(this._elementType,
-                        propertyLambda.Body.Type);
-                    aggregationExpression = Expression.Call(null, minMethod, asQuerableExpression, propertyLambda);
-                }
+                    {
+                        var minMethod = ExpressionHelperMethods.QueryableMin.MakeGenericMethod(this._elementType,
+                            propertyLambda.Body.Type);
+                        aggregationExpression = Expression.Call(null, minMethod, asQuerableExpression, propertyLambda);
+                    }
                     break;
                 case AggregationMethod.Max:
-                {
-                    var maxMethod = ExpressionHelperMethods.QueryableMax.MakeGenericMethod(this._elementType,
-                        propertyLambda.Body.Type);
-                    aggregationExpression = Expression.Call(null, maxMethod, asQuerableExpression, propertyLambda);
-                }
+                    {
+                        var maxMethod = ExpressionHelperMethods.QueryableMax.MakeGenericMethod(this._elementType,
+                            propertyLambda.Body.Type);
+                        aggregationExpression = Expression.Call(null, maxMethod, asQuerableExpression, propertyLambda);
+                    }
                     break;
                 case AggregationMethod.Sum:
-                {
-                    MethodInfo sumGenericMethod;
-                    if (
-                        !ExpressionHelperMethods.QueryableSumGenerics.TryGetValue(propertyLambda.Body.Type,
-                            out sumGenericMethod))
                     {
-                        throw new ODataException(Error.Format(SRResources.AggregationNotSupportedForType,
-                            expression.Method, expression.Expression, propertyLambda.Body.Type));
+                        MethodInfo sumGenericMethod;
+                        // For Dynamic properties cast to decimal
+                        Expression propertyExpression = WrapDynamicCastIfNeeded(propertyAccessor);
+                        propertyLambda = Expression.Lambda(propertyExpression, this._lambdaParameter);
+                        if (
+                            !ExpressionHelperMethods.QueryableSumGenerics.TryGetValue(propertyExpression.Type,
+                                out sumGenericMethod))
+                        {
+                            throw new ODataException(Error.Format(SRResources.AggregationNotSupportedForType,
+                                expression.Method, expression.Expression, propertyExpression.Type));
+                        }
+                        var sumMethod = sumGenericMethod.MakeGenericMethod(this._elementType);
+                        aggregationExpression = Expression.Call(null, sumMethod, asQuerableExpression, propertyLambda);
+
+                        // For Dynamic properties cast back to object 
+                        if (propertyAccessor.Type == typeof(object))
+                        {
+                            aggregationExpression = Expression.Convert(aggregationExpression, typeof(object));
+                        }
                     }
-                    var sumMethod = sumGenericMethod.MakeGenericMethod(this._elementType);
-                    aggregationExpression = Expression.Call(null, sumMethod, asQuerableExpression, propertyLambda);
-                }
                     break;
                 case AggregationMethod.Average:
-                {
-                    MethodInfo averageGenericMethod;
-                    if (
-                        !ExpressionHelperMethods.QueryableAverageGenerics.TryGetValue(propertyLambda.Body.Type,
-                            out averageGenericMethod))
                     {
-                        throw new ODataException(Error.Format(SRResources.AggregationNotSupportedForType,
-                            expression.Method, expression.Expression, propertyLambda.Body.Type));
+                        MethodInfo averageGenericMethod;
+                        // For Dynamic properties cast to decimal
+                        Expression propertyExpression = WrapDynamicCastIfNeeded(propertyAccessor);
+                        propertyLambda = Expression.Lambda(propertyExpression, this._lambdaParameter);
+
+                        if (
+                            !ExpressionHelperMethods.QueryableAverageGenerics.TryGetValue(propertyExpression.Type,
+                                out averageGenericMethod))
+                        {
+                            throw new ODataException(Error.Format(SRResources.AggregationNotSupportedForType,
+                                expression.Method, expression.Expression, propertyExpression.Type));
+                        }
+                        var averageMethod = averageGenericMethod.MakeGenericMethod(this._elementType);
+                        aggregationExpression = Expression.Call(null, averageMethod, asQuerableExpression, propertyLambda);
+
+                        // For Dynamic properties cast back to object 
+                        if (propertyAccessor.Type == typeof(object))
+                        {
+                            aggregationExpression = Expression.Convert(aggregationExpression, typeof(object));
+                        }
                     }
-                    var averageMethod = averageGenericMethod.MakeGenericMethod(this._elementType);
-                    aggregationExpression = Expression.Call(null, averageMethod, asQuerableExpression, propertyLambda);
-                }
                     break;
                 case AggregationMethod.CountDistinct:
-                {
-                    // I select the specific field 
-                    var selectMethod =
-                        ExpressionHelperMethods.QueryableSelectGeneric.MakeGenericMethod(this._elementType,
-                            propertyLambda.Body.Type);
-                    Expression queryableSelectExpression = Expression.Call(null, selectMethod, asQuerableExpression,
-                        propertyLambda);
+                    {
+                        // I select the specific field 
+                        var selectMethod =
+                            ExpressionHelperMethods.QueryableSelectGeneric.MakeGenericMethod(this._elementType,
+                                propertyLambda.Body.Type);
+                        Expression queryableSelectExpression = Expression.Call(null, selectMethod, asQuerableExpression,
+                            propertyLambda);
 
-                    // I run distinct over the set of items
-                    var distinctMethod =
-                        ExpressionHelperMethods.QueryableDistinct.MakeGenericMethod(propertyLambda.Body.Type);
-                    Expression distinctExpression = Expression.Call(null, distinctMethod, queryableSelectExpression);
+                        // I run distinct over the set of items
+                        var distinctMethod =
+                            ExpressionHelperMethods.QueryableDistinct.MakeGenericMethod(propertyLambda.Body.Type);
+                        Expression distinctExpression = Expression.Call(null, distinctMethod, queryableSelectExpression);
 
-                    // I count the distinct items as the aggregation expression
-                    var countMethod =
-                        ExpressionHelperMethods.QueryableCountGeneric.MakeGenericMethod(propertyLambda.Body.Type);
-                    aggregationExpression = Expression.Call(null, countMethod, distinctExpression);
-                }
+                        // I count the distinct items as the aggregation expression
+                        var countMethod =
+                            ExpressionHelperMethods.QueryableCountGeneric.MakeGenericMethod(propertyLambda.Body.Type);
+                        aggregationExpression = Expression.Call(null, countMethod, distinctExpression);
+                    }
                     break;
                 default:
                     throw new ODataException(Error.Format(SRResources.AggregationMethodNotSupported, expression.Method));
             }
 
             return aggregationExpression;
+        }
+
+        private static Expression WrapDynamicCastIfNeeded(Expression propertyAccessor)
+        {
+            if (propertyAccessor.Type == typeof(object))
+            {
+                return Expression.Call(null, ExpressionHelperMethods.ConvertToDecimal, propertyAccessor);
+            }
+
+            return propertyAccessor;
         }
 
         private Expression BindAccessor(SingleValueNode node)
@@ -264,7 +294,7 @@ namespace System.Web.OData.Query.Expressions
                     return CreatePropertyAccessExpression(BindAccessor(propAccessNode.Source), propAccessNode.Property);
                 case QueryNodeKind.SingleValueOpenPropertyAccess:
                     var openNode = node as SingleValueOpenPropertyAccessNode;
-                    return Expression.Property(BindAccessor(openNode.Source), openNode.Name);
+                    return CreateOpenPropertyAccessExpression(openNode);
                 case QueryNodeKind.SingleNavigationNode:
                     var navNode = node as SingleNavigationNode;
                     return CreatePropertyAccessExpression(BindAccessor(navNode.Source), navNode.NavigationProperty);
@@ -305,6 +335,44 @@ namespace System.Web.OData.Query.Expressions
             else
             {
                 return ConvertNonStandardPrimitives(Expression.Property(source, propertyName));
+            }
+        }
+
+        private Expression CreateOpenPropertyAccessExpression(SingleValueOpenPropertyAccessNode openNode)
+        {
+            var sourceAccessor = BindAccessor(openNode.Source);
+
+            // First check that property exists in source
+            // It's the case when we are apply transformation based on earlier transformation
+            if (sourceAccessor.Type.GetProperty(openNode.Name) != null)
+            {
+                return Expression.Property(sourceAccessor, openNode.Name);
+            }
+
+            // Property doesn't exists go for dynamic properties dictionary
+            PropertyInfo prop = GetDynamicPropertyContainer(openNode);
+            var propertyAccessExpression = Expression.Property(sourceAccessor, prop.Name);
+            var readDictionaryIndexerExpression = Expression.Property(propertyAccessExpression,
+                            DictionaryStringObjectIndexerName, Expression.Constant(openNode.Name));
+            var containsKeyExpression = Expression.Call(propertyAccessExpression,
+                propertyAccessExpression.Type.GetMethod("ContainsKey"), Expression.Constant(openNode.Name));
+            var nullExpression = Expression.Constant(null);
+
+            if (_querySettings.HandleNullPropagation == HandleNullPropagationOption.True)
+            {
+                var dynamicDictIsNotNull = Expression.NotEqual(propertyAccessExpression, Expression.Constant(null));
+                var dynamicDictIsNotNullAndContainsKey = Expression.AndAlso(dynamicDictIsNotNull, containsKeyExpression);
+                return Expression.Condition(
+                    dynamicDictIsNotNullAndContainsKey,
+                    readDictionaryIndexerExpression,
+                    nullExpression);
+            }
+            else
+            {
+                return Expression.Condition(
+                    containsKeyExpression,
+                    readDictionaryIndexerExpression,
+                    nullExpression);
             }
         }
 

--- a/src/System.Web.OData/OData/Query/Expressions/AggregationDynamicTypeProvider.cs
+++ b/src/System.Web.OData/OData/Query/Expressions/AggregationDynamicTypeProvider.cs
@@ -49,9 +49,9 @@ namespace System.Web.OData.Query.Expressions
             {
                 foreach (var field in expressions)
                 {
-                    if (field.TypeReference.Definition.TypeKind == EdmTypeKind.Primitive)
+                    if (field.TypeReference == null || field.TypeReference.Definition.TypeKind == EdmTypeKind.Primitive)
                     {
-                        var primitiveType = EdmLibHelpers.GetClrType(field.TypeReference, model);
+                        var primitiveType = field.TypeReference == null ? typeof(object) : EdmLibHelpers.GetClrType(field.TypeReference, model);
                         CreateProperty(tb, field.Alias, primitiveType);
                     }
                 }
@@ -61,9 +61,9 @@ namespace System.Web.OData.Query.Expressions
             {
                 foreach (var field in propertyNodes)
                 {
-                    if (field.Expression != null && field.TypeReference.Definition.TypeKind == EdmTypeKind.Primitive)
+                    if (field.Expression != null && (field.TypeReference == null || field.TypeReference.Definition.TypeKind == EdmTypeKind.Primitive))
                     {
-                        var primitiveType = EdmLibHelpers.GetClrType(field.TypeReference, model);
+                        var primitiveType = field.TypeReference == null ? typeof(object) : EdmLibHelpers.GetClrType(field.TypeReference, model);
                         CreateProperty(tb, field.Name, primitiveType);
                     }
                     else

--- a/src/System.Web.OData/OData/Query/Expressions/FilterBinder.cs
+++ b/src/System.Web.OData/OData/Query/Expressions/FilterBinder.cs
@@ -29,8 +29,6 @@ namespace System.Web.OData.Query.Expressions
     {
         private const string ODataItParameterName = "$it";
 
-        private static readonly string _dictionaryStringObjectIndexerName = typeof(Dictionary<string, object>).GetDefaultMembers()[0].Name;
-
         private Stack<Dictionary<string, ParameterExpression>> _parametersStack = new Stack<Dictionary<string, ParameterExpression>>();
         private Dictionary<string, ParameterExpression> _lambdaParameters;
         private Type _filterType;
@@ -252,7 +250,7 @@ namespace System.Web.OData.Query.Expressions
 
             var propertyAccessExpression = BindPropertyAccessExpression(openNode, prop);
             var readDictionaryIndexerExpression = Expression.Property(propertyAccessExpression,
-                _dictionaryStringObjectIndexerName, Expression.Constant(openNode.Name));
+                DictionaryStringObjectIndexerName, Expression.Constant(openNode.Name));
             var containsKeyExpression = Expression.Call(propertyAccessExpression,
                 propertyAccessExpression.Type.GetMethod("ContainsKey"), Expression.Constant(openNode.Name));
             var nullExpression = Expression.Constant(null);
@@ -289,26 +287,6 @@ namespace System.Web.OData.Query.Expressions
                 propertyAccessExpression = Expression.Property(source, prop.Name);
             }
             return propertyAccessExpression;
-        }
-
-        private PropertyInfo GetDynamicPropertyContainer(SingleValueOpenPropertyAccessNode openNode)
-        {
-            IEdmStructuredType edmStructuredType;
-            var edmTypeReference = openNode.Source.TypeReference;
-            if (edmTypeReference.IsEntity())
-            {
-                edmStructuredType = edmTypeReference.AsEntity().EntityDefinition();
-            }
-            else if (edmTypeReference.IsComplex())
-            {
-                edmStructuredType = edmTypeReference.AsComplex().ComplexDefinition();
-            }
-            else
-            {
-                throw Error.NotSupported(SRResources.QueryNodeBindingNotSupported, openNode.Kind, typeof(FilterBinder).Name);
-            }
-            var prop = EdmLibHelpers.GetDynamicPropertyDictionary(edmStructuredType, _model);
-            return prop;
         }
 
         private Expression BindSingleEntityFunctionCallNode(SingleEntityFunctionCallNode node)

--- a/test/UnitTest/System.Web.OData.Test/OData/Builder/TestModels/Customer.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Builder/TestModels/Customer.cs
@@ -17,5 +17,6 @@ namespace System.Web.OData.Builder.TestModels
         public List<Order> Orders { get; set; }
         public List<string> Aliases { get; set; }
         public List<Address> Addresses { get; set; }
+        public Dictionary<string, object> DynamicProperties { get; set; }
     }
 }

--- a/test/UnitTest/System.Web.OData.Test/OData/Query/ApplyQueryOptionTest.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Query/ApplyQueryOptionTest.cs
@@ -157,6 +157,68 @@ namespace System.Web.OData.Test.OData.Query
                             new Dictionary<string, object> { { "Website", null} },
                         }
                     },
+                    {
+                        "aggregate(IntProp with max as MaxIntProp)",
+                        new List<Dictionary<string, object>>
+                        {
+                            new Dictionary<string, object> { { "MaxIntProp", 2} }
+                        }
+                    },
+                    {
+                        "aggregate(IntProp with min as MinIntProp)",
+                        new List<Dictionary<string, object>>
+                        {
+                            new Dictionary<string, object> { { "MinIntProp", 1} }
+                        }
+                    },
+                    {
+                        "aggregate(IntProp with countdistinct as DistinctIntProp)",
+                        new List<Dictionary<string, object>>
+                        {
+                            new Dictionary<string, object> { { "DistinctIntProp", 3L} }
+                        }
+                    },
+                    {
+                        "aggregate(IntProp with sum as TotalIntProp)",
+                        new List<Dictionary<string, object>>
+                        {
+                            new Dictionary<string, object> { { "TotalIntProp", 3M} }
+                        }
+                    },
+                    {
+                        "aggregate(IntProp with average as TotalIntProp)",
+                        new List<Dictionary<string, object>>
+                        {
+                            new Dictionary<string, object> { { "TotalIntProp", 1.5M} }
+                        }
+                    },
+                    {
+                        "aggregate(MixedProp with sum as TotalMixedProp)",
+                        new List<Dictionary<string, object>>
+                        {
+                            new Dictionary<string, object> { { "TotalMixedProp", 1M} }
+                        }
+                    },
+                    {
+                        "groupby((StringProp), aggregate(IntProp with min as MinIntProp))",
+                        new List<Dictionary<string, object>>
+                        {
+                            new Dictionary<string, object> { { "StringProp", "Test1" }, { "MinIntProp", 1} },
+                            new Dictionary<string, object> { { "StringProp", "Test2" }, { "MinIntProp", 2} },
+                            new Dictionary<string, object> { { "StringProp", "Test3" }, { "MinIntProp", null} },
+                            new Dictionary<string, object> { { "StringProp", null }, { "MinIntProp", null} },
+                        }
+                    },
+                    {
+                        "groupby((StringProp), aggregate(IntProp with min as MinIntProp))/groupby((StringProp))",
+                        new List<Dictionary<string, object>>
+                        {
+                            new Dictionary<string, object> { { "StringProp", "Test1" } },
+                            new Dictionary<string, object> { { "StringProp", "Test2" } },
+                            new Dictionary<string, object> { { "StringProp", "Test3" } },
+                            new Dictionary<string, object> { { "StringProp", null } },
+                        }
+                    },
                 };
             }
         }
@@ -268,6 +330,7 @@ namespace System.Web.OData.Test.OData.Query
                     Name = "Lowest",
                     SharePrice = 10,
                     Address = new Address { City = "redmond", State = "WA" },
+                    DynamicProperties = new Dictionary<string, object> { { "StringProp", "Test1" }, { "IntProp", 1 }, { "MixedProp", 1 } }
                 };
                 c.Orders = new List<Order>
                 {
@@ -282,7 +345,8 @@ namespace System.Web.OData.Test.OData.Query
                     Name = "Highest",
                     SharePrice = 2.5M,
                     Address = new Address { City = "seattle", State = "WA" },
-                    Aliases = new List<string> { "alias2", "alias2" }
+                    Aliases = new List<string> { "alias2", "alias2" },
+                    DynamicProperties = new Dictionary<string, object> { { "StringProp", "Test2" }, { "IntProp", 2 }, { "MixedProp", "String" } }
                 };
                 customerList.Add(c);
 
@@ -291,7 +355,8 @@ namespace System.Web.OData.Test.OData.Query
                     CustomerId = 3,
                     Name = "Middle",
                     Address = new Address { City = "hobart" },
-                    Aliases = new List<string> { "alias2", "alias34", "alias31" }
+                    Aliases = new List<string> { "alias2", "alias34", "alias31" },
+                    DynamicProperties = new Dictionary<string, object> { { "StringProp", "Test3" } }
                 };
                 customerList.Add(c);
 
@@ -299,7 +364,7 @@ namespace System.Web.OData.Test.OData.Query
                 {
                     CustomerId = 4,
                     Name = "Lowest",
-                    Aliases = new List<string> { "alias34", "alias4" }
+                    Aliases = new List<string> { "alias34", "alias4" },
                 };
                 customerList.Add(c);
 

--- a/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/AggregationBinderTests.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/AggregationBinderTests.cs
@@ -56,6 +56,15 @@ namespace System.Web.OData.Query.Expressions
                 + ".Select($it => new DynamicTypeWrapper() {Category = new DynamicTypeWrapperCategory() {CategoryName = $it.Key.Category.CategoryName, }, SupplierAddress = new DynamicTypeWrapperSupplierAddress() {State = $it.Key.SupplierAddress.State, }, })");
         }
 
+        [Fact]
+        public void SingleDynamicGroupBy()
+        {
+            var filters = VerifyQueryDeserialization<DynamicProduct>(
+                "groupby((ProductProperty))",
+                ".GroupBy($it => new DynamicTypeWrapper() {ProductProperty = IIF($it.ProductProperties.ContainsKey(ProductProperty), $it.ProductPropertiesProductProperty, null), })"
+                + ".Select($it => new DynamicTypeWrapper() {ProductProperty = $it.Key.ProductProperty, })");
+        }
+
 
         [Fact]
         public void SingleSum()
@@ -67,12 +76,30 @@ namespace System.Web.OData.Query.Expressions
         }
 
         [Fact]
+        public void SingleDynamicSum()
+        {
+            var filters = VerifyQueryDeserialization<DynamicProduct>(
+                "aggregate(ProductProperty with sum as ProductProperty)",
+                ".GroupBy($it => new DynamicTypeWrapper())"
+                + ".Select($it => new DynamicTypeWrapper() {ProductProperty = Convert($it.AsQueryable().Sum($it => IIF($it.ProductProperties.ContainsKey(ProductProperty), $it.ProductPropertiesProductProperty, null).SafeConvertToDecimal())), })");
+        }
+
+        [Fact]
         public void SingleMin()
         {
             var filters = VerifyQueryDeserialization(
                 "aggregate(SupplierID with min as SupplierID)",
                 ".GroupBy($it => new DynamicTypeWrapper())"
                 + ".Select($it => new DynamicTypeWrapper() {SupplierID = $it.AsQueryable().Min($it => $it.SupplierID), })");
+        }
+
+        [Fact]
+        public void SingleDynamicMin()
+        {
+            var filters = VerifyQueryDeserialization<DynamicProduct>(
+                "aggregate(ProductProperty with min as MinProductProperty)",
+                ".GroupBy($it => new DynamicTypeWrapper())"
+                + ".Select($it => new DynamicTypeWrapper() {MinProductProperty = $it.AsQueryable().Min($it => IIF($it.ProductProperties.ContainsKey(ProductProperty), $it.ProductPropertiesProductProperty, null)), })");
         }
 
         [Fact]

--- a/test/UnitTest/System.Web.OData.Test/TestCommon/UsefulBuilders.cs
+++ b/test/UnitTest/System.Web.OData.Test/TestCommon/UsefulBuilders.cs
@@ -117,9 +117,17 @@ namespace System.Web.OData
             return builder;
         }
 
-        public static ODataModelBuilder Add_Customer_EntityType_With_Address(this ODataModelBuilder builder)
+        public static ODataModelBuilder Add_Customer_EntityType_With_DynamicProperties(this ODataModelBuilder builder)
         {
             builder.Add_Customer_EntityType();
+            var customer = builder.EntityType<Customer>();
+            customer.HasDynamicProperties(c => c.DynamicProperties);
+            return builder;
+        }
+
+        public static ODataModelBuilder Add_Customer_EntityType_With_Address(this ODataModelBuilder builder)
+        {
+            builder.Add_Customer_EntityType_With_DynamicProperties();
             builder.Add_Address_ComplexType();
             var customer = builder.EntityType<Customer>();
             customer.ComplexProperty(c => c.Address);


### PR DESCRIPTION
### Issues
*This pull request fixes issue #760.*  

### Description
Dynamic properties don't have type. Relaxed null check in AggregateExpression and related changes in ApplyBinder to allow usage of dynamic properties in groupby clause

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
Depends on https://github.com/OData/odata.net/pull/798 
