### PR TITLE
Always remember the instance provided to the SelectExpandBinder so it can be accessed during serialization

### DIFF
--- a/OData/src/System.Web.OData/OData/Query/Expressions/SelectExpandBinder.cs
+++ b/OData/src/System.Web.OData/OData/Query/Expressions/SelectExpandBinder.cs
@@ -262,13 +262,15 @@ namespace System.Web.OData.Query.Expressions
             wrapperProperty = wrapperType.GetProperty("ModelID");
             wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, Expression.Constant(_modelID)));
 
+            // Initialize property 'Instance' on the wrapper class
+            // source => new Wrapper { Instance = element }
+            wrapperProperty = wrapperType.GetProperty("Instance");
+            wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, source));
+
             if (IsSelectAll(selectExpandClause))
             {
-                // Initialize property 'Instance' on the wrapper class
-                // source => new Wrapper { Instance = element }
-                wrapperProperty = wrapperType.GetProperty("Instance");
-                Contract.Assert(wrapperProperty != null);
-                wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, source));
+                wrapperProperty = wrapperType.GetProperty("UseInstanceForProperties");
+                wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, Expression.Constant(true)));
                 isInstancePropertySet = true;
             }
             else
@@ -277,9 +279,6 @@ namespace System.Web.OData.Query.Expressions
                 Expression typeName = CreateTypeNameExpression(source, entityType, _model);
                 if (typeName != null)
                 {
-                    wrapperProperty = wrapperType.GetProperty("TypeName");
-                    Contract.Assert(wrapperProperty != null);
-                    wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, typeName));
                     isTypeNamePropertySet = true;
                 }
             }

--- a/OData/src/System.Web.OData/OData/Query/Expressions/SelectExpandWrapper.cs
+++ b/OData/src/System.Web.OData/OData/Query/Expressions/SelectExpandWrapper.cs
@@ -12,47 +12,12 @@ using Newtonsoft.Json;
 
 namespace System.Web.OData.Query.Expressions
 {
-    internal abstract class SelectExpandWrapper : IEdmEntityObject, ISelectExpandWrapper
-    {
-        /// <summary>
-        /// Gets or sets the property container that contains the properties being expanded. 
-        /// </summary>
-        public PropertyContainer Container { get; set; }
-
-        /// <summary>
-        /// Gets or sets the instance of the element being selected and expanded.
-        /// </summary>
-        public object Instance { get; set; }
-
-        /// <summary>
-        /// An ID to uniquely identify the model in the <see cref="ModelContainer"/>.
-        /// </summary>
-        public string ModelID { get; set; }
-
-        /// <summary>
-        /// Indicates whether the underlying instance can be used to obtain property values.
-        /// </summary>
-        public bool UseInstanceForProperties { get; set; }
-
-        /// <inheritdoc />
-        public abstract IEdmTypeReference GetEdmType();
-
-        /// <inheritdoc />
-        public abstract IDictionary<string, object> ToDictionary();
-
-        /// <inheritdoc />
-        public abstract IDictionary<string, object> ToDictionary(Func<IEdmModel, IEdmStructuredType, IPropertyMapper> mapperProvider);
-
-        /// <inheritdoc />
-        public abstract bool TryGetPropertyValue(string propertyName, out object value);
-    }
-
     /// <summary>
     /// Represents a container class that contains properties that are either selected or expanded using $select and $expand.
     /// </summary>
     /// <typeparam name="TElement">The element being selected and expanded.</typeparam>
     [JsonConverter(typeof(SelectExpandWrapperConverter))]
-    internal class SelectExpandWrapper<TElement> : SelectExpandWrapper
+    internal class SelectExpandWrapper<TElement> : IEdmEntityObject, ISelectExpandWrapper
     {
         private static readonly IPropertyMapper DefaultPropertyMapper = new IdentityPropertyMapper();
         private static readonly Func<IEdmModel, IEdmStructuredType, IPropertyMapper> _mapperProvider =
@@ -61,8 +26,31 @@ namespace System.Web.OData.Query.Expressions
         private Dictionary<string, object> _containerDict;
         private TypedEdmEntityObject _typedEdmEntityObject;
 
+        /// <summary>
+        /// Gets or sets the instance of the element being selected and expanded.
+        /// </summary>
+        public TElement Instance { get; set; }
+
+        /// <summary>
+        /// An ID to uniquely identify the model in the <see cref="ModelContainer"/>.
+        /// </summary>
+        public string ModelID { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property container that contains the properties being expanded. 
+        /// </summary>
+        public PropertyContainer Container { get; set; }
+
+        /// <summary>
+        /// Indicates whether the underlying instance can be used to obtain property values.
+        /// </summary>
+        public bool UseInstanceForProperties { get; set; }
+
         /// <inheritdoc />
-        public override IEdmTypeReference GetEdmType()
+        object ISelectExpandWrapper.Instance { get { return this.Instance; } }
+
+        /// <inheritdoc />
+        public IEdmTypeReference GetEdmType()
         {
             IEdmModel model = GetModel();
             Type elementType = GetElementType();
@@ -70,7 +58,7 @@ namespace System.Web.OData.Query.Expressions
         }
 
         /// <inheritdoc />
-        public override bool TryGetPropertyValue(string propertyName, out object value)
+        public bool TryGetPropertyValue(string propertyName, out object value)
         {
             // look into the container first to see if it has that property. container would have it 
             // if the property was expanded.
@@ -96,12 +84,12 @@ namespace System.Web.OData.Query.Expressions
             return false;
         }
 
-        public override IDictionary<string, object> ToDictionary()
+        public IDictionary<string, object> ToDictionary()
         {
             return ToDictionary(_mapperProvider);
         }
 
-        public override IDictionary<string, object> ToDictionary(Func<IEdmModel, IEdmStructuredType, IPropertyMapper> mapperProvider)
+        public IDictionary<string, object> ToDictionary(Func<IEdmModel, IEdmStructuredType, IPropertyMapper> mapperProvider)
         {
             if (mapperProvider == null)
             {

--- a/OData/src/System.Web.OData/OData/Query/ISelectExpandWrapper.cs
+++ b/OData/src/System.Web.OData/OData/Query/ISelectExpandWrapper.cs
@@ -13,6 +13,11 @@ namespace System.Web.OData.Query
     public interface ISelectExpandWrapper
     {
         /// <summary>
+        /// The instance on which the selection and/or expansion will is taking place.
+        /// </summary>
+        object Instance { get; }
+
+        /// <summary>
         /// Projects the result of a $select and $expand query to a <see cref="IDictionary{TKey,TValue}" />.
         /// </summary>
         /// <returns>An <see cref="IDictionary{TKey,TValue}"/> representing the $select and $expand result.</returns>

--- a/OData/src/System.Web.OData/OData/ResourceContext.cs
+++ b/OData/src/System.Web.OData/OData/ResourceContext.cs
@@ -11,7 +11,7 @@ using System.Web.OData.Formatter;
 using System.Web.OData.Formatter.Deserialization;
 using System.Web.OData.Formatter.Serialization;
 using System.Web.OData.Properties;
-using System.Web.OData.Query.Expressions;
+using System.Web.OData.Query;
 using Microsoft.OData.Edm;
 
 namespace System.Web.OData
@@ -231,7 +231,7 @@ namespace System.Web.OData
                 return edmStructruredObject.Instance;
             }
 
-            SelectExpandWrapper selectExpandWrapper = EdmObject as SelectExpandWrapper;
+            ISelectExpandWrapper selectExpandWrapper = EdmObject as ISelectExpandWrapper;
             if (selectExpandWrapper != null && selectExpandWrapper.Instance != null)
             {
                 return selectExpandWrapper.Instance;

--- a/OData/src/System.Web.OData/OData/ResourceContext.cs
+++ b/OData/src/System.Web.OData/OData/ResourceContext.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
@@ -12,6 +11,7 @@ using System.Web.OData.Formatter;
 using System.Web.OData.Formatter.Deserialization;
 using System.Web.OData.Formatter.Serialization;
 using System.Web.OData.Properties;
+using System.Web.OData.Query.Expressions;
 using Microsoft.OData.Edm;
 
 namespace System.Web.OData
@@ -229,6 +229,12 @@ namespace System.Web.OData
             if (edmStructruredObject != null)
             {
                 return edmStructruredObject.Instance;
+            }
+
+            SelectExpandWrapper selectExpandWrapper = EdmObject as SelectExpandWrapper;
+            if (selectExpandWrapper != null && selectExpandWrapper.Instance != null)
+            {
+                return selectExpandWrapper.Instance;
             }
 
             Type clrType = EdmLibHelpers.GetClrType(StructuredType, EdmModel);

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
@@ -74,7 +74,7 @@ namespace System.Web.OData.Query.Expressions
             Assert.True(enumerator.MoveNext());
             var partialCustomer = Assert.IsAssignableFrom<SelectExpandWrapper<Customer>>(enumerator.Current);
             Assert.False(enumerator.MoveNext());
-            Assert.Null(partialCustomer.Instance);
+            Assert.NotNull(partialCustomer.Instance);
             IEnumerable<SelectExpandWrapper<Order>> innerOrders = partialCustomer.Container
                 .ToDictionary(mapper)["Orders"] as IEnumerable<SelectExpandWrapper<Order>>;
             Assert.NotNull(innerOrders);
@@ -340,9 +340,9 @@ namespace System.Web.OData.Query.Expressions
 
             // Assert
             Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
-            Assert.Empty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "Instance"));
+            Assert.NotEmpty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "Instance"));
             SelectExpandWrapper<Customer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Customer>;
-            Assert.Null(customerWrapper.Instance);
+            Assert.NotNull(customerWrapper.Instance);
         }
 
         [Fact]

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
@@ -200,7 +200,7 @@ namespace System.Web.OData.Query.Expressions
             IEnumerable<SelectExpandWrapper<Order>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<Order>>;
             Assert.NotNull(projectedOrders);
             Assert.Equal(pageSize + 1, projectedOrders.Count());
-            Assert.Equal(1, projectedOrders.First().Instance.ID);
+            Assert.Equal(1, ((Order)projectedOrders.First().Instance).ID);
         }
 
         [Fact]

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
@@ -200,7 +200,7 @@ namespace System.Web.OData.Query.Expressions
             IEnumerable<SelectExpandWrapper<Order>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<Order>>;
             Assert.NotNull(projectedOrders);
             Assert.Equal(pageSize + 1, projectedOrders.Count());
-            Assert.Equal(1, ((Order)projectedOrders.First().Instance).ID);
+            Assert.Equal(1, projectedOrders.First().Instance.ID);
         }
 
         [Fact]

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandWrapperTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandWrapperTest.cs
@@ -38,29 +38,6 @@ namespace System.Web.OData.Query.Expressions
         }
 
         [Fact]
-        public void GetEdmType_Returns_TypeFromTypeNameIfNotNull()
-        {
-            SelectExpandWrapper<int> wrapper = new SelectExpandWrapper<int> { TypeName = _model.Customer.FullName(), ModelID = _modelID };
-
-            IEdmTypeReference result = wrapper.GetEdmType();
-
-            Assert.Same(_model.Customer, result.Definition);
-        }
-
-        [Fact]
-        public void GetEdmType_ThrowsODataException_IfTypeFromTypeNameIsNotFoundInModel()
-        {
-            // Arrange
-            _modelID = ModelContainer.GetModelID(EdmCoreModel.Instance);
-            SelectExpandWrapper<int> wrapper = new SelectExpandWrapper<int> { TypeName = _model.Customer.FullName(), ModelID = _modelID };
-
-            // Act & Assert
-            Assert.Throws<InvalidOperationException>(
-                () => wrapper.GetEdmType(),
-                "Cannot find the resource type 'NS.Customer' in the model.");
-        }
-
-        [Fact]
         public void GetEdmType_Returns_InstanceType()
         {
             _model.Model.SetAnnotationValue(_model.Customer, new ClrTypeAnnotation(typeof(TestEntity)));

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandWrapperTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandWrapperTest.cs
@@ -93,6 +93,7 @@ namespace System.Web.OData.Query.Expressions
                     Container = container
                 };
             wrapper.Instance = new TestEntity { SampleProperty = expectedPropertyValue };
+            wrapper.UseInstanceForProperties = true;
 
             object value;
             bool result = wrapper.TryGetPropertyValue("SampleProperty", out value);
@@ -107,6 +108,7 @@ namespace System.Web.OData.Query.Expressions
             object expectedPropertyValue = new object();
             SelectExpandWrapper<TestEntity> wrapper = new SelectExpandWrapper<TestEntity> { ModelID = _modelID };
             wrapper.Instance = new TestEntity { SampleProperty = expectedPropertyValue };
+            wrapper.UseInstanceForProperties = true;
 
             object value;
             bool result = wrapper.TryGetPropertyValue("SampleProperty", out value);
@@ -126,6 +128,7 @@ namespace System.Web.OData.Query.Expressions
             object expectedPropertyValue = new object();
             SelectExpandWrapper<TestEntityWithAlias> wrapper = new SelectExpandWrapper<TestEntityWithAlias> { ModelID = _modelID };
             wrapper.Instance = new TestEntityWithAlias { SampleProperty = expectedPropertyValue };
+            wrapper.UseInstanceForProperties = true;
 
             // Act
             object value;
@@ -171,7 +174,8 @@ namespace System.Web.OData.Query.Expressions
             SelectExpandWrapper<TestEntity> testWrapper = new SelectExpandWrapper<TestEntity>
             {
                 Instance = new TestEntity { SampleProperty = 42 },
-                ModelID = ModelContainer.GetModelID(model)
+                ModelID = ModelContainer.GetModelID(model),
+                UseInstanceForProperties = true,
             };
 
             // Act
@@ -259,7 +263,8 @@ namespace System.Web.OData.Query.Expressions
             SelectExpandWrapper<TestEntity> testWrapper = new SelectExpandWrapper<TestEntity>
             {
                 Instance = new TestEntity { SampleProperty = 42 },
-                ModelID = ModelContainer.GetModelID(model)
+                ModelID = ModelContainer.GetModelID(model),
+                UseInstanceForProperties = true,
             };
 
             Mock<IPropertyMapper> mapperMock = new Mock<IPropertyMapper>();
@@ -288,7 +293,8 @@ namespace System.Web.OData.Query.Expressions
             SelectExpandWrapper<TestEntity> testWrapper = new SelectExpandWrapper<TestEntity>
             {
                 Instance = new TestEntity { SampleProperty = 42 },
-                ModelID = ModelContainer.GetModelID(model)
+                ModelID = ModelContainer.GetModelID(model),
+                UseInstanceForProperties = true,
             };
             
             Mock<IPropertyMapper> mapperMock = new Mock<IPropertyMapper>();

--- a/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/OData/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -2198,6 +2198,8 @@ public interface System.Web.OData.Query.IPropertyMapper {
 }
 
 public interface System.Web.OData.Query.ISelectExpandWrapper {
+	object Instance  { public abstract get; }
+
 	System.Collections.Generic.IDictionary`2[[System.String],[System.Object]] ToDictionary ()
 	System.Collections.Generic.IDictionary`2[[System.String],[System.Object]] ToDictionary (System.Func`3[[Microsoft.OData.Edm.IEdmModel],[Microsoft.OData.Edm.IEdmStructuredType],[System.Web.OData.Query.IPropertyMapper]] propertyMapperProvider)
 }


### PR DESCRIPTION
### Issues
This pull request is a prototype fix for #987

### Description
This change exposes an `object Instance` property on `ISelectExpandWrapper` and ensures it's always populated. This value can then be used in `ResourceContext` instead of unnecessarily rehydrating a lossy instance of the original.

The semantics of the `TryGetPropertyValue` and `ToDictionary` are retained by way of a flag that indicates whether the `Instance` value should be used as a source of property values.

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
This adds a new property to `ISelectExpandWrapper`, which is public. Documentation update may be required.
