### PR TITLE
By default, make build.cmd run all tests as to ensure nothing is missed.

### DIFF
--- a/.github/CONTRIBUTION.md
+++ b/.github/CONTRIBUTION.md
@@ -1,8 +1,8 @@
-#How to contribute?
+# How to contribute?
 There are many ways for you to contribute to OData Web API.  The easiest way is to participate in discussion of features and issues.  You can also contribute by sending pull requests of features or bug fixes to us.  Contribution to the documentations at our [GitHub Pages](http://odata.github.io/WebApi/) is also highly welcomed. 
-##Discussion
+## Discussion
 You can participate into discussions and ask questions about OData Web API at our [GitHub issues](https://github.com/OData/WebApi/issues). 
-###Bug reports
+### Bug reports
 When reporting a bug at the issue tracker, please use the following template:
 ```
 ### Description
@@ -21,16 +21,16 @@ When reporting a bug at the issue tracker, please use the following template:
 *Optional, details of the root cause if known*  
 ```
 
-##Pull requests
+## Pull requests
 Pull request of features and bug fixes are both welcomed. Before you send a pull request to us, there are a few steps you need to make sure you've followed. 
-###Complete a Contribution License Agreement (CLA)
+### Complete a Contribution License Agreement (CLA)
 You will need to complete a Contributor License Agreement (CLA). Briefly, this agreement testifies that you are granting us permission to use the submitted change according to the terms of the project's license, and that the work being submitted is under appropriate copyright.
 
 Please submit a Contributor License Agreement (CLA) before submitting a pull request. Please fill and submit the [Contribution License Agreement Form | Microsoft](https://cla.microsoft.com/). Be sure to include your GitHub user name along with the agreement. Only after we have received the signed CLA, we'll review the pull request that you send. You only need to do this once for contributing to any Microsoft open source projects. 
 
-###Create a new issue on the issue tracker and link the pull request to it
+### Create a new issue on the issue tracker and link the pull request to it
 You should have an issue created on the [issue tracker](https://github.com/OData/WebApi/issues) before you work on the pull request. After the OData Web API team has reviewed this issue and change its label to "accepting pull request", you can issue a pull request to us in which the link to the related issue is included.
-###Requirement of pull requests
+### Requirement of pull requests
 Your pull request should:
 
  - Include a description of what your change intends to do
@@ -39,21 +39,13 @@ Your pull request should:
  - Include adequate function tests, corresponding E2E tests
  - Pass all tests without error
 
-###Run test
+### Run test
 Function test
 ```
-cd OData
-build
-```
-
-Corresponding E2E test
-```
-cd OData
-build E2EV3 (or E2EV4)
+build quick
 ```
 
 Or you can just run all test
 ```
-cd OData
-build FULL
+build
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ These are maintenance branches for previous RTMs. Project archives only, contrib
 
 ### Building
 ```
-cd OData
 build.cmd
 ```
 
@@ -53,12 +52,11 @@ build.cmd EnableSkipStrongNames
 ```
 
 #### Run tests in cmd
-* `build.cmd` build project, and run unit tests.
-
 To run end-to-end tests, you need to open an **elevated** - Run as administrator - command prompt
-* `build.cmd e2eV4` build projects, run unit tests, and OData **v4** end-to-end tests.
-* `build.cmd e2eV3` build projects, run unit tests, and OData **v3** end-to-end tests.
-* `build.cmd full` build projects, run unit tests, OData **v4 and v3** end-to-end tests.
+
+* `build.cmd` build projects, run unit tests, and OData end-to-end tests.
+
+* `build.cmd quick` or `build.cmd -q` build project, and run unit tests
 
 To disable the SkipStrongNames:
 ```

--- a/build.cmd
+++ b/build.cmd
@@ -12,21 +12,45 @@ REM is not supported. Also handle x86 operating systems, where %ProgramFiles(x86
 REM %MSBuild% value when setting the variable and never quote %MSBuild% references.
 set MSBuild="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 if not exist %MSBuild% @set MSBuild="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
+set FullBuild=0
 
-if /I "%1" == "" goto BuildDefaults
+REM with no switches, run the full set of tests.
+if /I "%1" == "" (
+  set FullBuild=1
+  goto BuildDefaults
+)
+
+REM support quick build, unit tests only.
+if /I "%1" == "QUICK" (
+  set FullBuild=0
+  goto BuildDefaults
+)
+if /I "%1" == "-Q" (
+  set FullBuild=0
+  goto BuildDefaults
+)
+
+REM Continue to suport original switches for those
+REM who might have scripts setup to use them.
 if /I "%1" == "E2EV4" goto BuildE2EV4
-if /I "%1" == "FULL" goto BuildDefaults
+if /I "%1" == "FULL" (
+  set FullBuild=1
+  goto BuildDefaults
+)
 
+REM Build a specified target
 %MSBuild% WebApiOData.msbuild /m /nr:false /t:%* /p:Platform="Any CPU" /p:Desktop=true /v:M /fl /flp:LogFile=bin\msbuild.log;Verbosity=Normal
 if %ERRORLEVEL% neq 0 goto BuildFail
 goto BuildSuccess
 
+REM Build product code and unit tests
 :BuildDefaults
 %MSBuild% WebApiOData.msbuild /m /nr:false /p:Platform="Any CPU" /p:Desktop=true /v:M /fl /flp:LogFile=bin\msbuild.log;Verbosity=Normal
 if %ERRORLEVEL% neq 0 goto BuildFail
-if /I "%1" == "FULL" goto BuildE2EV4
+if %FullBuild% neq 0 goto BuildE2EV4
 goto BuildSuccess
 
+REM Build product and V4 End to End tests
 :BuildE2EV4
 echo *** E2EV4 Test against KatanaSelf ***
 PowerShell.exe -executionpolicy remotesigned -File tools\scripts\ReplaceAppConfigValue.ps1 test\E2ETest\WebStack.QA.Test.OData\App.config "Nuwa.DefaultHostTypes" "KatanaSelf"


### PR DESCRIPTION
### Description
By default, make build.cmd run all tests as to ensure nothing is missed.
Optionally, run build.cmd quick to run only the unit tests.

### Checklist (Uncheck if it is not completed)
- [   ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
None