### PR TITLE
handle single navigation expand filter

### DIFF
--- a/src/System.Web.OData/OData/EnableQueryAttribute.cs
+++ b/src/System.Web.OData/OData/EnableQueryAttribute.cs
@@ -161,6 +161,23 @@ namespace System.Web.OData
         }
 
         /// <summary>
+        /// Honor $filter inside $expand of non-collection navigation property.
+        /// The expanded property is only populated when the filter evaluates to true.
+        /// This setting is false by default.
+        /// </summary>
+        public bool HandleReferenceNavigationPropertyExpandFilter
+        {
+            get
+            {
+                return _querySettings.HandleReferenceNavigationPropertyExpandFilter;
+            }
+            set
+            {
+                _querySettings.HandleReferenceNavigationPropertyExpandFilter = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the query parameters that are allowed in queries.
         /// </summary>
         /// <value>The default includes all query options: $filter, $skip, $top, $orderby, $expand, $select, $count,

--- a/src/System.Web.OData/OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/System.Web.OData/OData/Query/Expressions/SelectExpandBinder.cs
@@ -187,9 +187,11 @@ namespace System.Web.OData.Query.Expressions
             Type nullablePropertyType = propertyValue.Type.ToNullable();
             Expression nullablePropertyValue = ExpressionHelpers.ToNullable(propertyValue);
 
-            if (filterClause != null && property.Type.IsCollection())
+            if (filterClause != null)
             {
-                IEdmTypeReference edmElementType = property.Type.AsCollection().ElementType();
+                bool isCollection = property.Type.IsCollection();
+
+                IEdmTypeReference edmElementType = (isCollection ? property.Type.AsCollection().ElementType() : property.Type);
                 Type clrElementType = EdmLibHelpers.GetClrType(edmElementType, _model);
                 if (clrElementType == null)
                 {
@@ -197,23 +199,48 @@ namespace System.Web.OData.Query.Expressions
                         edmElementType.FullName()));
                 }
 
-                Expression filterSource =
-                    typeof(IEnumerable).IsAssignableFrom(source.Type.GetProperty(propertyName).PropertyType)
-                        ? Expression.Call(
-                            ExpressionHelperMethods.QueryableAsQueryable.MakeGenericMethod(clrElementType),
-                            nullablePropertyValue)
-                        : nullablePropertyValue;
-                // TODO: Implement proper support for $select/$expand after $apply
-                Expression filterPredicate = FilterBinder.Bind(null, filterClause, clrElementType, _context.RequestContainer);
-                MethodCallExpression filterResult = Expression.Call(
-                    ExpressionHelperMethods.QueryableWhereGeneric.MakeGenericMethod(clrElementType),
-                    filterSource,
-                    filterPredicate);
+                Expression filterResult = nullablePropertyValue;
 
-                nullablePropertyType = filterResult.Type;
+                if (isCollection)
+                {
+                    Expression filterSource =
+                        typeof(IEnumerable).IsAssignableFrom(source.Type.GetProperty(propertyName).PropertyType)
+                            ? Expression.Call(
+                                ExpressionHelperMethods.QueryableAsQueryable.MakeGenericMethod(clrElementType),
+                                nullablePropertyValue)
+                            : nullablePropertyValue;
+
+                    // TODO: Implement proper support for $select/$expand after $apply
+                    Expression filterPredicate = FilterBinder.Bind(null, filterClause, clrElementType, _context.RequestContainer);
+                    filterResult = Expression.Call(
+                        ExpressionHelperMethods.QueryableWhereGeneric.MakeGenericMethod(clrElementType),
+                        filterSource,
+                        filterPredicate);
+
+                    nullablePropertyType = filterResult.Type;
+                }
+                else if(_settings.HandleReferenceNavigationPropertyExpandFilter)
+                {
+                    LambdaExpression filterLambdaExpression = FilterBinder.Bind(null, filterClause, clrElementType, _context.RequestContainer) as LambdaExpression;
+                    if(filterLambdaExpression == null)
+                    {
+                        throw new ODataException(Error.Format(SRResources.ExpandFilterExpressionNotLambdaExpression,
+                            property.Name, "LambdaExpression"));
+                    }
+
+                    ParameterExpression filterParameter = filterLambdaExpression.Parameters.First();
+                    Expression predicateExpression = new ReferenceNavigationPropertyExpandFilterVisitor(filterParameter, nullablePropertyValue).Visit(filterLambdaExpression.Body);
+
+                    // create expression similar to: 'predicateExpression == true ? nullablePropertyValue : null'
+                    filterResult = Expression.Condition(
+                        test: predicateExpression,
+                        ifTrue: nullablePropertyValue,
+                        ifFalse: Expression.Constant(value: null, type: nullablePropertyType));
+                }
+
                 if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
                 {
-                    // nullablePropertyValue == null ? null : filterResult
+                    // create expression similar to: 'nullablePropertyValue == null ? null : filterResult'
                     nullablePropertyValue = Expression.Condition(
                         test: Expression.Equal(nullablePropertyValue, Expression.Constant(value: null)),
                         ifTrue: Expression.Constant(value: null, type: nullablePropertyType),
@@ -227,7 +254,7 @@ namespace System.Web.OData.Query.Expressions
 
             if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
             {
-                // source == null ? null : propertyValue
+                // create expression similar to: 'source == null ? null : propertyValue'
                 propertyValue = Expression.Condition(
                     test: Expression.Equal(source, Expression.Constant(value: null)),
                     ifTrue: Expression.Constant(value: null, type: nullablePropertyType),
@@ -240,6 +267,28 @@ namespace System.Web.OData.Query.Expressions
             }
 
             return propertyValue;
+        }
+
+        private class ReferenceNavigationPropertyExpandFilterVisitor : ExpressionVisitor
+        {
+            private Expression _source;
+            private ParameterExpression _parameterExpression;
+
+            public ReferenceNavigationPropertyExpandFilterVisitor(ParameterExpression parameterExpression, Expression source)
+            {
+                _source = source;
+                _parameterExpression = parameterExpression;
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                if(node != _parameterExpression)
+                {
+                    throw new ODataException(Error.Format(SRResources.ReferenceNavigationPropertyExpandFilterVisitorUnexpectedParameter, node.Name));
+                }
+
+                return _source;
+            }
         }
 
         // Generates the expression

--- a/src/System.Web.OData/OData/Query/ODataQuerySettings.cs
+++ b/src/System.Web.OData/OData/Query/ODataQuerySettings.cs
@@ -110,6 +110,13 @@ namespace System.Web.OData.Query
             }
         }
 
+        /// <summary>
+        /// Honor $filter inside $expand of non-collection navigation property.
+        /// The expanded property is only populated when the filter evaluates to true.
+        /// This setting is false by default.
+        /// </summary>
+        public bool HandleReferenceNavigationPropertyExpandFilter { get; set; }
+
         internal void CopyFrom(ODataQuerySettings settings)
         {
             EnsureStableOrdering = settings.EnsureStableOrdering;
@@ -117,6 +124,7 @@ namespace System.Web.OData.Query
             HandleNullPropagation = settings.HandleNullPropagation;
             PageSize = settings.PageSize;
             ModelBoundPageSize = settings.ModelBoundPageSize;
+            HandleReferenceNavigationPropertyExpandFilter = settings.HandleReferenceNavigationPropertyExpandFilter;
         }
     }
 }

--- a/src/System.Web.OData/Properties/SRResources.Designer.cs
+++ b/src/System.Web.OData/Properties/SRResources.Designer.cs
@@ -673,6 +673,15 @@ namespace System.Web.OData.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to $filter in $expand of reference navigation property &apos;{0}&apos; is not expected type &apos;{1}&apos;.
+        /// </summary>
+        internal static string ExpandFilterExpressionNotLambdaExpression {
+            get {
+                return ResourceManager.GetString("ExpandFilterExpressionNotLambdaExpression", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot create an EDM model as the action &apos;{0}&apos; on controller &apos;{1}&apos; has a void return type..
         /// </summary>
         internal static string FailedToBuildEdmModelBecauseReturnTypeIsNull {
@@ -1848,6 +1857,15 @@ namespace System.Web.OData.Properties {
         internal static string RecursiveComplexTypesNotAllowed {
             get {
                 return ResourceManager.GetString("RecursiveComplexTypesNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found unexpected parameter &apos;{0}&apos;..
+        /// </summary>
+        internal static string ReferenceNavigationPropertyExpandFilterVisitorUnexpectedParameter {
+            get {
+                return ResourceManager.GetString("ReferenceNavigationPropertyExpandFilterVisitorUnexpectedParameter", resourceCulture);
             }
         }
         

--- a/src/System.Web.OData/Properties/SRResources.resx
+++ b/src/System.Web.OData/Properties/SRResources.resx
@@ -868,4 +868,10 @@
   <data name="PropertyOrPathWasRemovedFromContext" xml:space="preserve">
     <value>Property or path {0} isn't available in the current context. It was removed in earlier transformation.</value>
   </data>
+  <data name="ExpandFilterExpressionNotLambdaExpression" xml:space="preserve">
+    <value>$filter in $expand of reference navigation property '{0}' is not expected type '{1}'</value>
+  </data>
+  <data name="ReferenceNavigationPropertyExpandFilterVisitorUnexpectedParameter" xml:space="preserve">
+    <value>Found unexpected parameter '{0}'.</value>
+  </data>
 </root>

--- a/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
@@ -534,7 +534,7 @@ namespace System.Web.OData.Query.Expressions
         }
 
         [Fact]
-        public void CreatePropertyValueExpressionWithFilter_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
+        public void CreatePropertyValueExpressionWithFilter_Collection_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
         {
             // Arrange
             _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.Order, value: null);
@@ -554,7 +554,7 @@ namespace System.Web.OData.Query.Expressions
         }
 
         [Fact]
-        public void CreatePropertyValueExpressionWithFilter_Works_HandleNullPropagationOptionIsTrue()
+        public void CreatePropertyValueExpressionWithFilter_Collection_Works_HandleNullPropagationOptionIsTrue()
         {
             // Arrange
             _model.Model.SetAnnotationValue(_model.Order, new ClrTypeAnnotation(typeof(Order)));
@@ -590,7 +590,7 @@ namespace System.Web.OData.Query.Expressions
         }
 
         [Fact]
-        public void CreatePropertyValueExpressionWithFilter_Works_HandleNullPropagationOptionIsFalse()
+        public void CreatePropertyValueExpressionWithFilter_Collection_Works_HandleNullPropagationOptionIsFalse()
         {
             // Arrange
             _model.Model.SetAnnotationValue(_model.Order, new ClrTypeAnnotation(typeof(Order)));
@@ -622,6 +622,137 @@ namespace System.Web.OData.Query.Expressions
             var orders = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as IEnumerable<Order>;
             Assert.Single(orders);
             Assert.Equal(1, orders.ToList()[0].ID);
+        }
+
+        [Fact]
+        public void CreatePropertyValueExpressionWithFilter_Single_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
+        {
+            // Arrange
+            _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.Customer, value: null);
+            _settings.HandleReferenceNavigationPropertyExpandFilter = true;
+            var order = Expression.Constant(new Order());
+            var customerProperty = _model.Order.NavigationProperties().Single(p => p.Name == "Customer");
+
+            var parser = new ODataQueryOptionParser(
+                _model.Model,
+                _model.Customer,
+                _model.Customers,
+                new Dictionary<string, string> { { "$filter", "ID eq 1" } });
+            var filterCaluse = parser.ParseFilter();
+
+            // Act & Assert
+            Assert.Throws<ODataException>(
+                () => _binder.CreatePropertyValueExpressionWithFilter(_model.Order, customerProperty, order, filterCaluse),
+                "The provided mapping does not contain a resource for the resource type 'NS.Customer'.");
+        }
+
+        [Fact]
+        public void CreatePropertyValueExpressionWithFilter_Single_Works_IfSettingIsOff()
+        {
+            // Arrange
+            _settings.HandleReferenceNavigationPropertyExpandFilter = false;
+            var order = Expression.Constant(
+                    new Order
+                    {
+                        Customer = new Customer
+                        {
+                            ID = 1
+                        }
+                    }
+            );
+            var customerProperty = _model.Order.NavigationProperties().Single(p => p.Name == "Customer");
+
+            var parser = new ODataQueryOptionParser(
+                _model.Model,
+                _model.Customer,
+                _model.Customers,
+                new Dictionary<string, string> { { "$filter", "ID ne 1" } });
+            var filterCaluse = parser.ParseFilter();
+
+            // Act 
+            var filterInExpand = _binder.CreatePropertyValueExpressionWithFilter(_model.Order, customerProperty, order, filterCaluse);
+
+            // Assert            
+            var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as Customer;
+            Assert.NotNull(customer);
+            Assert.Equal(1, customer.ID);
+        }
+
+        [Fact]
+        public void CreatePropertyValueExpressionWithFilter_Single_Works_HandleNullPropagationOptionIsTrue()
+        {
+            // Arrange
+            _settings.HandleReferenceNavigationPropertyExpandFilter = true;
+            _settings.HandleNullPropagation = HandleNullPropagationOption.True;
+            var order = Expression.Constant(
+                    new Order
+                    {
+                        Customer = new Customer
+                        {
+                            ID = 1
+                        }
+                    }
+            );
+            var customerProperty = _model.Order.NavigationProperties().Single(p => p.Name == "Customer");
+
+            var parser = new ODataQueryOptionParser(
+                _model.Model,
+                _model.Customer,
+                _model.Customers,
+                new Dictionary<string, string> { { "$filter", "ID ne 1" } });
+            var filterCaluse = parser.ParseFilter();
+
+            // Act
+            var filterInExpand = _binder.CreatePropertyValueExpressionWithFilter(_model.Order, customerProperty, order, filterCaluse);
+            
+            // Assert
+            Assert.Equal(
+                string.Format(
+                    "IIF((value({0}) == null), null, IIF((value({0}).Customer == null), null, " +
+                    "IIF((value({0}).Customer.ID != value(System.Web.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]).TypedProperty), " +
+                    "value({0}).Customer, null)))",
+                    order.Type),
+                filterInExpand.ToString());
+            var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as Customer;
+            Assert.Null(customer);
+        }
+
+        [Fact]
+        public void CreatePropertyValueExpressionWithFilter_Single_Works_HandleNullPropagationOptionIsFalse()
+        {
+            // Arrange
+            _settings.HandleReferenceNavigationPropertyExpandFilter = true;
+            _settings.HandleNullPropagation = HandleNullPropagationOption.False;
+            var order = Expression.Constant(
+                    new Order
+                    {
+                        Customer = new Customer
+                        {
+                            ID = 1
+                        }
+                    }
+            );
+            var customerProperty = _model.Order.NavigationProperties().Single(p => p.Name == "Customer");
+
+            var parser = new ODataQueryOptionParser(
+                _model.Model,
+                _model.Customer,
+                _model.Customers,
+                new Dictionary<string, string> { { "$filter", "ID ne 1" } });
+            var filterCaluse = parser.ParseFilter();
+
+            // Act
+            var filterInExpand = _binder.CreatePropertyValueExpressionWithFilter(_model.Order, customerProperty, order, filterCaluse);
+
+            // Assert
+            Assert.Equal(
+                string.Format(
+                    "IIF((value({0}).Customer.ID != value(System.Web.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]).TypedProperty), " +
+                    "value({0}).Customer, null)",
+                    order.Type),
+                filterInExpand.ToString());
+            var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as Customer;
+            Assert.Null(customer);
         }
 
         [Fact]

--- a/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -375,6 +375,7 @@ public class System.Web.OData.EnableQueryAttribute : System.Web.Http.Filters.Act
 	bool EnableConstantParameterization  { public get; public set; }
 	bool EnsureStableOrdering  { public get; public set; }
 	HandleNullPropagationOption HandleNullPropagation  { public get; public set; }
+	bool HandleReferenceNavigationPropertyExpandFilter  { public get; public set; }
 	int MaxAnyAllExpressionDepth  { public get; public set; }
 	int MaxExpansionDepth  { public get; public set; }
 	int MaxNodeCount  { public get; public set; }
@@ -2340,6 +2341,7 @@ public class System.Web.OData.Query.ODataQuerySettings {
 	bool EnableConstantParameterization  { public get; public set; }
 	bool EnsureStableOrdering  { public get; public set; }
 	HandleNullPropagationOption HandleNullPropagation  { public get; public set; }
+	bool HandleReferenceNavigationPropertyExpandFilter  { public get; public set; }
 	System.Nullable`1[[System.Int32]] PageSize  { public get; public set; }
 }
 


### PR DESCRIPTION
### Description
Today nested $filter inside $expand of non-collection navigation property is ignored. This change introduces a ODataQuerySettings that honor the $filter. If the condition is not met, the navigation property returns null.

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed
