### PR TITLE
Allow WebApi tests to run in Debug configuration.

### DIFF
--- a/src/System.Web.OData/OData/Query/SkipQueryOption.cs
+++ b/src/System.Web.OData/OData/Query/SkipQueryOption.cs
@@ -97,7 +97,6 @@ namespace System.Web.OData.Query
                     
                     if (skipValue.HasValue && skipValue > Int32.MaxValue)
                     {
-                        Contract.Assert(skipValue.Value <= Int32.MaxValue);
                         throw new ODataException(Error.Format(
                             SRResources.SkipTopLimitExceeded,
                             Int32.MaxValue,

--- a/src/System.Web.OData/OData/Query/TopQueryOption.cs
+++ b/src/System.Web.OData/OData/Query/TopQueryOption.cs
@@ -97,7 +97,6 @@ namespace System.Web.OData.Query
 
                     if (topValue.HasValue && topValue > Int32.MaxValue)
                     {
-                        Contract.Assert(topValue.Value <= Int32.MaxValue);
                         throw new ODataException(Error.Format(
                             SRResources.SkipTopLimitExceeded,
                             Int32.MaxValue,

--- a/test/UnitTest/System.Web.OData.Test/OData/Query/TopQueryOptionTests.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Query/TopQueryOptionTests.cs
@@ -80,7 +80,7 @@ namespace System.Web.OData.Query
         [InlineData(" ")]
         [InlineData("-1")]
         [InlineData("6926906880")]
-        public void ApplyInvalidSkipQueryThrows(string topValue)
+        public void ApplyInvalidTopQueryThrows(string topValue)
         {
             var model = new ODataModelBuilder().Add_Customer_EntityType().Add_Customers_EntitySet().GetEdmModel();
             var context = new ODataQueryContext(model, typeof(Customer));


### PR DESCRIPTION
The Top and Skip tests that check for value greater than the maximum integer
causes assertions the require the dismal of a popup. As such, these tests
fail in an automated environment.

This change removes the assert to allow the debug versions of the tests to pass.