### PR TITLE
Add memory cache for storing compiled select/expand delegates

### DIFF
--- a/src/System.Web.OData/OData/EnableQueryAttribute.cs
+++ b/src/System.Web.OData/OData/EnableQueryAttribute.cs
@@ -341,6 +341,19 @@ namespace System.Web.OData
         }
 
         /// <summary>
+        /// Gets or sets the minimum amount of time $select and $expand evaluations will be cached. The value may be
+        /// set to <c>0</c> to disable caching completely.
+        /// </summary>
+        public int SelectExpandEvaluationCacheLifetimeSeconds
+        {
+            get { return _querySettings.SelectExpandCacheExpirationTimeSeconds; }
+            set
+            {
+                _querySettings.SelectExpandCacheExpirationTimeSeconds = value;
+            }
+        }
+
+        /// <summary>
         /// Performs the query composition after action is executed. It first tries to retrieve the IQueryable from the
         /// returning response message. It then validates the query from uri based on the validation settings on
         /// <see cref="EnableQueryAttribute"/>. It finally applies the query appropriately, and reset it back on

--- a/src/System.Web.OData/OData/Query/ODataQuerySettings.cs
+++ b/src/System.Web.OData/OData/Query/ODataQuerySettings.cs
@@ -13,6 +13,7 @@ namespace System.Web.OData.Query
         private HandleNullPropagationOption _handleNullPropagationOption = HandleNullPropagationOption.Default;
         private int? _pageSize;
         private int? _modelBoundPageSize;
+        private int? _selectExpandCacheLifetime;
 
         /// <summary>
         /// Instantiates a new instance of the <see cref="ODataQuerySettings"/> class
@@ -49,6 +50,30 @@ namespace System.Web.OData.Query
         }
 
         /// <summary>
+        /// Gets or sets the amount of time unused generated delegates will be retained.
+        /// </summary>
+        /// <value>
+        /// The amount of time a compiled delegate should be retained while not being used, or <c>0</c> to 
+        /// disable caching.
+        /// </value>
+        internal int SelectExpandCacheExpirationTimeSeconds
+        {
+            get
+            {
+                return _selectExpandCacheLifetime ?? 0;
+            }
+            set
+            {
+                if (value < 0)
+                {
+                    throw Error.ArgumentMustBeGreaterThanOrEqualTo("value", value, 0);
+                }
+
+                _selectExpandCacheLifetime = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether query composition should
         /// alter the original query when necessary to ensure a stable sort order.
         /// </summary>
@@ -59,7 +84,7 @@ namespace System.Web.OData.Query
         /// a stable sort order should set this value to <c>false</c>.
         /// The default value is <c>true</c>.</value>
         public bool EnsureStableOrdering { get; set; }
-
+        
         /// <summary>
         /// Gets or sets a value indicating how null propagation should
         /// be handled during query composition.
@@ -117,6 +142,7 @@ namespace System.Web.OData.Query
             HandleNullPropagation = settings.HandleNullPropagation;
             PageSize = settings.PageSize;
             ModelBoundPageSize = settings.ModelBoundPageSize;
+            SelectExpandCacheExpirationTimeSeconds = settings.SelectExpandCacheExpirationTimeSeconds;
         }
     }
 }

--- a/src/System.Web.OData/System.Web.OData.csproj
+++ b/src/System.Web.OData/System.Web.OData.csproj
@@ -23,7 +23,7 @@
     <Reference Include="Microsoft.Spatial, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\sln\packages\Microsoft.Spatial.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
-    </Reference>    
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\sln\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -46,6 +46,7 @@
       <HintPath>..\..\sln\packages\Microsoft.AspNet.WebApi.Client.5.2.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web.Http, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/test/UnitTest/System.Web.OData.Test/OData/Query/EnableQueryAttributeTest.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Query/EnableQueryAttributeTest.cs
@@ -224,6 +224,20 @@ namespace System.Web.OData.Query
         }
 
         [Fact]
+        public void SelectExpandEvaluationCacheLifetimeMinutes_Property_RoundTrips()
+        {
+            Assert.Reflection.IntegerProperty(
+                new EnableQueryAttribute(),
+                o => o.SelectExpandEvaluationCacheLifetimeSeconds,
+                expectedDefaultValue: 0,
+                minLegalValue: 0,
+                illegalLowerValue: -1,
+                illegalUpperValue: null,
+                maxLegalValue: int.MaxValue,
+                roundTripTestValue: 100);
+        }
+
+        [Fact]
         public void OnActionExecuted_Throws_Null_Context()
         {
             Assert.ThrowsArgumentNull(() => new EnableQueryAttribute().OnActionExecuted(null), "actionExecutedContext");

--- a/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -382,6 +382,7 @@ public class System.Web.OData.EnableQueryAttribute : System.Web.Http.Filters.Act
 	int MaxSkip  { public get; public set; }
 	int MaxTop  { public get; public set; }
 	int PageSize  { public get; public set; }
+	int SelectExpandEvaluationCacheLifetimeMinutes  { public get; public set; }
 
 	public virtual System.Linq.IQueryable ApplyQuery (System.Linq.IQueryable queryable, ODataQueryOptions queryOptions)
 	public virtual object ApplyQuery (object entity, ODataQueryOptions queryOptions)
@@ -394,7 +395,6 @@ public class System.Web.OData.ETagMessageHandler : System.Net.Http.DelegatingHan
 	public ETagMessageHandler ()
 
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	protected virtual System.Threading.Tasks.Task`1[[System.Net.Http.HttpResponseMessage]] SendAsync (System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
@@ -435,7 +435,6 @@ public class System.Web.OData.ODataNullValueMessageHandler : System.Net.Http.Del
 	public ODataNullValueMessageHandler ()
 
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	protected virtual System.Threading.Tasks.Task`1[[System.Net.Http.HttpResponseMessage]] SendAsync (System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
@@ -604,7 +603,6 @@ public abstract class System.Web.OData.Batch.ODataBatchRequestItem : IDisposable
 	protected abstract void Dispose (bool disposing)
 	public abstract System.Collections.Generic.IEnumerable`1[[System.IDisposable]] GetResourcesForDisposal ()
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public static System.Threading.Tasks.Task`1[[System.Net.Http.HttpResponseMessage]] SendMessageAsync (System.Net.Http.HttpMessageInvoker invoker, System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken, System.Collections.Generic.Dictionary`2[[System.String],[System.String]] contentIdToLocationMapping)
@@ -620,7 +618,6 @@ public abstract class System.Web.OData.Batch.ODataBatchResponseItem : IDisposabl
 	internal virtual bool IsResponseSuccessful ()
 	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, System.Net.Http.HttpResponseMessage response)
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, System.Net.Http.HttpResponseMessage response, System.Threading.CancellationToken cancellationToken)
@@ -695,7 +692,6 @@ public sealed class System.Web.OData.Batch.ODataBatchReaderExtensions {
 	public static System.Threading.Tasks.Task`1[[System.Collections.Generic.IList`1[[System.Net.Http.HttpRequestMessage]]]] ReadChangeSetRequestAsync (Microsoft.OData.ODataBatchReader reader, System.Guid batchId)
 
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	ExtensionAttribute(),
 	]
@@ -723,7 +719,6 @@ public sealed class System.Web.OData.Batch.ODataHttpContentExtensions {
 	public static System.Threading.Tasks.Task`1[[Microsoft.OData.ODataMessageReader]] GetODataMessageReaderAsync (System.Net.Http.HttpContent content, System.IServiceProvider requestContainer)
 
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	ExtensionAttribute(),
 	]
@@ -738,7 +733,6 @@ public class System.Web.OData.Batch.ChangeSetRequestItem : ODataBatchRequestItem
 	protected virtual void Dispose (bool disposing)
 	public virtual System.Collections.Generic.IEnumerable`1[[System.IDisposable]] GetResourcesForDisposal ()
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public virtual System.Threading.Tasks.Task`1[[System.Web.OData.Batch.ODataBatchResponseItem]] SendRequestAsync (System.Net.Http.HttpMessageInvoker invoker, System.Threading.CancellationToken cancellationToken)
@@ -752,7 +746,6 @@ public class System.Web.OData.Batch.ChangeSetResponseItem : ODataBatchResponseIt
 	protected virtual void Dispose (bool disposing)
 	internal virtual bool IsResponseSuccessful ()
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, System.Threading.CancellationToken cancellationToken)
@@ -762,19 +755,16 @@ public class System.Web.OData.Batch.DefaultODataBatchHandler : ODataBatchHandler
 	public DefaultODataBatchHandler (System.Web.Http.HttpServer httpServer)
 
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public virtual System.Threading.Tasks.Task`1[[System.Collections.Generic.IList`1[[System.Web.OData.Batch.ODataBatchResponseItem]]]] ExecuteRequestMessagesAsync (System.Collections.Generic.IEnumerable`1[[System.Web.OData.Batch.ODataBatchRequestItem]] requests, System.Threading.CancellationToken cancellationToken)
 
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public virtual System.Threading.Tasks.Task`1[[System.Collections.Generic.IList`1[[System.Web.OData.Batch.ODataBatchRequestItem]]]] ParseBatchRequestsAsync (System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
 
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public virtual System.Threading.Tasks.Task`1[[System.Net.Http.HttpResponseMessage]] ProcessBatchAsync (System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
@@ -787,7 +777,6 @@ public class System.Web.OData.Batch.ODataBatchContent : System.Net.Http.HttpCont
 
 	protected virtual void Dispose (bool disposing)
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	protected virtual System.Threading.Tasks.Task SerializeToStreamAsync (System.IO.Stream stream, System.Net.TransportContext context)
@@ -803,7 +792,6 @@ public class System.Web.OData.Batch.OperationRequestItem : ODataBatchRequestItem
 	protected virtual void Dispose (bool disposing)
 	public virtual System.Collections.Generic.IEnumerable`1[[System.IDisposable]] GetResourcesForDisposal ()
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public virtual System.Threading.Tasks.Task`1[[System.Web.OData.Batch.ODataBatchResponseItem]] SendRequestAsync (System.Net.Http.HttpMessageInvoker invoker, System.Threading.CancellationToken cancellationToken)
@@ -823,19 +811,16 @@ public class System.Web.OData.Batch.UnbufferedODataBatchHandler : ODataBatchHand
 	public UnbufferedODataBatchHandler (System.Web.Http.HttpServer httpServer)
 
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public virtual System.Threading.Tasks.Task`1[[System.Web.OData.Batch.ODataBatchResponseItem]] ExecuteChangeSetAsync (Microsoft.OData.ODataBatchReader batchReader, System.Guid batchId, System.Net.Http.HttpRequestMessage originalRequest, System.Threading.CancellationToken cancellationToken)
 
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public virtual System.Threading.Tasks.Task`1[[System.Web.OData.Batch.ODataBatchResponseItem]] ExecuteOperationAsync (Microsoft.OData.ODataBatchReader batchReader, System.Guid batchId, System.Net.Http.HttpRequestMessage originalRequest, System.Threading.CancellationToken cancellationToken)
 
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public virtual System.Threading.Tasks.Task`1[[System.Net.Http.HttpResponseMessage]] ProcessBatchAsync (System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
@@ -2624,7 +2609,6 @@ public class System.Web.OData.Results.CreatedODataResult`1 : IHttpActionResult {
 	System.Net.Http.HttpRequestMessage Request  { public get; }
 
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public virtual System.Threading.Tasks.Task`1[[System.Net.Http.HttpResponseMessage]] ExecuteAsync (System.Threading.CancellationToken cancellationToken)
@@ -2640,7 +2624,6 @@ public class System.Web.OData.Results.UpdatedODataResult`1 : IHttpActionResult {
 	System.Net.Http.HttpRequestMessage Request  { public get; }
 
 	[
-	DebuggerStepThroughAttribute(),
 	AsyncStateMachineAttribute(),
 	]
 	public virtual System.Threading.Tasks.Task`1[[System.Net.Http.HttpResponseMessage]] ExecuteAsync (System.Threading.CancellationToken cancellationToken)

--- a/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
+++ b/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
@@ -54,6 +54,7 @@
       <HintPath>..\..\..\sln\packages\Microsoft.AspNet.WebApi.Client.5.2.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Http, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">


### PR DESCRIPTION
Adding opt-in capability to store precompiled delegates in a memory cache using a sliding window expiration policy. Since this is in the attribute, it should be possible to specify distinct caching policies on a per controller or per method basis, if that's desirable.

Thanks!