### PR TITLE
Url too long Error

### DIFF
--- a/src/System.Web.OData/OData/Routing/DefaultODataPathHandler.cs
+++ b/src/System.Web.OData/OData/Routing/DefaultODataPathHandler.cs
@@ -112,12 +112,10 @@ namespace System.Web.OData.Routing
             {
                 Contract.Assert(serviceRoot != null);
 
-                serviceRootUri = new Uri(
-                    serviceRoot.EndsWith("/", StringComparison.Ordinal)
-                        ? serviceRoot
-                        : serviceRoot + "/");
+                string serviceRootStr = serviceRoot.EndsWith("/", StringComparison.Ordinal) ? serviceRoot : serviceRoot + "/";
+                serviceRootUri = new Uri(serviceRootStr);
 
-                fullUri = new Uri(serviceRootUri, odataPath);
+                fullUri = new Uri(serviceRootStr + odataPath);
                 queryString = fullUri.ParseQueryString();
                 uriParser = new ODataUriParser(model, serviceRootUri, fullUri, requestContainer);
             }


### PR DESCRIPTION
 "$filter" requires a lot of "or" queries, but when the Url is too long, the page will prompt for "The Uri string is too long"