### PR TITLE
Add the GC Allocations measure for performance

### DIFF
--- a/test/PerfTest/WebApiPerformance.Test/CustomerTest.cs
+++ b/test/PerfTest/WebApiPerformance.Test/CustomerTest.cs
@@ -15,6 +15,7 @@ namespace WebApiPerformance.Test
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ODataClrTest()
         {
             Uri queryUri = new Uri(serviceFixture.ServiceBaseUri + "/ODataClr?n=1000");
@@ -22,6 +23,7 @@ namespace WebApiPerformance.Test
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ODataEdmTest()
         {
             Uri queryUri = new Uri(serviceFixture.ServiceBaseUri + "/ODataEdm?n=1000");
@@ -29,6 +31,7 @@ namespace WebApiPerformance.Test
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WebApiJsonTest()
         {
             Uri queryUri = new Uri(serviceFixture.ServiceBaseUri + "/api/WebApiJson?n=1000");


### PR DESCRIPTION
It's required to add the GC allocations measure for the performance test.
So, modify the performance tests to accept the [MeasureGCAllocations].

The performance test runner outputs the GC Allocations as below with "bytes" unit:

![image](https://user-images.githubusercontent.com/9426627/29085999-e8856a9c-7c25-11e7-8c5c-789489287b3c.png)

Meantime, to run the analysis will output the following:

![image](https://user-images.githubusercontent.com/9426627/29086043-161cfbf0-7c26-11e7-96db-27ac6fc64e3f.png)

