### PR TITLE
Fix StyleCop SA1402: A C# document may only contain a single class

### DIFF
--- a/src/System.Web.OData/OData/Query/Expressions/SelectExpandWrapper.cs
+++ b/src/System.Web.OData/OData/Query/Expressions/SelectExpandWrapper.cs
@@ -8,7 +8,6 @@ using System.Web.OData.Formatter;
 using System.Web.OData.Formatter.Serialization;
 using System.Web.OData.Properties;
 using Microsoft.OData.Edm;
-using Newtonsoft.Json;
 
 namespace System.Web.OData.Query.Expressions
 {
@@ -130,28 +129,6 @@ namespace System.Web.OData.Query.Expressions
             Contract.Assert(ModelID != null);
 
             return ModelContainer.GetModel(ModelID);
-        }
-    }
-
-    /// <summary>
-    /// Represents a container class that contains properties that are either selected or expanded using $select and $expand.
-    /// </summary>
-    /// <typeparam name="TElement">The element being selected and expanded.</typeparam>
-    [JsonConverter(typeof(SelectExpandWrapperConverter))]
-    internal class SelectExpandWrapper<TElement> : SelectExpandWrapper
-    {
-        /// <summary>
-        /// Gets or sets the instance of the element being selected and expanded.
-        /// </summary>
-        public TElement Instance
-        {
-            get { return (TElement)UntypedInstance; }
-            set { UntypedInstance = value; }
-        }
-
-        protected override Type GetElementType()
-        {
-            return UntypedInstance == null ? typeof(TElement) : UntypedInstance.GetType();
         }
     }
 }

--- a/src/System.Web.OData/OData/Query/Expressions/SelectExpandWrapperOfT.cs
+++ b/src/System.Web.OData/OData/Query/Expressions/SelectExpandWrapperOfT.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace System.Web.OData.Query.Expressions
+{
+    /// <summary>
+    /// Represents a container class that contains properties that are either selected or expanded using $select and $expand.
+    /// </summary>
+    /// <typeparam name="TElement">The element being selected and expanded.</typeparam>
+    [JsonConverter(typeof(SelectExpandWrapperConverter))]
+    internal class SelectExpandWrapper<TElement> : SelectExpandWrapper
+    {
+        /// <summary>
+        /// Gets or sets the instance of the element being selected and expanded.
+        /// </summary>
+        public TElement Instance
+        {
+            get { return (TElement)UntypedInstance; }
+            set { UntypedInstance = value; }
+        }
+
+        protected override Type GetElementType()
+        {
+            return UntypedInstance == null ? typeof(TElement) : UntypedInstance.GetType();
+        }
+    }
+}

--- a/src/System.Web.OData/System.Web.OData.csproj
+++ b/src/System.Web.OData/System.Web.OData.csproj
@@ -23,7 +23,7 @@
     <Reference Include="Microsoft.Spatial, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\sln\packages\Microsoft.Spatial.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
-    </Reference>    
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\sln\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -117,6 +117,7 @@
     <Compile Include="OData\ODataQueryContextExtensions.cs" />
     <Compile Include="OData\Query\CountAttribute.cs" />
     <Compile Include="OData\Query\Expressions\AggregationPropertyContainer.cs" />
+    <Compile Include="OData\Query\Expressions\SelectExpandWrapperOfT.cs" />
     <Compile Include="OData\Query\SelectAttribute.cs" />
     <Compile Include="OData\Query\ExpandConfiguration.cs" />
     <Compile Include="OData\Query\QueryOptionSetting.cs" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Fix StyleCop SA1402: A C# document may only contain a single class at the root level
unless all of the classes are partial and are of the same type.

### Checklist (Uncheck if it is not completed)

- [   ] Test cases added
- [ x ] Build and test with one-click build and test script passed
