### PR TITLE
Add try logic for the host server create for KatanaSelfHost

### DIFF
--- a/test/E2ETest/Nuwa.WebStack/Host/KatanaSelfHostElement.cs
+++ b/test/E2ETest/Nuwa.WebStack/Host/KatanaSelfHostElement.cs
@@ -38,9 +38,6 @@ namespace Nuwa.WebStack.Host
 
         protected override bool InitializeServer(RunFrame frame)
         {
-            string baseAddress;
-            string port;
-
             var sandbox = CreateFullTrustAppDomain();
             frame.SetState(KeySandbox, sandbox);
 
@@ -50,8 +47,29 @@ namespace Nuwa.WebStack.Host
                 sandbox.Load(TypeDescriptor.TestAssembly.GetName());
             }
 
-            // setup security strategy and base address
-            port = _portArranger.Reserve();
+            int repeat = 10; // a magic number
+            bool result = false;
+            for (int i = 1; i <= repeat; ++i)
+            {
+                if (TrySetupServer(i, sandbox, frame))
+                {
+                    result = true;
+                    break;
+                }
+            }
+
+            if (result == false)
+            {
+                throw new Exception(string.Format("Cannot setup host server. See Event log for details"));
+            }
+
+            return true;
+        }
+
+        private bool TrySetupServer(int tryIndex, AppDomain sandbox, RunFrame frame)
+        {
+            string baseAddress;
+            string port = _portArranger.Reserve();
             SecurityHelper.AddIpListen();
             SecurityOptionElement securityElem = frame.GetFirstElement<SecurityOptionElement>();
             if (securityElem != null)
@@ -75,8 +93,8 @@ namespace Nuwa.WebStack.Host
                 traceType = traceElem.TracerType;
             }
 
-            // create initiator in the sandbox
             KatanaSelfHostServerInitiator serverInitiator;
+            // create initiator in the sandbox
             if (sandbox != null)
             {
                 serverInitiator = sandbox.CreateInstanceAndUnwrap(
@@ -101,14 +119,15 @@ namespace Nuwa.WebStack.Host
             {
                 EventLog appLog = new System.Diagnostics.EventLog();
                 appLog.Source = "Nuwa Katana Self Host Test";
-                appLog.WriteEntry(string.Format("base address: {0}\n message: {1}\n stack trace: {2}\n", baseAddress, ex.Message, ex.StackTrace),
+                appLog.WriteEntry(string.Format("try index: {0}\nbase address: {1}\n message: {2}\n stack trace: {3}\n", tryIndex, baseAddress, ex.Message, ex.StackTrace),
                     EventLogEntryType.Error);
-                throw ex;
+
+                return false;
             }
+
             frame.SetState(KeyReservedPort, port);
             frame.SetState(KeyBaseAddresss, baseAddress);
             frame.SetState(KeyServerInitiator, serverInitiator);
-
             return true;
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Occasionally, we get test failures on WebApi. 

Event Log shows a lot of Error logged from E2E test running:

for example:

**Unable to bind to the underlying transport for [::]:9177. The IP Listen-Only list may contain a reference to an interface which may not exist on this machine.  The data field contains the error number.**

That's because the required port is being used for other process. 

### Description

Add a try logic to create the host server using different port.

### Checklist (Uncheck if it is not completed)

- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
