### PR TITLE
Fix errors, when execute check null in SelectExpandBinder

### DIFF
--- a/src/System.Web.OData/OData/Query/Expressions/SelectExpandBinder.cs
+++ b/src/System.Web.OData/OData/Query/Expressions/SelectExpandBinder.cs
@@ -543,9 +543,10 @@ namespace System.Web.OData.Query.Expressions
             Expression keysNullCheckExpression = null;
             foreach (var key in propertyToExpand.ToEntityType().Key())
             {
+                var propertyValueExpression = CreatePropertyValueExpressionWithFilter(propertyToExpand.ToEntityType(), key, propertyValue, null);
                 var keyExpression = Expression.Equal(
-                    CreatePropertyValueExpressionWithFilter(propertyToExpand.ToEntityType(), key, propertyValue, null),
-                    Expression.Constant(null));
+                    propertyValueExpression,
+                    Expression.Constant(null, propertyValueExpression.Type));
 
                 keysNullCheckExpression = keysNullCheckExpression == null
                     ? keyExpression


### PR DESCRIPTION
* Fix errors, in some ORMs (e.g. LinqToDb), when execute check null in SelectExpandBinder

### Issues

Maybe fix #1069

### Checklist (Uncheck if it is not completed)

- [  ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
