### PR TITLE
Call BuildServiceProvider using reflection to make it compatible with both MS.Extensions.DependencyInjection 1 & 2

### DIFF
--- a/src/System.Web.OData/OData/DefaultContainerBuilder.cs
+++ b/src/System.Web.OData/OData/DefaultContainerBuilder.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System.Reflection;
 using System.Web.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData;
 using ServiceLifetime = Microsoft.OData.ServiceLifetime;
-using System.Reflection;
 
 namespace System.Web.OData
 {

--- a/src/System.Web.OData/OData/DefaultContainerBuilder.cs
+++ b/src/System.Web.OData/OData/DefaultContainerBuilder.cs
@@ -5,6 +5,7 @@ using System.Web.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData;
 using ServiceLifetime = Microsoft.OData.ServiceLifetime;
+using System.Reflection;
 
 namespace System.Web.OData
 {
@@ -78,7 +79,7 @@ namespace System.Web.OData
         /// <returns>The container built by this builder.</returns>
         public virtual IServiceProvider BuildContainer()
         {
-            return services.BuildServiceProvider();
+            return (IServiceProvider)services.GetType().GetTypeInfo().Assembly.GetType(typeof(ServiceCollectionContainerBuilderExtensions).GetTypeInfo().FullName).GetMethod(nameof(ServiceCollectionContainerBuilderExtensions.BuildServiceProvider), new[] { typeof(IServiceCollection) }).Invoke(null, new object[] { services });
         }
 
         private static Microsoft.Extensions.DependencyInjection.ServiceLifetime TranslateServiceLifetime(

--- a/src/System.Web.OData/OData/DefaultContainerBuilder.cs
+++ b/src/System.Web.OData/OData/DefaultContainerBuilder.cs
@@ -79,7 +79,17 @@ namespace System.Web.OData
         /// <returns>The container built by this builder.</returns>
         public virtual IServiceProvider BuildContainer()
         {
-            return (IServiceProvider)services.GetType().GetTypeInfo().Assembly.GetType(typeof(ServiceCollectionContainerBuilderExtensions).GetTypeInfo().FullName).GetMethod(nameof(ServiceCollectionContainerBuilderExtensions.BuildServiceProvider), new[] { typeof(IServiceCollection) }).Invoke(null, new object[] { services });
+            /* "services.BuildServiceProvider()" returns IServiceProvider in Microsoft.Extensions.DependencyInjection 1.0 and ServiceProvider in Microsoft.Extensions.DependencyInjection 2.0
+            * (This is a breaking change)[https://github.com/aspnet/DependencyInjection/issues/550].
+            * To support both versions with the same code base in OData/WebAPI we decided to call that extension method using reflection.
+            * More info at https://github.com/OData/WebApi/pull/1082
+            */
+
+            Assembly microsoftExtensionsDependencyInjectionAssembly = services.GetType().GetTypeInfo().Assembly;
+            TypeInfo serviceCollectionContainerBuilderExtensionsType = microsoftExtensionsDependencyInjectionAssembly.GetType(typeof(ServiceCollectionContainerBuilderExtensions).GetTypeInfo().FullName).GetTypeInfo();
+            MethodInfo buildServiceProviderMethod = serviceCollectionContainerBuilderExtensionsType.GetMethod("BuildServiceProvider", new[] { typeof(IServiceCollection) });
+
+            return (IServiceProvider)buildServiceProviderMethod.Invoke(null, new object[] { services });
         }
 
         private static Microsoft.Extensions.DependencyInjection.ServiceLifetime TranslateServiceLifetime(


### PR DESCRIPTION
### Issues

Short version of story:

Microsoft.Extensions.DependencyInjection has a class called **ServiceCollectionContainerBuilderExtensions** which has a method named **BuildServiceProvider**. In MS.Extensions.DependencyInjection 1.0, it was returning **IServiceCollection** and in version 2.0 it returns **ServiceCollection**

[This is a breaking change](https://github.com/aspnet/DependencyInjection/issues/550) and you've to either recompile your code or use dynamic method call using reflection. I'm not a fan of recompile against MS.Extensions.DependencyInjection 2.0, because it forces all developers who are using Microsoft.AspNet.OData 6.0+ to use .NET standard 2.0 based tools such as VS 2017.3 and the project itself should be updated from .NET 4.5 to .NET 4.6.1

Using dynamic method call, MS.AspNet.OData 6.0+ becomes compatible with both MS.Extensions.DependencyInjection 1 & 2.  **I've tested that code a lot and it works like a charm** and it makes **no breaking change** to this fantastic library at all.

This allows us to use libraries such as EntityFramework Core 2.0 and lots of other libraries on nuget.org which are dependent on MS.Extensions.DependencyInjection 2.0.

Thanks in advance

Issue link >> https://github.com/OData/WebApi/pull/1058#issuecomment-326710746

### Checklist (Uncheck if it is not completed)

- [ x ] Build and test with one-click build and test script passed

### Additional work necessary

**Change nuspec** dependencies from:

```
Microsoft.Extensions.DependencyInjection (>= 1.0.0 && < 2.0.0) 
Microsoft.Extensions.DependencyInjection.Abstractions (>= 1.0.0 && < 2.0.0) 
```

to

```
Microsoft.Extensions.DependencyInjection (>= 1.0.0) 
Microsoft.Extensions.DependencyInjection.Abstractions (>= 1.0.0) 
```