### PR TITLE
Support newtonsoft.json serialization for grouby results

### DIFF
--- a/src/System.Web.OData/OData/Query/Expressions/DynamicTypeWrapper.cs
+++ b/src/System.Web.OData/OData/Query/Expressions/DynamicTypeWrapper.cs
@@ -12,7 +12,6 @@ namespace System.Web.OData.Query.Expressions
     /// <summary>
     /// Represents a container class that contains properties that are grouped by using $apply.
     /// </summary>
-    [JsonConverter(typeof(DynamicTypeWrapperConverter))]
     public abstract class DynamicTypeWrapper
     {
         /// <summary>
@@ -33,6 +32,7 @@ namespace System.Web.OData.Query.Expressions
         }
     }
 
+    [JsonConverter(typeof(DynamicTypeWrapperConverter))]
     internal class GroupByWrapper : DynamicTypeWrapper
     {
         private Dictionary<string, object> _values;

--- a/src/System.Web.OData/OData/Query/Expressions/DynamicTypeWrapper.cs
+++ b/src/System.Web.OData/OData/Query/Expressions/DynamicTypeWrapper.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Newtonsoft.Json;
 [module: SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "Extra needed to workaorund EF issue with expression shape.")]
 
 namespace System.Web.OData.Query.Expressions
@@ -11,6 +12,7 @@ namespace System.Web.OData.Query.Expressions
     /// <summary>
     /// Represents a container class that contains properties that are grouped by using $apply.
     /// </summary>
+    [JsonConverter(typeof(DynamicTypeWrapperConverter))]
     public abstract class DynamicTypeWrapper
     {
         /// <summary>

--- a/src/System.Web.OData/OData/Query/Expressions/DynamicTypeWrapperConverter.cs
+++ b/src/System.Web.OData/OData/Query/Expressions/DynamicTypeWrapperConverter.cs
@@ -33,10 +33,10 @@ namespace System.Web.OData.Query.Expressions
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            DynamicTypeWrapper selectExpandWrapper = value as DynamicTypeWrapper;
-            if (selectExpandWrapper != null)
+            DynamicTypeWrapper dynamicTypeWrapper = value as DynamicTypeWrapper;
+            if (dynamicTypeWrapper != null)
             {
-                serializer.Serialize(writer, selectExpandWrapper.Values);
+                serializer.Serialize(writer, dynamicTypeWrapper.Values);
             }
         }
     }

--- a/src/System.Web.OData/OData/Query/Expressions/DynamicTypeWrapperConverter.cs
+++ b/src/System.Web.OData/OData/Query/Expressions/DynamicTypeWrapperConverter.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Reflection;
+using System.Web.Http;
+using Microsoft.OData.Edm;
+using Newtonsoft.Json;
+
+namespace System.Web.OData.Query.Expressions
+{
+    /// <summary>
+    /// Represents a custom <see cref="JsonConverter"/> to serialize <see cref="DynamicTypeWrapper"/> instances to JSON.
+    /// </summary>
+    internal class DynamicTypeWrapperConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            if (objectType == null)
+            {
+                throw Error.ArgumentNull("objectType");
+            }
+
+            return objectType.IsAssignableFrom(typeof(DynamicTypeWrapper));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            Contract.Assert(false, "DynamicTypeWrapper is internal and should never be deserialized into.");
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            DynamicTypeWrapper selectExpandWrapper = value as DynamicTypeWrapper;
+            if (selectExpandWrapper != null)
+            {
+                serializer.Serialize(writer, selectExpandWrapper.Values);
+            }
+        }
+    }
+}

--- a/src/System.Web.OData/System.Web.OData.csproj
+++ b/src/System.Web.OData/System.Web.OData.csproj
@@ -117,6 +117,7 @@
     <Compile Include="OData\ODataQueryContextExtensions.cs" />
     <Compile Include="OData\Query\CountAttribute.cs" />
     <Compile Include="OData\Query\Expressions\AggregationPropertyContainer.cs" />
+    <Compile Include="OData\Query\Expressions\DynamicTypeWrapperConverter.cs" />
     <Compile Include="OData\Query\Expressions\SelectExpandWrapperOfT.cs" />
     <Compile Include="OData\Query\SelectAttribute.cs" />
     <Compile Include="OData\Query\ExpandConfiguration.cs" />

--- a/test/UnitTest/System.Web.OData.Test/OData/ApplyTest.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/ApplyTest.cs
@@ -1,0 +1,180 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.Serialization;
+using System.Web.Http;
+using System.Web.OData.Builder;
+using System.Web.OData.Extensions;
+using System.Web.OData.Query;
+using Microsoft.OData.Edm;
+using Microsoft.TestCommon;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace System.Web.OData
+{
+    public class ApplyTest
+    {
+        private const string AcceptJsonFullMetadata = "application/json;odata.metadata=full";
+        private const string AcceptJson = "application/json";
+
+        private HttpConfiguration _configuration;
+        private HttpClient _client;
+
+        public ApplyTest()
+        {
+            _configuration =
+                new[]
+                {
+                    typeof(ApplyTestCustomersController),
+                    typeof(NonODataApplyTestCustomersController),
+                }.GetHttpConfiguration();
+            _configuration.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
+            _configuration.Count().Filter().OrderBy().Expand().MaxTop(null).Select();
+
+            _configuration.MapODataServiceRoute("odata", "odata", GetModel());
+            _configuration.Routes.MapHttpRoute("api", "api/{controller}", new { controller = "NonODataApplyTestCustomers" });
+            _configuration.EnableDependencyInjection();
+
+            HttpServer server = new HttpServer(_configuration);
+            _client = new HttpClient(server);
+        }
+
+        [Fact]
+        public void Apply_Works_WithODataJson()
+        {
+            // Arrange
+            string uri = "/odata/ApplyTestCustomers?$apply=groupby((Name), aggregate($count as Cnt))";
+
+            // Act
+            HttpResponseMessage response = GetResponse(uri, AcceptJson);
+
+            // Assert
+            var r = response.Content.ReadAsStringAsync().Result;
+            Console.WriteLine(r);
+            JArray result = JObject.Parse(response.Content.ReadAsStringAsync().Result)["value"] as JArray;
+            Assert.Equal("Name", result[0]["Name"]);
+            Assert.Equal(3, result[0]["Cnt"]);
+        }
+
+        [Fact]
+        public void Apply_Works_WithNonODataJson()
+        {
+            // Arrange
+            string uri = "/api/?$apply=groupby((Name), aggregate($count as Cnt))";
+
+            // Act
+            HttpResponseMessage response = GetResponse(uri, AcceptJson);
+
+            // Assert
+            JArray result = JArray.Parse(response.Content.ReadAsStringAsync().Result);
+            Assert.Equal("Name", result[0]["Name"]);
+            Assert.Equal(3, result[0]["Cnt"]);
+        }
+
+        private HttpResponseMessage GetResponse(string uri, string acceptHeader)
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://localhost" + uri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(acceptHeader));
+            request.SetConfiguration(_configuration);
+            return _client.SendAsync(request).Result;
+        }
+        private IEdmModel GetModel()
+        {
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<ApplyTestCustomer>("ApplyTestCustomers");
+            return builder.GetEdmModel();
+        }
+    }
+
+    public class ApplyTestCustomer
+    {
+        public static IList<ApplyTestCustomer> Customers
+        {
+            get
+            {
+                ApplyTestCustomer customer = new ApplyTestCustomer { ID = 42, Name = "Name" };
+                ApplyTestOrder order = new ApplyTestOrder { ID = 24, Amount = 100, Customer = customer };
+                ApplyTestOrder anotherOrder = new ApplyTestOrder
+                {
+                    ID = 28,
+                    Amount = 10,
+                    Customer = customer,
+                };
+                customer.Orders = new[] { order, anotherOrder };
+
+                ApplyTestCustomer specialCustomer = new ApplyTestCustomer
+                {
+                    ID = 43,
+                    Name = "Name",
+                    PreviousCustomer = customer
+                };
+                ApplyTestOrder specialOrder = new ApplyTestOrder
+                {
+                    ID = 25,
+                    Amount = 100,
+                    Customer = specialCustomer
+                };
+                specialCustomer.Orders = new[] { specialOrder };
+
+                ApplyTestCustomer nextCustomer = new ApplyTestCustomer
+                {
+                    ID = 44,
+                    Name = "Name",
+                    PreviousCustomer = specialCustomer
+                };
+                ApplyTestOrder nextOrder = new ApplyTestOrder
+                {
+                    ID = 26,
+                    Amount = 100,
+                    Customer = nextCustomer
+                };
+                nextCustomer.Orders = new[] { nextOrder };
+
+                return new[] { customer, specialCustomer, nextCustomer };
+            }
+        }
+
+        public int ID { get; set; }
+
+        public string Name { get; set; }
+
+        public ApplyTestOrder[] Orders { get; set; }
+
+        public ApplyTestCustomer PreviousCustomer { get; set; }
+    }
+
+
+    public class ApplyTestOrder
+    {
+        public int ID { get; set; }
+
+        public int Amount { get; set; }
+
+        public ApplyTestCustomer Customer { get; set; }
+    }
+
+
+    public class ApplyTestCustomersController : ODataController
+    {
+        [EnableQuery]
+        public IEnumerable<ApplyTestCustomer> Get()
+        {
+            return ApplyTestCustomer.Customers;
+        }
+    }
+
+    public class NonODataApplyTestCustomersController : ApiController
+    {
+        [EnableQuery]
+        public IEnumerable<ApplyTestCustomer> Get()
+        {
+            return ApplyTestCustomer.Customers;
+        }
+    }
+}

--- a/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -3216,6 +3216,9 @@ public class System.Web.OData.Formatter.Serialization.SelectExpandNode {
 	public static void GetStructuralProperties (Microsoft.OData.Edm.IEdmStructuredType structuredType, System.Collections.Generic.HashSet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] structuralProperties, System.Collections.Generic.HashSet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] nestedStructuralProperties)
 }
 
+[
+JsonConverterAttribute(),
+]
 public abstract class System.Web.OData.Query.Expressions.DynamicTypeWrapper {
 	protected DynamicTypeWrapper ()
 

--- a/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -3216,9 +3216,6 @@ public class System.Web.OData.Formatter.Serialization.SelectExpandNode {
 	public static void GetStructuralProperties (Microsoft.OData.Edm.IEdmStructuredType structuredType, System.Collections.Generic.HashSet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] structuralProperties, System.Collections.Generic.HashSet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] nestedStructuralProperties)
 }
 
-[
-JsonConverterAttribute(),
-]
 public abstract class System.Web.OData.Query.Expressions.DynamicTypeWrapper {
 	protected DynamicTypeWrapper ()
 

--- a/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
+++ b/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
@@ -351,6 +351,7 @@
     <Compile Include="OData\Query\Validators\TopQueryValidatorTest.cs" />
     <Compile Include="OData\Routing\ODataValueProviderFactoryTest.cs" />
     <Compile Include="OData\SelectExpandNestedDollarCountTest.cs" />
+    <Compile Include="OData\ApplyTest.cs" />
     <Compile Include="OData\SelectExpandTest.cs" />
     <Compile Include="PublicApi\PublicApiHelper.cs" />
     <Compile Include="PublicApi\PublicApiTest.cs" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1078.*

### Description

Added converter for DynamicTypeWrapper to support cases when basic newtonsoft.json serialization is used instead of WebAPI formatters

### Checklist (Uncheck if it is not completed)

- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed


