### PR TITLE
Add more port check logic for Katana server initialization

### DIFF
--- a/test/E2ETest/Nuwa.WebStack/Host/KatanaSelfHostElement.cs
+++ b/test/E2ETest/Nuwa.WebStack/Host/KatanaSelfHostElement.cs
@@ -47,7 +47,11 @@ namespace Nuwa.WebStack.Host
                 sandbox.Load(TypeDescriptor.TestAssembly.GetName());
             }
 
-            int repeat = 10; // a magic number
+            SecurityHelper.AddIpListen();
+
+            // retry three times using port scan with three port types.
+            int repeat = 3;
+
             bool result = false;
             for (int i = 1; i <= repeat; ++i)
             {
@@ -70,7 +74,7 @@ namespace Nuwa.WebStack.Host
         {
             string baseAddress;
             string port = _portArranger.Reserve();
-            SecurityHelper.AddIpListen();
+
             SecurityOptionElement securityElem = frame.GetFirstElement<SecurityOptionElement>();
             if (securityElem != null)
             {

--- a/test/E2ETest/Nuwa.WebStack/Host/PortArranger.cs
+++ b/test/E2ETest/Nuwa.WebStack/Host/PortArranger.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.NetworkInformation;
 using System.Threading;
+using System.Web.Management;
 
 namespace Nuwa.WebStack.Host
 {
@@ -15,8 +18,18 @@ namespace Nuwa.WebStack.Host
             string startPort = NuwaGlobalConfiguration.KatanaSelfStartingPort;
             if (_available == null)
             {
-                _available = new ConcurrentQueue<string>(Enumerable.Range(int.Parse(startPort), 1000).Select(i => i.ToString()));
+                _available = new ConcurrentQueue<string>(Enumerable.Range(int.Parse(startPort), 3000).Select(i => i.ToString()));
             }
+        }
+
+        /// <summary>
+        /// Enum type for active ports
+        /// </summary>
+        private enum PortTypes
+        {
+            TCPActiveConnection,
+            TCPActiveListener,
+            UDPActiveListener
         }
 
         public string Reserve()
@@ -59,12 +72,45 @@ namespace Nuwa.WebStack.Host
 
         private static bool IsFree(string port)
         {
-            IPGlobalProperties properties = IPGlobalProperties.GetIPGlobalProperties();
-            TcpConnectionInformation[] connections = properties.GetActiveTcpConnections();
             int portOfInt = int.Parse(port);
-            var isInUse = connections.Any(c =>
-                c.LocalEndPoint.Port == portOfInt || c.RemoteEndPoint.Port == portOfInt);
-            return !isInUse;
+
+            IPGlobalProperties properties = IPGlobalProperties.GetIPGlobalProperties();
+
+            // Check the port with active TCP connections.
+            TcpConnectionInformation[] connections = properties.GetActiveTcpConnections();
+            if (connections.Any(c => c.LocalEndPoint.Port == portOfInt || c.RemoteEndPoint.Port == portOfInt))
+            {
+                LogEvent(portOfInt, PortTypes.TCPActiveConnection, connections.Length);
+                return false;
+            }
+
+            // Check the port with active TCP listeners.
+            IPEndPoint[] tcpListeningEndpoints = properties.GetActiveTcpListeners();
+            if (tcpListeningEndpoints.Any(ep => ep.Port == portOfInt))
+            {
+                LogEvent(portOfInt, PortTypes.TCPActiveListener, tcpListeningEndpoints.Length);
+                return false;
+            }
+
+            // Check the port with active UDP listeners
+            // We shouldn't need to check with UDP ports for current usage, but just in case for general purpose...
+            IPEndPoint[] udpListeningEndpoints = properties.GetActiveUdpListeners();
+            if (udpListeningEndpoints.Any(ep => ep.Port == portOfInt))
+            {
+                LogEvent(portOfInt, PortTypes.UDPActiveListener, udpListeningEndpoints.Length);
+                return false;
+            }
+
+            // pass all checks, port is free to use.
+            return true;
+        }
+
+        private static void LogEvent(int portNum, PortTypes activePortType, int totalCount)
+        {
+            EventLog appLog = new EventLog();
+            appLog.Source = "Nuwa Katana Self Host Test";
+            appLog.WriteEntry(string.Format("Port: [{0}] is already used by: [type: {1}, count: {2}]\n", portNum, activePortType, totalCount),
+                EventLogEntryType.Error);
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes stability issue of Katana server initialization for Nuwa Katana Self Host Tests.*

### Description

*Adding check for additional active listening ports to ensure that the specific port is OK to use. Also extend the port search range 3x to 3k, providing more resource available for test run.*

### Checklist (Uncheck if it is not completed)

- [  ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
