### PR TITLE
Change FilterQueryValidator lifetime to Scoped (#1083)

### DIFF
--- a/src/System.Web.OData/Extensions/ContainerBuilderExtensions.cs
+++ b/src/System.Web.OData/Extensions/ContainerBuilderExtensions.cs
@@ -43,7 +43,7 @@ namespace System.Web.OData.Extensions
 
             // QueryValidators.
             builder.AddService<CountQueryValidator>(ServiceLifetime.Singleton);
-            builder.AddService<FilterQueryValidator>(ServiceLifetime.Singleton);
+            builder.AddService<FilterQueryValidator>(ServiceLifetime.Scoped);
             builder.AddService<ODataQueryValidator>(ServiceLifetime.Singleton);
             builder.AddService<OrderByQueryValidator>(ServiceLifetime.Singleton);
             builder.AddService<SelectExpandQueryValidator>(ServiceLifetime.Singleton);

--- a/test/UnitTest/System.Web.OData.Test/OData/QueryableLimitationTest.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/QueryableLimitationTest.cs
@@ -6,13 +6,13 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.OData.Builder;
 using System.Web.OData.Extensions;
 using System.Web.OData.Query;
 using Microsoft.OData.Edm;
 using Microsoft.TestCommon;
-using System.Threading.Tasks;
 
 namespace System.Web.OData
 {


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1083.*

### Description

Change the lifetime scope of FilterQueryValidator because it is not thread safe.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*
