### PR TITLE
Fix for memory leak in EdmLibHelpers 

### DIFF
--- a/src/System.Web.OData/OData/ConcurrencyPropertiesAnnotation.cs
+++ b/src/System.Web.OData/OData/ConcurrencyPropertiesAnnotation.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.OData.Edm;
+
+namespace System.Web.OData
+{
+    /// <summary>
+    /// Annotation to store cache for concurrency properties
+    /// </summary>
+    [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "Annotation suffix is more appropriate here.")]
+    public class ConcurrencyPropertiesAnnotation : ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>>
+    {
+    }
+}

--- a/src/System.Web.OData/OData/Formatter/EdmLibHelpers.cs
+++ b/src/System.Web.OData/OData/Formatter/EdmLibHelpers.cs
@@ -786,7 +786,7 @@ namespace System.Web.OData.Formatter
             Contract.Assert(navigationSource != null);
 
             // Ensure that concurrency properties cache is attached to model as an annotation to avoid expensive calculations each time
-            ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>> concurrencyProperties = model.GetAnnotationValue<ConcurrencyPropertiesAnnotation>(model);
+            ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>> concurrencyProperties = model.GetAnnotationValue<ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>>>(model);
             if (concurrencyProperties == null)
             {
                 concurrencyProperties = new ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>>();
@@ -994,13 +994,6 @@ namespace System.Web.OData.Formatter
                     type.Name.Replace('`', '_'),
                     String.Join("_", type.GetGenericArguments().Select(t => MangleClrTypeName(t))));
             }
-        }
-
-        /// <summary>
-        /// Annotation to store cache for concurrency properties
-        /// </summary>
-        private class ConcurrencyPropertiesAnnotation : ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>>
-        {
         }
     }
 }

--- a/src/System.Web.OData/OData/Formatter/EdmLibHelpers.cs
+++ b/src/System.Web.OData/OData/Formatter/EdmLibHelpers.cs
@@ -786,7 +786,7 @@ namespace System.Web.OData.Formatter
             Contract.Assert(navigationSource != null);
 
             // Ensure that concurrency properties cache is attached to model as an annotation to avoid expensive calculations each time
-            ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>> concurrencyProperties = model.GetAnnotationValue<ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>>>(model);
+            ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>> concurrencyProperties = model.GetAnnotationValue<ConcurrencyPropertiesAnnotation>(model);
             if (concurrencyProperties == null)
             {
                 concurrencyProperties = new ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>>();
@@ -994,6 +994,13 @@ namespace System.Web.OData.Formatter
                     type.Name.Replace('`', '_'),
                     String.Join("_", type.GetGenericArguments().Select(t => MangleClrTypeName(t))));
             }
+        }
+
+        /// <summary>
+        /// Annotation to store cache for concurrency properties
+        /// </summary>
+        private class ConcurrencyPropertiesAnnotation : ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>>
+        {
         }
     }
 }

--- a/src/System.Web.OData/OData/Formatter/EdmLibHelpers.cs
+++ b/src/System.Web.OData/OData/Formatter/EdmLibHelpers.cs
@@ -789,12 +789,12 @@ namespace System.Web.OData.Formatter
             ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>> concurrencyProperties = model.GetAnnotationValue<ConcurrencyPropertiesAnnotation>(model);
             if (concurrencyProperties == null)
             {
-                concurrencyProperties = new ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>>();
+                concurrencyProperties = new ConcurrencyPropertiesAnnotation();
                 model.SetAnnotationValue(model, concurrencyProperties);
             }
 
             IEnumerable<IEdmStructuralProperty> cachedProperties;
-            if (concurrencyProperties != null && concurrencyProperties.TryGetValue(navigationSource, out cachedProperties))
+            if (concurrencyProperties.TryGetValue(navigationSource, out cachedProperties))
             {
                 return cachedProperties;
             }
@@ -829,11 +829,6 @@ namespace System.Web.OData.Formatter
                         }
                     }
                 }
-            }
-
-            if (concurrencyProperties == null)
-            {
-                concurrencyProperties = new ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>>();
             }
 
             if (results.Any())
@@ -994,13 +989,6 @@ namespace System.Web.OData.Formatter
                     type.Name.Replace('`', '_'),
                     String.Join("_", type.GetGenericArguments().Select(t => MangleClrTypeName(t))));
             }
-        }
-
-        /// <summary>
-        /// Annotation to store cache for concurrency properties
-        /// </summary>
-        private class ConcurrencyPropertiesAnnotation : ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>>
-        {
         }
     }
 }

--- a/src/System.Web.OData/OData/Formatter/EdmLibHelpers.cs
+++ b/src/System.Web.OData/OData/Formatter/EdmLibHelpers.cs
@@ -786,7 +786,7 @@ namespace System.Web.OData.Formatter
             Contract.Assert(navigationSource != null);
 
             // Ensure that concurrency properties cache is attached to model as an annotation to avoid expensive calculations each time
-            ConcurrentDictionary<IEdmNavigationSource, IEnumerable<IEdmStructuralProperty>> concurrencyProperties = model.GetAnnotationValue<ConcurrencyPropertiesAnnotation>(model);
+            ConcurrencyPropertiesAnnotation concurrencyProperties = model.GetAnnotationValue<ConcurrencyPropertiesAnnotation>(model);
             if (concurrencyProperties == null)
             {
                 concurrencyProperties = new ConcurrencyPropertiesAnnotation();
@@ -831,10 +831,7 @@ namespace System.Web.OData.Formatter
                 }
             }
 
-            if (results.Any())
-            {
-                concurrencyProperties[navigationSource] = results;
-            }
+            concurrencyProperties[navigationSource] = results;
             return results;
         }
 

--- a/src/System.Web.OData/System.Web.OData.csproj
+++ b/src/System.Web.OData/System.Web.OData.csproj
@@ -110,6 +110,7 @@
     <Compile Include="OData\Builder\Conventions\Attributes\MediaTypeAttributeConvention.cs" />
     <Compile Include="OData\Builder\BindingPathHelper.cs" />
     <Compile Include="OData\Builder\PrecisionPropertyConfiguration.cs" />
+    <Compile Include="OData\ConcurrencyPropertiesAnnotation.cs" />
     <Compile Include="OData\EdmDeltaComplexObject.cs" />
     <Compile Include="OData\Formatter\Deserialization\ODataDeserializerProviderProxy.cs" />
     <Compile Include="OData\Formatter\ODataModelBinderConverter.cs" />

--- a/test/UnitTest/System.Web.OData.Test/OData/Formatter/EdmLibHelpersTests.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Formatter/EdmLibHelpersTests.cs
@@ -246,6 +246,28 @@ namespace System.Web.OData.Formatter
             Assert.Same(first, second);
         }
 
+        [Theory]
+        [InlineData("WithoutCP")]
+        [InlineData("WithCP")]
+        public void ConcurrencyPropertiesAnnotation_NotSerializedToMetadata(string entitySetName)
+        {
+            // Arrange
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<TypeWithoutConcurrencyProperties>("WithoutCP");
+            builder.EntitySet<TypeWithConcurrencyProperties>("WithCP");
+            IEdmModel model = builder.GetEdmModel();
+            string originalMetadata = MetadataTest.GetCSDL(model);
+
+            IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet(entitySetName);
+
+            // Act
+            EdmLibHelpers.GetConcurrencyProperties(model, entitySet);
+            string actualMetadata = MetadataTest.GetCSDL(model);
+
+            // Assert
+            Assert.Equal(originalMetadata, actualMetadata);
+        }
+
         private static IEdmModel _edmModel;
         private static IEdmModel GetEdmModel()
         {

--- a/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -186,6 +186,10 @@ public class System.Web.OData.ClrTypeAnnotation {
 	System.Type ClrType  { public get; }
 }
 
+public class System.Web.OData.ConcurrencyPropertiesAnnotation : System.Collections.Concurrent.ConcurrentDictionary`2[[Microsoft.OData.Edm.IEdmNavigationSource],[System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmStructuralProperty]]]], ICollection, IDictionary, IEnumerable, IDictionary`2, IReadOnlyDictionary`2, ICollection`1, IEnumerable`1, IReadOnlyCollection`1 {
+	public ConcurrencyPropertiesAnnotation ()
+}
+
 public class System.Web.OData.CustomAggregateMethodAnnotation {
 	public CustomAggregateMethodAnnotation ()
 


### PR DESCRIPTION
### Issues

*This pull request fixes issue #822.*

### Description

EdmLibHelpers caches concurrency properties in private static dictionary to improve performance. When WebAPI used with dynamic models (created on each call or pretty often), that dictionary will keep references on EntityTypes that ever used in queries. As a result we have memory leak.

Fix create cache per model and attaches it as an annotation to model. As a result when model is no longer in use entity types will be GCed too.


### Checklist (Uncheck if it is not completed)

- [x] *Test cases added.* 
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
