### PR TITLE
Fix the bug#1113: ODataResourceDeserializer on longer supports null c…

### DIFF
--- a/src/System.Web.OData/OData/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/System.Web.OData/OData/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -308,6 +308,21 @@ namespace System.Web.OData.Formatter.Deserialization
 
             foreach (ODataItemBase childItem in resourceInfoWrapper.NestedItems)
             {
+                // it maybe null.
+                if (childItem == null)
+                {
+                    if (edmProperty == null)
+                    {
+                        // for the dynamic, OData.net has a bug. see https://github.com/OData/odata.net/issues/977
+                        ApplyDynamicResourceInNestedProperty(resourceInfoWrapper.NestedResourceInfo.Name, resource,
+                            structuredType, null, readContext);
+                    }
+                    else
+                    {
+                        ApplyResourceInNestedProperty(edmProperty, resource, null, readContext);
+                    }
+                }
+
                 ODataEntityReferenceLinkBase entityReferenceLink = childItem as ODataEntityReferenceLinkBase;
                 if (entityReferenceLink != null)
                 {
@@ -345,6 +360,7 @@ namespace System.Web.OData.Formatter.Deserialization
                         ApplyResourceInNestedProperty(edmProperty, resource, resourceWrapper, readContext);
                     }
                 }
+
             }
         }
 
@@ -429,10 +445,14 @@ namespace System.Web.OData.Formatter.Deserialization
             Contract.Assert(resource != null);
             Contract.Assert(readContext != null);
 
-            IEdmSchemaType elementType = readContext.Model.FindDeclaredType(resourceWrapper.Resource.TypeName);
-            IEdmTypeReference edmTypeReference = elementType.ToEdmTypeReference(true);
+            object value = null;
+            if (resourceWrapper != null)
+            {
+                IEdmSchemaType elementType = readContext.Model.FindDeclaredType(resourceWrapper.Resource.TypeName);
+                IEdmTypeReference edmTypeReference = elementType.ToEdmTypeReference(true);
 
-            object value = ReadNestedResourceInline(resourceWrapper, edmTypeReference, readContext);
+                value = ReadNestedResourceInline(resourceWrapper, edmTypeReference, readContext);
+            }
 
             DeserializationHelpers.SetDynamicProperty(resource, propertyName, value,
                 resourceStructuredType.StructuredDefinition(), readContext.Model);
@@ -440,9 +460,13 @@ namespace System.Web.OData.Formatter.Deserialization
 
         private object ReadNestedResourceInline(ODataResourceWrapper resourceWrapper, IEdmTypeReference edmType, ODataDeserializerContext readContext)
         {
-            Contract.Assert(resourceWrapper != null);
             Contract.Assert(edmType != null);
             Contract.Assert(readContext != null);
+
+            if (resourceWrapper == null)
+            {
+                return null;
+            }
 
             ODataEdmTypeDeserializer deserializer = DeserializerProvider.GetEdmTypeDeserializer(edmType);
             if (deserializer == null)

--- a/src/System.Web.OData/OData/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/System.Web.OData/OData/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -360,7 +360,6 @@ namespace System.Web.OData.Formatter.Deserialization
                         ApplyResourceInNestedProperty(edmProperty, resource, resourceWrapper, readContext);
                     }
                 }
-
             }
         }
 


### PR DESCRIPTION
Fix #1113

### Issues

ODataResourceDeserializer no longer supports null ComplexType values 

### Description

ODataResourceDeserializer no longer supports null ComplexType values 

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
