### PR TITLE
Finalize split between Shared and AspNet in preperation for AspNetCore.

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/LinkGenerationHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/LinkGenerationHelpers.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.OData.Builder
                 throw Error.ArgumentNull("resourceContext");
             }
 
-            if (resourceContext.Url == null)
+            if (resourceContext.InternalUrlHelper == null)
             {
                 throw Error.Argument("resourceContext", SRResources.UrlHelperNull, typeof(ResourceContext).Name);
             }
@@ -72,7 +72,7 @@ namespace Microsoft.AspNet.OData.Builder
             {
                 throw Error.ArgumentNull("resourceContext");
             }
-            if (resourceContext.Url == null)
+            if (resourceContext.InternalUrlHelper == null)
             {
                 throw Error.Argument("resourceContext", SRResources.UrlHelperNull, typeof(ResourceContext).Name);
             }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataCollectionSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataCollectionSerializer.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Runtime.Serialization;
 using Microsoft.AspNet.OData.Common;
-using Microsoft.AspNet.OData.Extensions;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 
@@ -87,14 +86,14 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
             if (writeContext.Request != null)
             {
-                if (writeContext.Request.ODataProperties().NextLink != null)
+                if (writeContext.InternalRequest.Context.NextLink != null)
                 {
-                    collectionStart.NextPageLink = writeContext.Request.ODataProperties().NextLink;
+                    collectionStart.NextPageLink = writeContext.InternalRequest.Context.NextLink;
                 }
 
-                if (writeContext.Request.ODataProperties().TotalCount != null)
+                if (writeContext.InternalRequest.Context.TotalCount != null)
                 {
-                    collectionStart.Count = writeContext.Request.ODataProperties().TotalCount;
+                    collectionStart.Count = writeContext.InternalRequest.Context.TotalCount;
                 }
             }
 

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataDeltaFeedSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataDeltaFeedSerializer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 if (entrySerializer == null)
                 {
                     throw new SerializationException(
-                        Error.Format(SRResources.TypeCannotBeSerialized, elementType.FullName(), typeof(ODataMediaTypeFormatter).Name));
+                        Error.Format(SRResources.TypeCannotBeSerialized, elementType.FullName()));
                 }
 
                 foreach (object entry in enumerable)

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -212,7 +212,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 // if (serializer == null)
                 // {
                 //     throw new SerializationException(
-                //         Error.Format(SRResources.TypeCannotBeSerialized, edmProperty.Type.ToTraceString(), typeof(ODataResourceSerializer).Name));
+                //         Error.Format(SRResources.TypeCannotBeSerialized, edmProperty.Type.ToTraceString()));
                 // }
                 if (edmProperty.Type.IsCollection())
                 {
@@ -723,8 +723,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             if (serializer == null)
             {
                 throw new SerializationException(
-                    Error.Format(SRResources.TypeCannotBeSerialized, edmType.ToTraceString(),
-                        typeof(ODataResourceSerializer).Name));
+                    Error.Format(SRResources.TypeCannotBeSerialized, edmType.ToTraceString()));
             }
 
             serializer.WriteObjectInline(propertyValue, edmType, writer, nestedWriteContext);
@@ -794,7 +793,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 if (serializer == null)
                 {
                     throw new SerializationException(
-                        Error.Format(SRResources.TypeCannotBeSerialized, edmProperty.Type.ToTraceString(), typeof(ODataResourceSerializer).Name));
+                        Error.Format(SRResources.TypeCannotBeSerialized, edmProperty.Type.ToTraceString()));
                 }
 
                 serializer.WriteObjectInline(propertyValue, edmProperty.Type, writer, nestedWriteContext);
@@ -909,7 +908,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             if (serializer == null)
             {
                 throw new SerializationException(
-                    Error.Format(SRResources.TypeCannotBeSerialized, structuralProperty.Type.FullName(), typeof(ODataMediaTypeFormatter).Name));
+                    Error.Format(SRResources.TypeCannotBeSerialized, structuralProperty.Type.FullName()));
             }
 
             object propertyValue = resourceContext.GetPropertyValue(structuralProperty.Name);

--- a/src/Microsoft.AspNet.OData.Shared/MetadataController.cs
+++ b/src/Microsoft.AspNet.OData.Shared/MetadataController.cs
@@ -6,21 +6,16 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.AspNet.OData.Builder;
-using Microsoft.AspNet.OData.Common;
-using Microsoft.AspNet.OData.Extensions;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
-using Microsoft.OData.Edm.Csdl;
 
 namespace Microsoft.AspNet.OData
 {
     /// <summary>
     /// Represents a controller for generating OData servicedoc and metadata document ($metadata).
     /// </summary>
-    public class MetadataController : ODataController
+    public partial class MetadataController : ODataController
     {
-        private static readonly Version _defaultEdmxVersion = new Version(4, 0);
-
         /// <summary>
         /// Generates the OData $metadata document.
         /// </summary>
@@ -100,18 +95,6 @@ namespace Microsoft.AspNet.OData
             };
 
             return info;
-        }
-
-        private IEdmModel GetModel()
-        {
-            IEdmModel model = Request.GetModel();
-            if (model == null)
-            {
-                throw Error.InvalidOperation(SRResources.RequestMustHaveModel);
-            }
-
-            model.SetEdmxVersion(_defaultEdmxVersion);
-            return model;
         }
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/AttributeRoutingConvention.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/AttributeRoutingConvention.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
     /// Represents a routing convention that looks for <see cref="ODataRouteAttribute"/>s to match an <see cref="ODataPath"/>
     /// to a controller and an action.
     /// </summary>
-    public partial class AttributeRoutingConvention : IODataRoutingConvention
+    public partial class AttributeRoutingConvention
     {
         /// <inheritdoc />
         internal static SelectControllerResult SelectControllerImpl(ODataPath odataPath, IWebApiRequestMessage request,

--- a/src/Microsoft.AspNet.OData/Formatter/ODataMediaTypeFormatter.cs
+++ b/src/Microsoft.AspNet.OData/Formatter/ODataMediaTypeFormatter.cs
@@ -600,7 +600,7 @@ namespace Microsoft.AspNet.OData.Formatter
                 serializer = serializerProvider.GetEdmTypeSerializer(edmType);
                 if (serializer == null)
                 {
-                    string message = Error.Format(SRResources.TypeCannotBeSerialized, edmType.ToTraceString(), typeof(ODataMediaTypeFormatter).Name);
+                    string message = Error.Format(SRResources.TypeCannotBeSerialized, edmType.ToTraceString());
                     throw new SerializationException(message);
                 }
             }
@@ -616,7 +616,7 @@ namespace Microsoft.AspNet.OData.Formatter
                 serializer = serializerProvider.GetODataPayloadSerializer(type, Request);
                 if (serializer == null)
                 {
-                    string message = Error.Format(SRResources.TypeCannotBeSerialized, type.Name, typeof(ODataMediaTypeFormatter).Name);
+                    string message = Error.Format(SRResources.TypeCannotBeSerialized, type.Name);
                     throw new SerializationException(message);
                 }
             }

--- a/src/Microsoft.AspNet.OData/MetadataController.cs
+++ b/src/Microsoft.AspNet.OData/MetadataController.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+
+namespace Microsoft.AspNet.OData
+{
+    /// <summary>
+    /// Represents a controller for generating OData servicedoc and metadata document ($metadata).
+    /// </summary>
+    public partial class MetadataController
+    {
+        private static readonly Version _defaultEdmxVersion = new Version(4, 0);
+
+        private IEdmModel GetModel()
+        {
+            IEdmModel model = Request.GetModel();
+            if (model == null)
+            {
+                throw Error.InvalidOperation(SRResources.RequestMustHaveModel);
+            }
+
+            model.SetEdmxVersion(_defaultEdmxVersion);
+            return model;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
+++ b/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Formatter\Serialization\ODataSerializerContext.cs" />
     <Compile Include="Formatter\Serialization\ODataSerializerProvider.cs" />
     <Compile Include="Formatter\Serialization\ODataSerializerProviderProxy.cs" />
+    <Compile Include="MetadataController.cs" />
     <Compile Include="Query\Expressions\ExpressionBinderBase.cs" />
     <Compile Include="Batch\UnbufferedODataBatchHandler.cs" />
     <Compile Include="Batch\ODataBatchResponseItem.cs" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request makes progress on issues #975, #939, #772, #628, #229, 

### Description

Finalize split between Shared and AspNet. A few AspNet-specific bits leaked into the shared
code during refactoring of the first 8 PRs.

Additionally, this change modifies the Metadata controller to be mostly shared
with the a bit of AspNet-specific code to get the model.

### Checklist (Uncheck if it is not completed)

- [   ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary

Add AspNetCore version of product code
Port Unit Tests to NetCore & Xunit 2.0
Port E2E Tests to NetCore & Xunit 2.0

