### PR TITLE
Add fix for DateTimeOffset Day function test

### DIFF
--- a/test/E2ETest/WebStack.QA.Test.OData/DateTimeOffsetSupport/DateTimeOffsetTest.cs
+++ b/test/E2ETest/WebStack.QA.Test.OData/DateTimeOffsetSupport/DateTimeOffsetTest.cs
@@ -354,7 +354,7 @@ namespace WebStack.QA.Test.OData.DateTimeOffsetSupport
 
             var responseFileList = DeserializeList(response);
             Assert.Equal(5, fileList.Count());
-            Assert.True(fileList.SequenceEqual(responseFileList));
+            Assert.True(fileList.Where(p => p.CreatedDate.Day == time.Day).OrderBy(p => p.CreatedDate).SequenceEqual(responseFileList.OrderBy(p => p.CreatedDate)));
         }
 
         [Theory]


### PR DESCRIPTION
### Issues

*The issue address a problem in the test where the comparison fails when the day of the month goes beyond the maximum day of the month in the control months used in the test. So, on October 31st, the test failed because the results were compared to November 30th and September 30th (as well as August 31st and December 31st). These two entries were mismatched because the months did not have 31 days. This caused the test to fail.

### Description

*The broken test was modified so that the control data will be filtered when doing the comparison. Thus, any control instances that don't match with the test criteria will not be expected to exist in the query results.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*None needed
