### PR TITLE
[feature/netcore] HttpRequest(Message) in OData container

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Extensions/ContainerBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Extensions/ContainerBuilderExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNet.OData.Query;
 using Microsoft.AspNet.OData.Query.Expressions;
 using Microsoft.AspNet.OData.Query.Validators;
 using Microsoft.AspNet.OData.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData;
 using ServiceLifetime = Microsoft.OData.ServiceLifetime;
 
@@ -80,6 +81,9 @@ namespace Microsoft.AspNet.OData.Extensions
             builder.AddService<ODataQuerySettings>(ServiceLifetime.Scoped);
             builder.AddService<FilterBinder>(ServiceLifetime.Transient);
 
+            // HttpRequestScope.
+            builder.AddService<HttpRequestScope>(ServiceLifetime.Scoped);
+            builder.AddService(ServiceLifetime.Scoped, sp => sp.GetRequiredService<HttpRequestScope>().HttpRequest);
             return builder;
         }
     }

--- a/src/Microsoft.AspNet.OData/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.AspNet.OData/Extensions/HttpRequestMessageExtensions.cs
@@ -414,7 +414,15 @@ namespace Microsoft.AspNet.OData.Extensions
             }
 
             IServiceProvider rootContainer = configuration.GetODataRootContainer(routeName);
-            return rootContainer.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            IServiceScope scope = rootContainer.GetRequiredService<IServiceScopeFactory>().CreateScope();
+
+            // Bind scoping request into the OData container.
+            if (routeName != null)
+            {
+                scope.ServiceProvider.GetRequiredService<HttpRequestScope>().HttpRequest = request;
+            }
+
+            return scope;
         }
     }
 }

--- a/src/Microsoft.AspNet.OData/HttpRequestScope.cs
+++ b/src/Microsoft.AspNet.OData/HttpRequestScope.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+
+namespace Microsoft.AspNet.OData
+{
+    /// <summary>
+    /// Provides access to the <see cref="HttpRequestMessage"/>
+    /// to which the OData service container instance is scoped.
+    /// </summary>
+    public class HttpRequestScope
+    {
+        /// <summary>
+        /// Provides access to the <see cref="HttpRequestMessage"/>
+        /// to which the OData service container instance is scoped.
+        /// </summary>
+        public HttpRequestMessage HttpRequest { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
+++ b/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Formatter\Serialization\ODataSerializerContext.cs" />
     <Compile Include="Formatter\Serialization\ODataSerializerProvider.cs" />
     <Compile Include="Formatter\Serialization\ODataSerializerProviderProxy.cs" />
+    <Compile Include="HttpRequestScope.cs" />
     <Compile Include="PerRouteContainer.cs" />
     <Compile Include="GetNextPageHelper.cs" />
     <Compile Include="Batch\UnbufferedODataBatchHandler.cs" />

--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -400,7 +400,15 @@ namespace Microsoft.AspNet.OData.Extensions
                 throw Error.ArgumentNull("routeName");
             }
 
-            return rootContainer.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            IServiceScope scope = rootContainer.GetRequiredService<IServiceScopeFactory>().CreateScope();
+
+            // Bind scoping request into the OData container.
+            if (!string.IsNullOrEmpty(routeName))
+            {
+                scope.ServiceProvider.GetRequiredService<HttpRequestScope>().HttpRequest = request;
+            }
+
+            return scope;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/HttpRequestScope.cs
+++ b/src/Microsoft.AspNetCore.OData/HttpRequestScope.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNet.OData
+{
+    /// <summary>
+    /// Provides access to the <see cref="HttpRequest"/>
+    /// to which the OData service container instance is scoped.
+    /// </summary>
+    public class HttpRequestScope
+    {
+        /// <summary>
+        /// Provides access to the <see cref="HttpRequest"/>
+        /// to which the OData service container instance is scoped.
+        /// </summary>
+        public HttpRequest HttpRequest { get; set; }
+    }
+}

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -399,6 +399,12 @@ public class Microsoft.AspNet.OData.ETagMessageHandler : System.Net.Http.Delegat
 	protected virtual System.Threading.Tasks.Task`1[[System.Net.Http.HttpResponseMessage]] SendAsync (System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
 }
 
+public class Microsoft.AspNet.OData.HttpRequestScope {
+	public HttpRequestScope ()
+
+	System.Net.Http.HttpRequestMessage HttpRequest  { public get; public set; }
+}
+
 public class Microsoft.AspNet.OData.MetadataController : ODataController, IDisposable, IHttpController {
 	public MetadataController ()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

This PR splits out `ODataServiceCollectionExtensions.AddODataCore()` that does not add OData formatters and action selectors, and adds code to bind `HttpRequest(Message)` into the per-request instance of OData per-route container.