### PR TITLE
Add DefaultQuerySettings and ODataOptions to Di container as required…

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Common/Error.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Common/Error.cs
@@ -114,7 +114,7 @@ namespace Microsoft.AspNet.OData.Common
         /// <returns>The logged <see cref="Exception"/>.</returns>
         internal static ArgumentNullException ArgumentNull(string parameterName, string messageFormat, params object[] messageArgs)
         {
-            return Error.ArgumentNull(parameterName, Error.Format(messageFormat, messageArgs));
+            return new ArgumentNullException(parameterName, Error.Format(messageFormat, messageArgs));
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData/Adapters/WebApiActionDescriptor.cs
+++ b/src/Microsoft.AspNet.OData/Adapters/WebApiActionDescriptor.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNet.OData.Adapters
             if (actionDescriptor.SupportedHttpMethods != null)
             {
                 this.supportedHttpMethods = new List<ODataRequestMethod>();
-                foreach (System.Net.Http.HttpMethod method in actionDescriptor.SupportedHttpMethods)
+                foreach (HttpMethod method in actionDescriptor.SupportedHttpMethods)
                 {
                     bool ignoreCase = true;
                     ODataRequestMethod methodEnum = ODataRequestMethod.Unknown;

--- a/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
+++ b/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
@@ -12,7 +12,6 @@
     <RunCodeAnalysis Condition=" '$(CodeAnalysis)' == '' and '$(Configuration)' != 'Release' ">true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Strict.ruleset</CodeAnalysisRuleSet>
     <StyleCopEnabled Condition=" '$(StyleCopEnabled)' == '' ">true</StyleCopEnabled>
-    <DefineConstants>$(DefineConstants);ASPNETODATA;ASPNETWEBAPI</DefineConstants>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <DefineConstants>$(DefineConstants);ASPNETODATA;ASPNETWEBAPI;NETFX;NETFX45</DefineConstants>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.OData/Extensions/ODataRouteBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ODataRouteBuilderExtensions.cs
@@ -158,6 +158,11 @@ namespace Microsoft.AspNet.OData.Extensions
                 builder.AddService<IODataPathTemplateHandler, DefaultODataPathHandler>(ServiceLifetime.Singleton);
                 builder.AddService<IETagHandler, DefaultODataETagHandler>(ServiceLifetime.Singleton);
 
+                // TODO #1147 - These are used by some constructors and the IOptions<> versions
+                // don't work in that case.
+                builder.AddService<ODataOptions, ODataOptions>(ServiceLifetime.Singleton);
+                builder.AddService<DefaultQuerySettings, DefaultQuerySettings>(ServiceLifetime.Singleton);
+
                 // Add the default webApi services.
                 builder.AddDefaultWebApiServices();
 

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -7,6 +7,7 @@
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <CodeAnalysisRuleSet>..\Strict.ruleset</CodeAnalysisRuleSet>
     <DefineConstants>$(DefineConstants);ASPNETODATA;ASPNETWEBAPI;NETCORE;NETCORE2x;NOT_CLS_COMPLIANT</DefineConstants>
+    <RootNamespace>Microsoft.AspNetCore.OData</RootNamespace>
     <!-- Let's generate our own assembly info -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
@@ -84,7 +84,11 @@ namespace Microsoft.AspNet.OData.Routing
                     .Where(c => c.Parameters.All(p => context.RouteData.Values.ContainsKey(p.Name)))
                     .OrderByDescending(c => c.Parameters.Count);
 
-                return matchedCandidates.FirstOrDefault();
+                // Return either the best matched candidate or the first
+                // candidate if none matched.
+                return (matchedCandidates.Any())
+                    ? matchedCandidates.FirstOrDefault()
+                    : candidates.FirstOrDefault();
             }
 
             return _innerSelector.SelectBestCandidate(context, candidates);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request makes progress on issues #975, #939, #772, #628, #229, 

### Description

Add DefaultQuerySettings and ODataOptions to Di container as required by some class constructors.
Allow action selector to pick a default method if none have matched.
Fix StackOverflow in ArgumentNullException()
Minor code cleanup.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x ] *Build and test with one-click build and test script passed*

### Additional work necessary

Refactor Batching and Formatting for AspNetCore.
Port Unit Tests to NetCore & Xunit 2.0
Port E2E Tests to NetCore & Xunit 2.0
