### PR TITLE
Implement FromODataUriAttribute & ODataQueryParameterBindingAttribute.

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/ODataQueryParameterBindingAttribute.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ODataQueryParameterBindingAttribute.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using Microsoft.AspNet.OData.Query;
+
 namespace Microsoft.AspNet.OData
 {
     /// <summary>
@@ -8,5 +13,17 @@ namespace Microsoft.AspNet.OData
     /// </summary>
     public partial class ODataQueryParameterBindingAttribute
     {
+        internal static Type GetEntityClrTypeFromParameterType(Type parameterType)
+        {
+            Contract.Assert(parameterType != null);
+
+            if (parameterType.IsGenericType &&
+                parameterType.GetGenericTypeDefinition() == typeof(ODataQueryOptions<>))
+            {
+                return parameterType.GetGenericArguments().Single();
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Microsoft.AspNet.OData/Formatter/ODataModelBinderProvider.cs
+++ b/src/Microsoft.AspNet.OData/Formatter/ODataModelBinderProvider.cs
@@ -23,6 +23,10 @@ namespace Microsoft.AspNet.OData.Formatter
     /// <summary>
     /// Provides a <see cref="IModelBinder"/> for EDM primitive types.
     /// </summary>
+    /// <remarks>
+    /// This class is similar to ODataModelBinder in AspNetCore. The flow is similar but the
+    /// type are dissimilar enough making a common version more complex than separate versions.
+    /// </remarks>
     public class ODataModelBinderProvider : ModelBinderProvider
     {
         /// <inheritdoc />

--- a/src/Microsoft.AspNet.OData/ODataQueryParameterBindingAttribute.cs
+++ b/src/Microsoft.AspNet.OData/ODataQueryParameterBindingAttribute.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading;
@@ -73,7 +71,7 @@ namespace Microsoft.AspNet.OData
                 // Get the entity type from the parameter type if it is ODataQueryOptions<T>.
                 // Fall back to the return type if not. Also, note that the entity type from the return type and ODataQueryOptions<T>
                 // can be different (example implementing $select or $expand).
-                Type entityClrType = GetEntityClrTypeFromParameterType(Descriptor) ?? GetEntityClrTypeFromActionReturnType(actionDescriptor);
+                Type entityClrType = GetEntityClrTypeFromParameterType(Descriptor.ParameterType) ?? GetEntityClrTypeFromActionReturnType(actionDescriptor);
 
                 IEdmModel userModel = request.GetModel();
                 IEdmModel model = userModel != EdmCoreModel.Instance ? userModel : actionDescriptor.GetEdmModel(entityClrType);
@@ -123,22 +121,6 @@ namespace Microsoft.AspNet.OData
                 }
 
                 return entityClrType;
-            }
-
-            internal static Type GetEntityClrTypeFromParameterType(HttpParameterDescriptor parameterDescriptor)
-            {
-                Contract.Assert(parameterDescriptor != null);
-
-                Type parameterType = parameterDescriptor.ParameterType;
-                Contract.Assert(parameterType != null);
-
-                if (parameterType.IsGenericType &&
-                    parameterType.GetGenericTypeDefinition() == typeof(ODataQueryOptions<>))
-                {
-                    return parameterType.GetGenericArguments().Single();
-                }
-
-                return null;
             }
         }
     }

--- a/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
@@ -182,21 +182,7 @@ namespace Microsoft.AspNet.OData
             {
                 // user has not configured anything or has registered a model without the element type
                 // let's create one just for this type and cache it in the action descriptor
-                string key = ModelKeyPrefix + elementClrType.FullName;
-                object modelAsObject = null;
-                if (!actionDescriptor.Properties.TryGetValue(key, out modelAsObject))
-                {
-                    ODataConventionModelBuilder builder =
-                        new ODataConventionModelBuilder(request.HttpContext.RequestServices, isQueryCompositionMode: true);
-                    EntityTypeConfiguration entityTypeConfiguration = builder.AddEntityType(elementClrType);
-                    builder.AddEntitySet(elementClrType.Name, entityTypeConfiguration);
-                    model = builder.GetEdmModel();
-                    actionDescriptor.Properties.Add(key, model);
-                }
-                else
-                {
-                    model = modelAsObject as IEdmModel;
-                }
+                model = actionDescriptor.GetEdmModel(request, elementClrType);
             }
 
             Contract.Assert(model != null);

--- a/src/Microsoft.AspNetCore.OData/Extensions/ActionDescriptorExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ActionDescriptorExtensions.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNet.OData.Extensions
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class ActionDescriptorExtensions
+    {
+        // Maintain the Microsoft.AspNet.OData. prefix in any new properties to avoid conflicts with user properties
+        // and those of the v3 assembly.  Concern is reduced here due to addition of user type name but prefix
+        // also clearly ties the property to code in this assembly.
+        private const string ModelKeyPrefix = "Microsoft.AspNet.OData.Model+";
+
+        internal static IEdmModel GetEdmModel(this ActionDescriptor actionDescriptor, HttpRequest request, Type entityClrType)
+        {
+            if (actionDescriptor == null)
+            {
+                throw Error.ArgumentNull("actionDescriptor");
+            }
+
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
+            if (entityClrType == null)
+            {
+                throw Error.ArgumentNull("entityClrType");
+            }
+
+            IEdmModel model = null;
+
+            string key = ModelKeyPrefix + entityClrType.FullName;
+            object modelAsObject = null;
+            if (actionDescriptor.Properties.TryGetValue(key, out modelAsObject))
+            {
+                model = modelAsObject as IEdmModel;
+            }
+            else
+            {
+                ODataConventionModelBuilder builder =
+                    new ODataConventionModelBuilder(request.HttpContext.RequestServices, isQueryCompositionMode: true);
+                EntityTypeConfiguration entityTypeConfiguration = builder.AddEntityType(entityClrType);
+                builder.AddEntitySet(entityClrType.Name, entityTypeConfiguration);
+                model = builder.GetEdmModel();
+                actionDescriptor.Properties.Add(key, model);
+            }
+
+            return model;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -167,7 +167,7 @@ namespace Microsoft.AspNet.OData.Extensions
                 }
 
                 // get the etag handler, and parse the etag
-                IETagHandler etagHandler = request.HttpContext.RequestServices.GetRequiredService<IETagHandler>();
+                IETagHandler etagHandler = request.GetRequestContainer().GetRequiredService<IETagHandler>();
                 IDictionary<string, object> properties = etagHandler.ParseETag(entityTagHeaderValue) ?? new Dictionary<string, object>();
                 IList<object> parsedETagValues = properties.Select(property => property.Value).AsList();
 

--- a/src/Microsoft.AspNetCore.OData/Extensions/ODataRouteBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ODataRouteBuilderExtensions.cs
@@ -502,7 +502,7 @@ namespace Microsoft.AspNet.OData.Extensions
         /// Remote the trailing slash from a route prefix string.
         /// </summary>
         /// <param name="routePrefix">The route prefix string.</param>
-        /// <returns>The route prefix string without a strainling slash.</returns>
+        /// <returns>The route prefix string without a trailing slash.</returns>
         private static string RemoveTrailingSlash(string routePrefix)
         {
             if (!String.IsNullOrEmpty(routePrefix))

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataModelBinder.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataModelBinder.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Formatter;
+using Microsoft.AspNet.OData.Formatter.Deserialization;
+using Microsoft.AspNet.OData.Routing;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Primitives;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNet.OData.Formatter
+{
+    /// <summary>
+    /// A model binder for ODataParameterValue values.
+    /// </summary>
+    /// <remarks>
+    /// This class is similar to ODataModelBinderProvider in AspNet. The flow is similar but the
+    /// type are dissimilar enough making a common version more complex than separate versions.
+    /// </remarks>
+    internal class ODataModelBinder : IModelBinder
+    {
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We don't want to fail in model binding.")]
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            if (bindingContext == null)
+            {
+                throw Error.ArgumentNull("bindingContext");
+            }
+
+            if (bindingContext.ModelMetadata == null)
+            {
+                throw Error.Argument("bindingContext", SRResources.ModelBinderUtil_ModelMetadataCannotBeNull);
+            }
+
+            ValueProviderResult valueProviderResult = ValueProviderResult.None;
+            string modelName = ODataParameterValue.ParameterValuePrefix + bindingContext.ModelName;
+            try
+            {
+                // Look in route data for a ODataParameterValue.
+                object valueAsObject = null;
+                if (!bindingContext.HttpContext.Request.ODataFeature().RoutingConventionsStore.TryGetValue(modelName, out valueAsObject))
+                {
+                    bindingContext.ActionContext.RouteData.Values.TryGetValue(modelName, out valueAsObject);
+                }
+
+                if (valueAsObject != null)
+                {
+                    StringValues stringValues = new StringValues(valueAsObject.ToString());
+                    valueProviderResult = new ValueProviderResult(stringValues);
+                    bindingContext.ModelState.SetModelValue(bindingContext.ModelName, valueProviderResult);
+
+                    ODataParameterValue paramValue = valueAsObject as ODataParameterValue;
+                    if (paramValue != null)
+                    {
+                        HttpRequest request = bindingContext.HttpContext.Request;
+                        object model = ConvertTo(paramValue, bindingContext, request.GetRequestContainer());
+                        bindingContext.Result = ModelBindingResult.Success(model);
+                        return Task.CompletedTask;
+                    }
+                }
+                else
+                {
+                    // If not in the route data, ask the value provider.
+                    valueProviderResult = bindingContext.ValueProvider.GetValue(modelName);
+                    if (valueProviderResult == ValueProviderResult.None)
+                    {
+                        valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+                    }
+
+                    if (valueProviderResult != ValueProviderResult.None)
+                    {
+                        bindingContext.ModelState.SetModelValue(bindingContext.ModelName, valueProviderResult);
+
+                        object model = ODataModelBinderConverter.ConvertTo(valueProviderResult.FirstValue, bindingContext.ModelType);
+                        if (model != null)
+                        {
+                            bindingContext.Result = ModelBindingResult.Success(model);
+                            return Task.CompletedTask;
+                        }
+                    }
+                }
+
+                // No matches, binding failed.
+                bindingContext.Result = ModelBindingResult.Failed();
+            }
+            catch (ODataException ex)
+            {
+                bindingContext.ModelState.AddModelError(bindingContext.ModelName, ex.Message);
+                bindingContext.Result = ModelBindingResult.Failed();
+            }
+            catch (ValidationException ex)
+            {
+                bindingContext.ModelState.AddModelError(bindingContext.ModelName, Error.Format(SRResources.ValueIsInvalid, valueProviderResult.FirstValue, ex.Message));
+                bindingContext.Result = ModelBindingResult.Failed();
+            }
+            catch (FormatException ex)
+            {
+                bindingContext.ModelState.AddModelError(bindingContext.ModelName, Error.Format(SRResources.ValueIsInvalid, valueProviderResult.FirstValue, ex.Message));
+                bindingContext.Result = ModelBindingResult.Failed();
+            }
+            catch (Exception e)
+            {
+                bindingContext.ModelState.AddModelError(bindingContext.ModelName, e.Message);
+                bindingContext.Result = ModelBindingResult.Failed();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        internal static object ConvertTo(ODataParameterValue parameterValue, ModelBindingContext bindingContext, IServiceProvider requestContainer)
+        {
+            Contract.Assert(parameterValue != null && parameterValue.EdmType != null);
+
+            object oDataValue = parameterValue.Value;
+            if (oDataValue == null || oDataValue is ODataNullValue)
+            {
+                return null;
+            }
+
+            IEdmTypeReference edmTypeReference = parameterValue.EdmType;
+            ODataDeserializerContext readContext = BuildDeserializerContext(bindingContext, edmTypeReference);
+            return ODataModelBinderConverter.Convert(oDataValue, edmTypeReference, bindingContext.ModelType,
+                bindingContext.ModelName, readContext, requestContainer);
+        }
+
+        internal static ODataDeserializerContext BuildDeserializerContext(ModelBindingContext bindingContext, IEdmTypeReference edmTypeReference)
+        {
+            HttpRequest request = bindingContext.HttpContext.Request;
+            ODataPath path = request.ODataFeature().Path;
+            IEdmModel edmModel = request.GetModel();
+
+            return new ODataDeserializerContext
+            {
+                Path = path,
+                Model = edmModel,
+                Request = request,
+                ResourceType = bindingContext.ModelType,
+                ResourceEdmType = edmTypeReference,
+            };
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/FromODataUriAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/FromODataUriAttribute.cs
@@ -3,7 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNet.OData.Formatter;
 
 namespace Microsoft.AspNet.OData
 {
@@ -13,18 +13,12 @@ namespace Microsoft.AspNet.OData
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Parameter, Inherited = true, AllowMultiple = false)]
     public sealed class FromODataUriAttribute : ModelBinderAttribute
     {
-        /// <inheritdoc/>
-        public override BindingSource BindingSource
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="FromODataUriAttribute"/> class.
+        /// </summary>
+        public FromODataUriAttribute()
+            : base(typeof(ODataModelBinder))
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
-
-            protected set
-            {
-                throw new NotImplementedException();
-            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/NonValidatingParameterBindingAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/NonValidatingParameterBindingAttribute.cs
@@ -2,17 +2,23 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
 namespace Microsoft.AspNet.OData
 {
     /// <summary>
     /// An attribute to disable WebApi model validation for a particular type.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
-    internal sealed partial class NonValidatingParameterBindingAttribute : Attribute, IBindingSourceMetadata
+    /// <remarks>
+    /// This is essentially a <see cref="ValidateNeverAttribute"/>.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    internal sealed partial class NonValidatingParameterBindingAttribute : Attribute, IPropertyValidationFilter
     {
-        public BindingSource BindingSource => throw new NotImplementedException();
+        /// <inheritdoc />
+        public bool ShouldValidateEntry(ValidationEntry entry, ValidationEntry parentEntry)
+        {
+            return false;
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/ODataFeature.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataFeature.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData;
@@ -23,12 +24,16 @@ namespace Microsoft.AspNet.OData
         internal const string ODataServiceVersionHeader = "OData-Version";
         internal const ODataVersion DefaultODataVersion = ODataVersion.V4;
 
+        private long? totalCount;
+        private bool totalCountSet;
+
         /// <summary>
         /// Instantiates a new instance of the <see cref="ODataFeature"/> class.
         /// </summary>
         public ODataFeature()
         {
             Model = EdmCoreModel.Instance; // default Edm model
+            totalCountSet = false;
         }
 
         /// <summary>
@@ -78,7 +83,36 @@ namespace Microsoft.AspNet.OData
         /// Gets or sets the total count for the OData response.
         /// </summary>
         /// <value><c>null</c> if no count should be sent back to the client.</value>
-        public long? TotalCount { get; set; }
+        public long? TotalCount
+        {
+            get
+            {
+                if (this.totalCountSet)
+                {
+                    return this.totalCount;
+                }
+
+                if (this.TotalCountFunc != null)
+                {
+                    this.totalCount = this.TotalCountFunc();
+                    this.totalCountSet = true;
+                    return this.totalCount;
+                }
+
+                return null;
+            }
+
+            set
+            {
+                if (!value.HasValue)
+                {
+                    throw Error.ArgumentNull("value");
+                }
+
+                this.totalCount = value;
+                this.totalCountSet = true;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the total count function for the OData response.

--- a/src/Microsoft.AspNetCore.OData/ODataNullValueMessageHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataNullValueMessageHandler.cs
@@ -1,13 +1,58 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System.Net;
+using System.Net.Http;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
 namespace Microsoft.AspNet.OData
 {
     /// <summary>
-    /// Represents an <see href="HttpMessageHandler" /> that converts null values in OData responses to
+    /// Represents an <see href="IResultFilter" /> that converts null values in OData responses to
     /// HTTP NotFound responses or NoContent responses following the OData specification.
     /// </summary>
-    public partial class ODataNullValueMessageHandler
+    public partial class ODataNullValueMessageHandler : IResultFilter
     {
+        /// <inheritdocs/>
+        public void OnResultExecuting(ResultExecutingContext context)
+        {
+            if (context == null)
+            {
+                throw Error.ArgumentNull("context");
+            }
+
+            HttpRequest request = context.HttpContext.Request;
+            HttpResponse response = context.HttpContext.Response;
+
+            // Only operate on OData requests.
+            if (request.ODataFeature().Path != null)
+            {
+                // This message handler is intended for helping with queries that return a null value, for example in a
+                // get request for a particular entity on an entity set, for a single valued navigation property or for
+                // a structural property of a given entity. The only case in which a data modification request will result
+                // in a 204 response status code, is when a primitive property is set to null through a PUT request to the
+                // property URL and in that case, the user can return the right status code himself.
+                ObjectResult objectResult = context.Result as ObjectResult;
+                if (request.Method == HttpMethod.Get.ToString() && objectResult != null && objectResult.Value == null &&
+                    response.StatusCode == (int)HttpStatusCode.OK)
+                {
+                    HttpStatusCode? newStatusCode = GetUpdatedResponseStatusCodeOrNull(request.ODataFeature().Path);
+                    if (newStatusCode.HasValue)
+                    {
+                        response.StatusCode = (int)newStatusCode.Value;
+                    }
+                }
+            }
+        }
+
+        /// <inheritdocs/>
+        public void OnResultExecuted(ResultExecutedContext context)
+        {
+            // Can't add to headers here because response has already begun.
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/ODataQueryParameterBindingAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataQueryParameterBindingAttribute.cs
@@ -2,15 +2,143 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Query;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.OData.Edm;
 
 namespace Microsoft.AspNet.OData
 {
     /// <summary>
-    /// A <see cref="Attribute"/> to bind parameters of type <see cref="ODataQueryOptions"/> to the OData query from the incoming request.
+    /// A <see cref="ModelBinderAttribute"/> to bind parameters of type <see cref="ODataQueryOptions"/> to the OData query from the incoming request.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Parameter, Inherited = true, AllowMultiple = false)]
-    public sealed partial class ODataQueryParameterBindingAttribute : Attribute
+    public sealed partial class ODataQueryParameterBindingAttribute : ModelBinderAttribute
     {
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="ODataQueryParameterBindingAttribute"/> class.
+        /// </summary>
+        public ODataQueryParameterBindingAttribute()
+            :base(typeof(ODataQueryParameterBinding))
+        {
+        }
+
+        internal class ODataQueryParameterBinding : IModelBinder
+        {
+            private static MethodInfo _createODataQueryOptions = typeof(ODataQueryParameterBinding).GetMethod("CreateODataQueryOptions");
+            private const string CreateODataQueryOptionsCtorKey = "MS_CreateODataQueryOptionsOfT";
+
+            [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We don't want to fail in model binding.")]
+            public Task BindModelAsync(ModelBindingContext bindingContext)
+            {
+                if (bindingContext == null)
+                {
+                    throw Error.ArgumentNull("bindingContext");
+                }
+
+                HttpRequest request = bindingContext.HttpContext.Request;
+
+                if (request == null)
+                {
+                    throw Error.Argument("actionContext", SRResources.ActionContextMustHaveRequest);
+                }
+
+                ActionDescriptor actionDescriptor = bindingContext.ActionContext.ActionDescriptor;
+
+                if (actionDescriptor == null)
+                {
+                    throw Error.Argument("actionContext", SRResources.ActionContextMustHaveDescriptor);
+                }
+
+                // Get the entity type from the parameter type if it is ODataQueryOptions<T>.
+                // Fall back to the return type if not. Also, note that the entity type from the return type and ODataQueryOptions<T>
+                // can be different (example implementing $select or $expand).
+                Type entityClrType = null;
+                ParameterDescriptor paramDescriptor = bindingContext.ActionContext.ActionDescriptor.Parameters.FirstOrDefault();
+                if (paramDescriptor != null)
+                {
+                    entityClrType = GetEntityClrTypeFromParameterType(paramDescriptor.ParameterType);
+                }
+
+                if (entityClrType == null)
+                {
+                    entityClrType = GetEntityClrTypeFromActionReturnType(actionDescriptor);
+                }
+
+                IEdmModel userModel = request.GetModel();
+                IEdmModel model = userModel != EdmCoreModel.Instance ? userModel : actionDescriptor.GetEdmModel(request, entityClrType);
+                ODataQueryContext entitySetContext = new ODataQueryContext(model, entityClrType, request.ODataFeature().Path);
+
+                Func<ODataQueryContext, HttpRequest, ODataQueryOptions> createODataQueryOptions;
+                object constructorAsObject = null;
+                if (actionDescriptor.Properties.TryGetValue(CreateODataQueryOptionsCtorKey, out constructorAsObject))
+                {
+                    createODataQueryOptions = (Func<ODataQueryContext, HttpRequest, ODataQueryOptions>)constructorAsObject;
+                }
+                else
+                {
+                    createODataQueryOptions = (Func<ODataQueryContext, HttpRequest, ODataQueryOptions>)
+                        Delegate.CreateDelegate(typeof(Func<ODataQueryContext, HttpRequest, ODataQueryOptions>),
+                            _createODataQueryOptions.MakeGenericMethod(entityClrType));
+                };
+
+                ODataQueryOptions parameterValue = createODataQueryOptions(entitySetContext, request);
+                bindingContext.Result = ModelBindingResult.Success(parameterValue);
+
+                return TaskHelpers.Completed();
+            }
+
+            public static ODataQueryOptions<T> CreateODataQueryOptions<T>(ODataQueryContext context, HttpRequest request)
+            {
+                return new ODataQueryOptions<T>(context, request);
+            }
+
+            internal static Type GetEntityClrTypeFromActionReturnType(ActionDescriptor actionDescriptor)
+            {
+                // It is a developer programming error to use this binding attribute
+                // on actions that return void.
+                ControllerActionDescriptor controllerActionDescriptor = actionDescriptor as ControllerActionDescriptor;
+                if (controllerActionDescriptor == null)
+                {
+                    throw Error.InvalidOperation(
+                                    SRResources.FailedToBuildEdmModelBecauseReturnTypeIsNull,
+                                    actionDescriptor.DisplayName,
+                                    actionDescriptor.ToString());
+                }
+
+                if (controllerActionDescriptor.MethodInfo.ReturnType == null)
+                {
+                    throw Error.InvalidOperation(
+                                    SRResources.FailedToBuildEdmModelBecauseReturnTypeIsNull,
+                                    controllerActionDescriptor.ActionName,
+                                    controllerActionDescriptor.ControllerName);
+                }
+
+                Type entityClrType = TypeHelper.GetImplementedIEnumerableType(controllerActionDescriptor.MethodInfo.ReturnType);
+
+                if (entityClrType == null)
+                {
+                    // It is a developer programming error to use this binding attribute
+                    // on actions that return a collection whose element type cannot be
+                    // determined, such as a non-generic IQueryable or IEnumerable.
+                    throw Error.InvalidOperation(
+                                    SRResources.FailedToRetrieveTypeToBuildEdmModel,
+                                    controllerActionDescriptor.ActionName,
+                                    controllerActionDescriptor.ControllerName,
+                                    controllerActionDescriptor.MethodInfo.ReturnType.FullName);
+                }
+
+                return entityClrType;
+            }
+        }
     }
 }

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Query/ODataQueryParameterBindingAttributeTests.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Query/ODataQueryParameterBindingAttributeTests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Test.AspNet.OData.Query
 
             Assert.Equal(
                 elementType,
-                ODataQueryParameterBindingAttribute.ODataQueryParameterBinding.GetEntityClrTypeFromParameterType(parameter.Object));
+                ODataQueryParameterBindingAttribute.GetEntityClrTypeFromParameterType(parameter.Object.ParameterType));
         }
 
         [Theory]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request makes progress on issues #975, #939, #772, #628, #229, 
This pull request fixes issues #1142, #1149, #1153 

### Description

Implement NonValidatingParameterBindingAttribute.
Implement ODataNullValueMessageHandler as a IResultFilter.
Implement ODataQueryParameterBindingAttribute.
Fixed $count calculation in ODataFeature.TotalCount.
Fixed an ETag is where the etag handler was not being retrieved from the per-route service container.
Refactor EnableQueryAttribute to move model retrieval to ActionDescriptorExtensions.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x ] *Build and test with one-click build and test script passed*

### Additional work necessary

Refactor Batching and Formatting for AspNetCore.
Port Unit Tests to NetCore & Xunit 2.0
Port E2E Tests to NetCore & Xunit 2.0
