### PR TITLE
[feature/netcore] Fix OData model builder

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/ODataConventionModelBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/ODataConventionModelBuilder.cs
@@ -1067,7 +1067,7 @@ namespace Microsoft.AspNet.OData.Builder
         private static Dictionary<Type, List<Type>> BuildDerivedTypesMapping(IWebApiAssembliesResolver assemblyResolver)
         {
             IEnumerable<Type> allTypes = TypeHelper.GetLoadedTypes(assemblyResolver).Where(t => TypeHelper.IsVisible(t) && TypeHelper.IsClass(t) && t != typeof(object));
-            Dictionary<Type, List<Type>> allTypeMapping = allTypes.ToDictionary(k => k, k => new List<Type>());
+            Dictionary<Type, List<Type>> allTypeMapping = allTypes.Distinct().ToDictionary(k => k, k => new List<Type>());
 
             foreach (Type type in allTypes)
             {


### PR DESCRIPTION
### Description
OData model builder throws an exception in a case when a list of application parts contains duplicates.
 
### Simple code to reproduce a bug
```
public class Startup
{
    public IServiceProvider ConfigureServices(IServiceCollection services)
    {
        var assembly = typeof(ControllerInLibrary).GetTypeInfo().Assembly; 
        
        services.AddMvc()
            .AddApplicationPart(assembly)
            .AddApplicationPart(assembly);

        services.AddOData();
    }

    public void Configure(IApplicationBuilder app)
    {
        IEdmModel model = GetEdmModel(app.ApplicationServices);
        app.UseMvc(routeBuilder => routeBuilder.MapODataServiceRoute("odata", "odata", model));
    }
}
```