### PR TITLE
[feature/netcore] Fix $count parameter

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSetSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSetSerializer.cs
@@ -209,7 +209,8 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                     resourceSet.NextPageLink = writeContext.InternalRequest.Context.NextLink;
                     resourceSet.DeltaLink = writeContext.InternalRequest.Context.DeltaLink;
 
-                    long? countValue = writeContext.InternalRequest.Context.TotalCount;
+                    long? countValue = writeContext.InternalRequest.Context.TotalCount
+                        ?? writeContext.InternalRequest.Context.TotalCountFunc?.Invoke();
                     if (countValue.HasValue)
                     {
                         resourceSet.Count = countValue.Value;


### PR DESCRIPTION
### Description

*In a case when $count parameter is specified OData request processor ignores it and doesn't return count of records.*