### PR TITLE
[feature/netcore] Fix implementation of WebApiAssembliesResolver to return a list of distinct assemblies

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Adapters/WebApiAssembliesResolver.cs
+++ b/src/Microsoft.AspNetCore.OData/Adapters/WebApiAssembliesResolver.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.OData.Adapters
                 if (this.innerManager != null)
                 {
                     IList<ApplicationPart> parts = this.innerManager.ApplicationParts;
-                    return parts.Where(p => p is AssemblyPart).Select(p => (p as AssemblyPart).Assembly);
+                    return parts.Where(p => p is AssemblyPart).Select(p => (p as AssemblyPart).Assembly).Distinct();
                 }
 
                 // Cannot get the list of assemblies without an innerManager.


### PR DESCRIPTION
### Issue
The 'Assemblies' property of WebApiAssembliesResolver returns duplicated assemblies in a case when application part/assembly added to a collection of the ApplicationPartManager more than once (currently, there is no restriction to do this). As a result, OData model builder throws an exception during model configuration.

### Simple code to reproduce a bug
```
public class Startup
{
    public IServiceProvider ConfigureServices(IServiceCollection services)
    {
        var assembly = typeof(ControllerInLibrary).GetTypeInfo().Assembly; 
        
        services.AddMvc()
            .AddApplicationPart(assembly)
            .AddApplicationPart(assembly);

        services.AddOData();
    }

    public void Configure(IApplicationBuilder app)
    {
        IEdmModel model = GetEdmModel(app.ApplicationServices);
        app.UseMvc(routeBuilder => routeBuilder.MapODataServiceRoute("odata", "odata", model));
    }
}
```