### PR TITLE
Matching parameter by name when binding ODataQueryOptions.

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/IPerRouteContainer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/IPerRouteContainer.cs
@@ -27,12 +27,5 @@ namespace Microsoft.AspNet.OData
         /// <param name="routeName">The route name.</param>
         /// <returns>The root container for the route name.</returns>
         IServiceProvider GetODataRootContainer(string routeName);
-
-        /// <summary>
-        /// Create a root container not associated with a route.
-        /// </summary>
-        /// <param name="configureAction">The configuration actions to apply to the container.</param>
-        /// <returns>An instance of <see cref="IServiceProvider"/> to manage services for a route.</returns>
-        IServiceProvider CreateODataRootContainer(Action<IContainerBuilder> configureAction);
     }
 }

--- a/src/Microsoft.AspNet.OData/Extensions/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.AspNet.OData/Extensions/HttpConfigurationExtensions.cs
@@ -499,8 +499,7 @@ namespace Microsoft.AspNet.OData.Extensions
 
             // Get the per-route container and create a new non-route container.
             IPerRouteContainer perRouteContainer = GetPerRouteContainer(configuration);
-            IServiceProvider rootContainer = perRouteContainer.CreateODataRootContainer(ConfigureDefaultServices(configuration, configureAction));
-            configuration.Properties[NonODataRootContainerKey] = rootContainer;
+            perRouteContainer.CreateODataRootContainer(null, ConfigureDefaultServices(configuration, configureAction));
         }
 
         /// <summary>
@@ -786,6 +785,32 @@ namespace Microsoft.AspNet.OData.Extensions
             }
 
             throw Error.InvalidOperation(SRResources.NoNonODataHttpRouteRegistered);
+        }
+
+        /// <summary>
+        /// Enables dependency injection support for HTTP routes.
+        /// </summary>
+        /// <param name="configuration">The server configuration.</param>
+        /// <param name="rootContainer">The root container.</param>
+        internal static void SetNonODataRootContainer(this HttpConfiguration configuration,
+            IServiceProvider rootContainer)
+        {
+            if (configuration == null)
+            {
+                throw Error.ArgumentNull("configuration");
+            }
+
+            if (rootContainer == null)
+            {
+                throw Error.ArgumentNull("rootContainer");
+            }
+
+            if (configuration.Properties.ContainsKey(NonODataRootContainerKey))
+            {
+                throw Error.InvalidOperation(SRResources.CannotReEnableDependencyInjection);
+            }
+
+            configuration.Properties[NonODataRootContainerKey] = rootContainer;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.AspNet.OData/Extensions/HttpRequestMessageExtensions.cs
@@ -413,11 +413,7 @@ namespace Microsoft.AspNet.OData.Extensions
                 throw Error.Argument("request", SRResources.RequestMustContainConfiguration);
             }
 
-            // Requests from OData routes will have RouteName set.
-            IServiceProvider rootContainer = (routeName != null)
-                ? configuration.GetODataRootContainer(routeName)
-                : configuration.GetNonODataRootContainer();
-
+            IServiceProvider rootContainer = configuration.GetODataRootContainer(routeName);
             return rootContainer.GetRequiredService<IServiceScopeFactory>().CreateScope();
         }
     }

--- a/src/Microsoft.AspNet.OData/PerRouteContainer.cs
+++ b/src/Microsoft.AspNet.OData/PerRouteContainer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Web.Http;
 using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Formatter.Serialization;
 
 namespace Microsoft.AspNet.OData
@@ -32,7 +33,7 @@ namespace Microsoft.AspNet.OData
         {
             if (String.IsNullOrEmpty(routeName))
             {
-                throw Error.ArgumentNull("routeName");
+                return configuration.GetNonODataRootContainer();
             }
 
             IServiceProvider rootContainer;
@@ -53,17 +54,19 @@ namespace Microsoft.AspNet.OData
         /// <remarks>Used by unit tests to insert root containers.</remarks>
         internal override void SetODataRootContainer(string routeName, IServiceProvider rootContainer)
         {
-            if (String.IsNullOrEmpty(routeName))
-            {
-                throw Error.ArgumentNull("routeName");
-            }
-
             if (rootContainer == null)
             {
                 throw Error.InvalidOperation(SRResources.NullContainer);
             }
 
-            this.GetRootContainerMappings()[routeName] = rootContainer;
+            if (String.IsNullOrEmpty(routeName))
+            {
+                configuration.SetNonODataRootContainer(rootContainer);
+            }
+            else
+            {
+                this.GetRootContainerMappings()[routeName] = rootContainer;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Adapters/WebApiRequestMessage.cs
+++ b/src/Microsoft.AspNetCore.OData/Adapters/WebApiRequestMessage.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNet.OData.Adapters
         {
             get
             {
-                string method = this.innerRequest.Method.ToString().ToUpperInvariant();
+                string method = this.innerRequest.Method.ToUpperInvariant();
 
                 bool ignoreCase = true;
                 ODataRequestMethod methodEnum = ODataRequestMethod.Unknown;

--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -388,26 +388,16 @@ namespace Microsoft.AspNet.OData.Extensions
         /// <returns></returns>
         private static IServiceScope CreateRequestScope(this HttpRequest request, string routeName)
         {
-            IServiceProvider rootContainer;
-            if (string.IsNullOrEmpty(routeName))
+            IPerRouteContainer perRouteContainer = request.HttpContext.RequestServices.GetRequiredService<IPerRouteContainer>();
+            if (perRouteContainer == null)
             {
-                // For HTTP routes, use the default request services.
-                rootContainer = request.HttpContext.RequestServices;
+                throw Error.ArgumentNull("routeName");
             }
-            else
-            {
-                // For OData routes, create a scoped requested from the per-route container.
-                IPerRouteContainer perRouteContainer = request.HttpContext.RequestServices.GetRequiredService<IPerRouteContainer>();
-                if (perRouteContainer == null)
-                {
-                    throw Error.ArgumentNull("routeName");
-                }
 
-                rootContainer = perRouteContainer.GetODataRootContainer(routeName);
-                if (perRouteContainer == null)
-                {
-                    throw Error.ArgumentNull("routeName");
-                }
+            IServiceProvider rootContainer = perRouteContainer.GetODataRootContainer(routeName);
+            if (rootContainer == null)
+            {
+                throw Error.ArgumentNull("routeName");
             }
 
             return rootContainer.GetRequiredService<IServiceScopeFactory>().CreateScope();

--- a/src/Microsoft.AspNetCore.OData/ODataQueryParameterBindingAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataQueryParameterBindingAttribute.cs
@@ -63,7 +63,9 @@ namespace Microsoft.AspNet.OData
                 // Fall back to the return type if not. Also, note that the entity type from the return type and ODataQueryOptions<T>
                 // can be different (example implementing $select or $expand).
                 Type entityClrType = null;
-                ParameterDescriptor paramDescriptor = bindingContext.ActionContext.ActionDescriptor.Parameters.FirstOrDefault();
+                ParameterDescriptor paramDescriptor = bindingContext.ActionContext.ActionDescriptor.Parameters
+                    .Where(p => p.Name == bindingContext.FieldName)
+                    .FirstOrDefault();
                 if (paramDescriptor != null)
                 {
                     entityClrType = GetEntityClrTypeFromParameterType(paramDescriptor.ParameterType);

--- a/src/Microsoft.AspNetCore.OData/PerRouteContainer.cs
+++ b/src/Microsoft.AspNetCore.OData/PerRouteContainer.cs
@@ -11,6 +11,7 @@ namespace Microsoft.AspNet.OData
     internal class PerRouteContainer : PerRouteContainerBase
     {
         private ConcurrentDictionary<string, IServiceProvider> _perRouteContainers;
+        private IServiceProvider _nonODataRouteContainer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataSerializerContext"/> class.
@@ -29,7 +30,7 @@ namespace Microsoft.AspNet.OData
         {
             if (String.IsNullOrEmpty(routeName))
             {
-                throw Error.ArgumentNull("routeName");
+                return _nonODataRouteContainer;
             }
 
             IServiceProvider rootContainer;
@@ -49,17 +50,19 @@ namespace Microsoft.AspNet.OData
         /// <remarks>Used by unit tests to insert root containers.</remarks>
         internal override void SetODataRootContainer(string routeName, IServiceProvider rootContainer)
         {
-            if (String.IsNullOrEmpty(routeName))
-            {
-                throw Error.ArgumentNull("routeName");
-            }
-
             if (rootContainer == null)
             {
                 throw Error.InvalidOperation(SRResources.NullContainer);
             }
 
-            this._perRouteContainers.AddOrUpdate(routeName, rootContainer, (k, v) => rootContainer);
+            if (String.IsNullOrEmpty(routeName))
+            {
+                _nonODataRouteContainer = rootContainer;
+            }
+            else
+            {
+                this._perRouteContainers.AddOrUpdate(routeName, rootContainer, (k, v) => rootContainer);
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/NavigationSourceRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/NavigationSourceRoutingConvention.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
         /// Selects the action for OData requests.
         /// </summary>
         /// <param name="routeContext">The route context.</param>
-        /// <param name="controllerResult">The result of selecitng a controller.</param>
+        /// <param name="controllerResult">The result of selecting a controller.</param>
         /// <param name="actionDescriptors">The list of action descriptors.</param>
         /// <returns>
         ///   <c>null</c> if the request isn't handled by this convention; otherwise, the action descriptor of the selected action.

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
@@ -79,9 +79,10 @@ namespace Microsoft.AspNet.OData.Routing
             ODataPath odataPath = context.HttpContext.ODataFeature().Path;
             if (odataPath != null && routeData.Values.ContainsKey(ODataRouteConstants.Action))
             {
-                // Find the action with the greatest number of matched parameters.
+                // Find the action with the greatest number of matched parameters including
+                // matches with no parameters.
                 var matchedCandidates = candidates
-                    .Where(c => c.Parameters.All(p => context.RouteData.Values.ContainsKey(p.Name)))
+                    .Where(c => !c.Parameters.Any() || c.Parameters.Any(p => context.RouteData.Values.ContainsKey(p.Name)))
                     .OrderByDescending(c => c.Parameters.Count);
 
                 // Return either the best matched candidate or the first

--- a/test/UnitTest/Microsoft.Test.AspNet.OData.TestCommon/Microsoft.Test.AspNet.OData.TestCommon.csproj
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData.TestCommon/Microsoft.Test.AspNet.OData.TestCommon.csproj
@@ -114,6 +114,9 @@
   <ItemGroup>
     <Analyzer Include="..\..\..\sln\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request makes progress on issues #975, #939, #772, #628, #229.
This pull request fixes #1170, #1171, #1172 

### Description

Matching parameter by name when binding ODataQueryOptions.
Skip OData output formatting for non-OData routes.
Improved routing action selection.
Add EnableDependencyInjection() for non-OData routes.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x ] *Build and test with one-click build and test script passed*

### Additional work necessary

Refactor Batching for AspNetCore.
Port Unit Tests to NetCore
Port E2E Tests to NetCore & Xunit 2.0
