### PR TITLE
[feature/netcore] Fix errors, when execute check null in SelectExpandBinder

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -495,9 +495,10 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             Expression keysNullCheckExpression = null;
             foreach (var key in propertyToExpand.ToEntityType().Key())
             {
+                var propertyValueExpression = CreatePropertyValueExpressionWithFilter(propertyToExpand.ToEntityType(), key, propertyValue, null);
                 var keyExpression = Expression.Equal(
-                    CreatePropertyValueExpressionWithFilter(propertyToExpand.ToEntityType(), key, propertyValue, null),
-                    Expression.Constant(null));
+                    propertyValueExpression,
+                    Expression.Constant(null, propertyValueExpression.Type));
 
                 keysNullCheckExpression = keysNullCheckExpression == null
                     ? keyExpression


### PR DESCRIPTION
Fix errors, in some ORMs (e.g. LinqToDb), when execute check null in SelectExpandBinder

From PR #1081