### PR TITLE
Remove Model and IsValidODataRequest from IODataFeature

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Interfaces/IODataFeature.cs
+++ b/src/Microsoft.AspNetCore.OData/Interfaces/IODataFeature.cs
@@ -18,11 +18,6 @@ namespace Microsoft.AspNet.OData.Interfaces
     public interface IODataFeature
     {
         /// <summary>
-        /// Gets or sets the EDM model.
-        /// </summary>
-        IEdmModel Model { get; set; }
-
-        /// <summary>
         /// Gets or sets the OData path.
         /// </summary>
         ODataPath Path { get; set; }
@@ -41,11 +36,6 @@ namespace Microsoft.AspNet.OData.Interfaces
         /// Gets or sets the request container.
         /// </summary>
         IServiceProvider RequestContainer { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the request is the valid OData request.
-        /// </summary>
-        bool IsValidODataRequest { get; }
 
         /// <summary>
         /// Gets or sets the next link for the OData response.

--- a/src/Microsoft.AspNetCore.OData/ODataFeature.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataFeature.cs
@@ -32,14 +32,8 @@ namespace Microsoft.AspNet.OData
         /// </summary>
         public ODataFeature()
         {
-            Model = EdmCoreModel.Instance; // default Edm model
             totalCountSet = false;
         }
-
-        /// <summary>
-        /// Gets or sets the EDM model.
-        /// </summary>
-        public IEdmModel Model { get; set; }
 
         /// <summary>
         /// Gets or sets the OData path.
@@ -60,14 +54,6 @@ namespace Microsoft.AspNet.OData
         /// Gets or sets the request container.
         /// </summary>
         public IServiceProvider RequestContainer { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the request is the valid OData request.
-        /// </summary>
-        public bool IsValidODataRequest
-        {
-            get { return this.Path != null; }
-        }
 
         /// <summary>
         /// Gets or sets the next link for the OData response.


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request makes progress on #939.
This pull request fixes #1184

### Description

Remove Model and IsValidODataRequest from IODataFeature to align APIs
between IODataFeature in AspNetCore.OData and HttpRequestMessageProperties
in AspNet.OData.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ x ] *Build and test with one-click build and test script passed*
