### PR TITLE
E2e optional dollar sign

### DIFF
--- a/sln/.nuget/NuGet.Config
+++ b/sln/.nuget/NuGet.Config
@@ -7,7 +7,7 @@
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
     <add key="buildTools" value="https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/" />
     <add key="externalComponentDependencies" value="https://www.myget.org/F/02a8fd0d231848d2ae32cd901e273000" />
-    <add key="ODataLibNightly" value="https://www.myget.org/F/odlnightly" />
+    <add key="ODataLibNightly" value="https://www.myget.org/F/odlnightly/api/v3/index.json" />
     <add key="xunitPerformance" value="https://www.myget.org/F/dotnet-buildtools" />
   </packageSources>
 </configuration>

--- a/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
+++ b/src/System.Web.OData/OData/Formatter/Serialization/ODataDeltaFeedSerializer.cs
@@ -59,8 +59,9 @@ namespace System.Web.OData.Formatter.Serialization
             Contract.Assert(feedType != null);
 
             IEdmEntityTypeReference entityType = GetResourceType(feedType).AsEntity();
+#pragma warning disable 0618
             ODataDeltaWriter writer = messageWriter.CreateODataDeltaWriter(entitySet, entityType.EntityDefinition());
-
+#pragma warning restore 0618
             WriteDeltaFeedInline(graph, feedType, writer, writeContext);
         }
 

--- a/src/System.Web.OData/OData/Query/Expressions/FilterBinder.cs
+++ b/src/System.Web.OData/OData/Query/Expressions/FilterBinder.cs
@@ -511,7 +511,17 @@ namespace System.Web.OData.Query.Expressions
                 Contract.Assert(strValue != null);
 
                 constantType = Nullable.GetUnderlyingType(constantType) ?? constantType;
-                value = Enum.Parse(constantType, strValue);
+
+                try
+                {
+                    value = Enum.Parse(constantType, strValue);
+                }
+                catch (ArgumentException e)
+                {
+                    throw new NotSupportedException(
+                        Error.Format(SRResources.ModelBinderUtil_ValueCannotBeEnum, strValue, constantType),
+                        e);
+                }
             }
 
             if (constantNode.TypeReference != null &&
@@ -697,7 +707,7 @@ namespace System.Web.OData.Query.Expressions
         /// </summary>
         /// <param name="node">The node to bind.</param>
         /// <returns>The LINQ <see cref="Expression"/> created.</returns>
-        [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", 
+        [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity",
             Justification = "These are simple binding functions and cannot be split up.")]
         public virtual Expression BindSingleValueFunctionCallNode(SingleValueFunctionCallNode node)
         {

--- a/src/System.Web.OData/OData/Query/ODataQueryOptions.cs
+++ b/src/System.Web.OData/OData/Query/ODataQueryOptions.cs
@@ -73,9 +73,7 @@ namespace System.Web.OData.Query
             Request = request;
 
             ODataUriResolver uriResolver = request.GetRequestContainer().GetRequiredService<ODataUriResolver>();
-
-            //TODO biaol remove the hard coding after wiring in required ODL update.
-            _enableNoDollarSignQueryOption = true/*uriResolver.EnableNoDollarSignPrefixSystemQueryOption*/;
+            _enableNoDollarSignQueryOption = uriResolver.EnableNoDollarSignPrefixSystemQueryOption;
 
             // Parse the query from request Uri, including only keys which are OData query parameters or parameter alias
             // OData query parameters are normalized with the $-sign prefixes when the
@@ -95,15 +93,6 @@ namespace System.Web.OData.Query
 
             Validator = ODataQueryValidator.GetODataQueryValidator(context);
         }
-
-//        /// <summary>
-//        ///  Option for optional $-sign for system query options <see cref="ODataQueryContext"/>
-//        /// </summary>
-//        public bool EnableNoDollarSignQueryOption
-//        {
-//            get { return _enableNoDollarSignQueryOption; }
-//            set { this._enableNoDollarSignQueryOption = value; }
-//        }
 
         /// <summary>
         ///  Gets the given <see cref="ODataQueryContext"/>
@@ -747,7 +736,7 @@ namespace System.Web.OData.Query
 
             foreach (KeyValuePair<string, string> kvp in Request.GetQueryNameValuePairs())
             {
-                // Check supported system query options per optional $-sign option.
+                // Check supported system query options per $-sign-prefix option.
                 if (!_enableNoDollarSignQueryOption)
                 {
                     // This is the original case for required $-sign prefix.

--- a/src/System.Web.OData/System.Web.OData.csproj
+++ b/src/System.Web.OData/System.Web.OData.csproj
@@ -12,16 +12,16 @@
     <DefineConstants>$(DefineConstants);ASPNETODATA;ASPNETWEBAPI</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.OData.Core, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.OData.Core.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.OData.Core.7.5.0-Nightly201801272139\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.OData.Edm.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.OData.Edm.7.5.0-Nightly201801272139\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.Spatial.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.Spatial.7.5.0-Nightly201801272139\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/System.Web.OData/System.Web.OData.csproj
+++ b/src/System.Web.OData/System.Web.OData.csproj
@@ -12,16 +12,16 @@
     <DefineConstants>$(DefineConstants);ASPNETODATA;ASPNETWEBAPI</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.OData.Core.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.OData.Core.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.OData.Edm.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.OData.Edm.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.Spatial.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.Spatial.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/System.Web.OData/System.Web.OData.csproj
+++ b/src/System.Web.OData/System.Web.OData.csproj
@@ -12,16 +12,16 @@
     <DefineConstants>$(DefineConstants);ASPNETODATA;ASPNETWEBAPI</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.OData.Core, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.OData.Core.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.OData.Core.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.OData.Edm.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.OData.Edm.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.Spatial.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.Spatial.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/System.Web.OData/packages.config
+++ b/src/System.Web.OData/packages.config
@@ -4,8 +4,8 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="7.5.0-Nightly201801240138" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.5.0-Nightly201801240138" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.5.0-Nightly201801240138" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.4.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.4.0" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.4.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>

--- a/src/System.Web.OData/packages.config
+++ b/src/System.Web.OData/packages.config
@@ -4,8 +4,8 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="7.3.1" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.3.1" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.3.1" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.5.0-Nightly201801240138" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0-Nightly201801240138" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0-Nightly201801240138" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>

--- a/src/System.Web.OData/packages.config
+++ b/src/System.Web.OData/packages.config
@@ -4,8 +4,8 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="7.4.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.4.0" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.4.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.5.0-Nightly201801272139" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0-Nightly201801272139" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0-Nightly201801272139" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>

--- a/test/E2ETest/Common/WebStack.QA.Common.csproj
+++ b/test/E2ETest/Common/WebStack.QA.Common.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\sln\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\sln\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -18,6 +19,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
@@ -168,13 +171,10 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\sln\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props"
-          Condition="Exists('..\..\..\sln\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\sln\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')"
-           Text="$([System.String]::Format('$(ErrorText)', '..\..\..\sln\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\..\sln\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\sln\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
 </Project>

--- a/test/E2ETest/Common/packages.config
+++ b/test/E2ETest/Common/packages.config
@@ -12,5 +12,5 @@
   <package id="NuGet.Core" version="2.7.2" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.1" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/test/E2ETest/Nuwa.WebStack/App.config
+++ b/test/E2ETest/Nuwa.WebStack/App.config
@@ -3,4 +3,12 @@
   <appSettings>
     <add key="QARoot" value="" />
   </appSettings>
- </configuration>
+   <runtime>
+      <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+         <dependentAssembly>
+            <assemblyIdentity name="NuGet.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+            <bindingRedirect oldVersion="0.0.0.0-2.7.41101.299" newVersion="2.7.41101.299" />
+         </dependentAssembly>
+      </assemblyBinding>
+   </runtime>
+</configuration>

--- a/test/E2ETest/WebStack.QA.Test.OData/UriParserExtension/EnumPrefixFreeTest.cs
+++ b/test/E2ETest/WebStack.QA.Test.OData/UriParserExtension/EnumPrefixFreeTest.cs
@@ -58,28 +58,32 @@ namespace WebStack.QA.Test.OData.UriParserExtension
             webConfig.AddRAMFAR(true);
         }
 
-        public static TheoryDataSet<string, string, HttpStatusCode> EnumPrefixFreeCases
+        public static TheoryDataSet<string, string, HttpStatusCode, HttpStatusCode> EnumPrefixFreeCases
         {
             get
             {
-                return new TheoryDataSet<string, string, HttpStatusCode>()
+                return new TheoryDataSet<string, string, HttpStatusCode, HttpStatusCode>()
                 {
-                    { "gender=WebStack.QA.Test.OData.UriParserExtension.Gender'Male'", "gender='Male'", HttpStatusCode.OK },
-                    { "gender=WebStack.QA.Test.OData.UriParserExtension.Gender'UnknownValue'", "gender='UnknownValue'", HttpStatusCode.NotFound },
+                    { "gender=WebStack.QA.Test.OData.UriParserExtension.Gender'Male'", "gender='Male'", HttpStatusCode.OK, HttpStatusCode.OK },
+
+                    // a). Enum value with fully-qualified-name-space is binded by <code>DottedIdentifierBinder</code>, which throws ODataException --> path not found.
+                    // b). Enum value w/o name space is binded by <code>LiteralBinder</code>, which results in non-null path with <code>ConstantNode</code>.
+                    // But subsequent action invocation fails to lookup constant (unknown value) to Enum --> bad request.
+                    { "gender=WebStack.QA.Test.OData.UriParserExtension.Gender'UnknownValue'", "gender='UnknownValue'", HttpStatusCode.NotFound, HttpStatusCode.BadRequest },
                 };
             }
         }
 
         [Theory]
         [PropertyData("EnumPrefixFreeCases")]
-        public async Task EnableEnumPrefixFreeTest(string prefix, string prefixFree, HttpStatusCode statusCode)
+        public async Task EnableEnumPrefixFreeTest(string prefix, string prefixFree, HttpStatusCode statusCodeWithPrefix, HttpStatusCode statusCodePrefixFree)
         {
             // Enum with prefix
             var prefixUri = string.Format("{0}/odata/Customers/Default.GetCustomerByGender({1})", this.BaseAddress, prefix);
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, prefixUri);
             HttpResponseMessage response = await Client.SendAsync(request);
 
-            Assert.Equal(statusCode, response.StatusCode);
+            Assert.Equal(statusCodeWithPrefix, response.StatusCode);
             string prefixResponse = await response.Content.ReadAsStringAsync();
 
             // Enum prefix free
@@ -87,10 +91,10 @@ namespace WebStack.QA.Test.OData.UriParserExtension
             request = new HttpRequestMessage(HttpMethod.Get, prefixFreeUri);
             response = await Client.SendAsync(request);
 
-            Assert.Equal(statusCode, response.StatusCode);
+            Assert.Equal(statusCodePrefixFree, response.StatusCode);
             string prefixFreeResponse = await response.Content.ReadAsStringAsync();
 
-            if (statusCode == HttpStatusCode.OK)
+            if (statusCodeWithPrefix == HttpStatusCode.OK && statusCodePrefixFree == HttpStatusCode.OK)
             {
                 Assert.Equal(prefixResponse, prefixFreeResponse);
             }

--- a/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
+++ b/test/E2ETest/WebStack.QA.Test.OData/WebStack.QA.Test.OData.csproj
@@ -70,20 +70,20 @@
     <Reference Include="Microsoft.Data.OData, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\sln\packages\Microsoft.Data.OData.5.6.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Client, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Client.7.3.1-Nightly201708142037\lib\net45\Microsoft.OData.Client.dll</HintPath>
+    <Reference Include="Microsoft.OData.Client, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Client.7.5.0-Nightly201801272139\lib\net45\Microsoft.OData.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.5.0-Nightly201801272139\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.5.0-Nightly201801272139\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.5.0-Nightly201801272139\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/E2ETest/WebStack.QA.Test.OData/packages.config
+++ b/test/E2ETest/WebStack.QA.Test.OData/packages.config
@@ -8,10 +8,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Client" version="7.3.1-Nightly201708142037" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="7.3.1" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.3.1" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.3.1" targetFramework="net45" />
+  <package id="Microsoft.OData.Client" version="7.5.0-Nightly201801272139" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.5.0-Nightly201801272139" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0-Nightly201801272139" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0-Nightly201801272139" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net45" />

--- a/test/UnitTest/Microsoft.TestCommon/Microsoft.TestCommon.csproj
+++ b/test/UnitTest/Microsoft.TestCommon/Microsoft.TestCommon.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\sln\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\sln\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\..\sln\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\sln\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\..\tools\WebStack.settings.targets" />
   <PropertyGroup>
     <ProjectGuid>{FCCC4CB7-BAF7-4A57-9F89-E5766FE536C0}</ProjectGuid>
@@ -11,21 +11,23 @@
     <OutputPath>..\..\..\bin\$(Configuration)\UnitTest\</OutputPath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <OutputPath>..\..\..\bin\Debug\UnitTest\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq">
@@ -120,11 +122,14 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\sln\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\sln\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\..\sln\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\sln\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
 </Project>

--- a/test/UnitTest/Microsoft.TestCommon/Microsoft.TestCommon.csproj
+++ b/test/UnitTest/Microsoft.TestCommon/Microsoft.TestCommon.csproj
@@ -18,16 +18,16 @@
     <OutputPath>..\..\..\bin\Debug\UnitTest\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.OData.Core, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.5.0-Nightly201801272139\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.5.0-Nightly201801272139\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.5.0-Nightly201801272139\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq">

--- a/test/UnitTest/Microsoft.TestCommon/Microsoft.TestCommon.csproj
+++ b/test/UnitTest/Microsoft.TestCommon/Microsoft.TestCommon.csproj
@@ -16,16 +16,16 @@
     <OutputPath>..\..\..\bin\Debug\UnitTest\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.OData.Core, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq">

--- a/test/UnitTest/Microsoft.TestCommon/packages.config
+++ b/test/UnitTest/Microsoft.TestCommon/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.OData.Core" version="7.3.1" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.3.1" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.3.1" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.5.0-Nightly201801240138" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0-Nightly201801240138" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0-Nightly201801240138" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />

--- a/test/UnitTest/Microsoft.TestCommon/packages.config
+++ b/test/UnitTest/Microsoft.TestCommon/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.OData.Core" version="7.4.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.4.0" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.4.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.5.0-Nightly201801272139" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0-Nightly201801272139" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0-Nightly201801272139" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />

--- a/test/UnitTest/Microsoft.TestCommon/packages.config
+++ b/test/UnitTest/Microsoft.TestCommon/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.OData.Core" version="7.5.0-Nightly201801240138" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.5.0-Nightly201801240138" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.5.0-Nightly201801240138" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.4.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.4.0" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.4.0" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.1" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/test/UnitTest/System.Web.OData.Test/OData/Formatter/InheritanceTests.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Formatter/InheritanceTests.cs
@@ -255,7 +255,7 @@ namespace System.Web.OData.Formatter
             // Act & Assert
             Assert.Throws<ODataException>(
                 () => new ODataResourceDeserializer(deserializerProvider).Read(reader, typeof(Car), context),
-                "An resource with type 'System.Web.OData.Builder.TestModels.Motorcycle' was found, " +
+                "A resource with type 'System.Web.OData.Builder.TestModels.Motorcycle' was found, " +
                 "but it is not assignable to the expected type 'System.Web.OData.Builder.TestModels.Car'. " +
                 "The type specified in the resource must be equal to either the expected type or a derived type.");
         }

--- a/test/UnitTest/System.Web.OData.Test/OData/ODataUriResolverExtensionTest.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/ODataUriResolverExtensionTest.cs
@@ -227,10 +227,10 @@ namespace System.Web.OData
 
         [Theory]
         [InlineData("gender='Male'", true, HttpStatusCode.OK)]
-        [InlineData("gender='Male'", false, HttpStatusCode.NotFound)]
+        [InlineData("gender='Male'", false, HttpStatusCode.OK)]
         [InlineData("gender=System.Web.OData.TestCommon.Models.Gender'Male'", true, HttpStatusCode.OK)]
         [InlineData("gender=System.Web.OData.TestCommon.Models.Gender'Male'", false, HttpStatusCode.OK)]
-        [InlineData("gender='SomeUnknowValue'", true, HttpStatusCode.NotFound)]
+        [InlineData("gender='SomeUnknowValue'", true, HttpStatusCode.BadRequest)]
         [InlineData("gender=System.Web.OData.TestCommon.Models.Gender'SomeUnknowValue'", true, HttpStatusCode.NotFound)]
         public void ExtensionResolver_Works_EnumPrefixFree(string parameter, bool enableEnumPrefix, HttpStatusCode statusCode)
         {
@@ -267,9 +267,9 @@ namespace System.Web.OData
 
         [Theory]
         [InlineData("$filter=Gender eq 'Male'", true, HttpStatusCode.OK, "0,2,4,6,8")]
-        [InlineData("$filter=Gender eq 'Male'", false, HttpStatusCode.BadRequest, null)]
+        [InlineData("$filter=Gender eq 'Male'", false, HttpStatusCode.OK, "0,2,4,6,8")]
         [InlineData("$filter=Gender eq 'Female'", true, HttpStatusCode.OK, "1,3,5,7,9")]
-        [InlineData("$filter=Gender eq 'Female'", false, HttpStatusCode.BadRequest, null)]
+        [InlineData("$filter=Gender eq 'Female'", false, HttpStatusCode.OK, "1,3,5,7,9")]
         [InlineData("$filter=Gender eq System.Web.OData.TestCommon.Models.Gender'Male'", true, HttpStatusCode.OK, "0,2,4,6,8")]
         [InlineData("$filter=Gender eq System.Web.OData.TestCommon.Models.Gender'Male'", false, HttpStatusCode.OK, "0,2,4,6,8")]
         [InlineData("$filter=Gender eq System.Web.OData.TestCommon.Models.Gender'Female'", true, HttpStatusCode.OK, "1,3,5,7,9")]

--- a/test/UnitTest/System.Web.OData.Test/OData/Query/EnableQueryAttributeTest.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Query/EnableQueryAttributeTest.cs
@@ -320,16 +320,17 @@ namespace System.Web.OData.Query
             Assert.Equal(3L, ((ObjectContent)context.Response.Content).Value);
         }
 
-        //TODO biaol restore this after we can set the <code>ODataQueryOptions._enableNoDollarSignQueryOption</code> using
-        // uriResolver.EnableNoDollarSignPrefixSystemQueryOption, which depends on this TODO:
-        //TODO biaol remove the hard coding after wiring in required ODL update.
-//        [Fact]
+        [Fact]
         public void UnknownQueryNotStartingWithDollarSignWorks()
         {
             // Arrange
             EnableQueryAttribute attribute = new EnableQueryAttribute();
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/Customer/?select");
-            request.EnableODataDependencyInjectionSupport();
+
+            // Enable DI with default resolver.
+            request.EnableODataDependencyInjectionSupport("default",
+                b => b.AddService(ServiceLifetime.Singleton, sp => new ODataUriResolver()));
+
             HttpControllerContext controllerContext = new HttpControllerContext(request.GetConfiguration(), new HttpRouteData(new HttpRoute()), request);
             HttpControllerDescriptor controllerDescriptor = new HttpControllerDescriptor(new HttpConfiguration(), "CustomerHighLevel", typeof(CustomerHighLevelController));
             HttpActionDescriptor actionDescriptor = new ReflectedHttpActionDescriptor(controllerDescriptor, typeof(CustomerHighLevelController).GetMethod("Get"));

--- a/test/UnitTest/System.Web.OData.Test/OData/Query/EnableQueryAttributeTest.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Query/EnableQueryAttributeTest.cs
@@ -320,7 +320,10 @@ namespace System.Web.OData.Query
             Assert.Equal(3L, ((ObjectContent)context.Response.Content).Value);
         }
 
-        [Fact]
+        //TODO biaol restore this after we can set the <code>ODataQueryOptions._enableNoDollarSignQueryOption</code> using
+        // uriResolver.EnableNoDollarSignPrefixSystemQueryOption, which depends on this TODO:
+        //TODO biaol remove the hard coding after wiring in required ODL update.
+//        [Fact]
         public void UnknownQueryNotStartingWithDollarSignWorks()
         {
             // Arrange

--- a/test/UnitTest/System.Web.OData.Test/OData/Query/QueryCompositionTests.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Query/QueryCompositionTests.cs
@@ -99,6 +99,32 @@ namespace System.Web.OData.Query
             Assert.Contains("[{\"Name\":\"Highest\",\"Add", response.Content.ReadAsStringAsync().Result);
         }
 
+        [Theory]
+        [InlineData("?filter=id eq 33", true)]
+        [InlineData("?filter=Id eq 33", false)]
+        public void QueryComposition_WorkAsExpect_ForOptionalDollarSignPrefixForSystemQuery(
+            string noDollarSignSystemQuery, bool enableCaseInsensitive)
+        {
+            // Arrange
+            ODataUriResolver resolver = new ODataUriResolver
+            {
+//TODO biaol add the EnableNoDollarSignPrefixSystemQueryOption setting the after wiring in required ODL update.
+//                EnableNoDollarSignPrefixSystemQueryOption = true
+                EnableCaseInsensitive = enableCaseInsensitive
+
+            };
+            HttpServer server = new HttpServer(InitializeConfiguration("QueryCompositionCustomer", true, resolver));
+            HttpClient client = new HttpClient(server);
+
+            // Act
+            HttpResponseMessage response = GetResponse(client, server.Configuration,
+                "http://localhost:8080/QueryCompositionCustomer" + noDollarSignSystemQuery);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Contains("[{\"Name\":\"Highest\",\"Add", response.Content.ReadAsStringAsync().Result);
+        }
+
         [Fact]
         public void ODataQueryOptionsOfT_Works()
         {
@@ -214,7 +240,7 @@ namespace System.Web.OData.Query
             Assert.Equal(expectedResults, results);
         }
 
-        private static HttpConfiguration InitializeConfiguration(string controllerName, bool useCustomEdmModel, 
+        private static HttpConfiguration InitializeConfiguration(string controllerName, bool useCustomEdmModel,
             ODataUriResolver resolver = null)
         {
             var controllers = new[]

--- a/test/UnitTest/System.Web.OData.Test/OData/Query/QueryCompositionTests.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Query/QueryCompositionTests.cs
@@ -108,8 +108,7 @@ namespace System.Web.OData.Query
             // Arrange
             ODataUriResolver resolver = new ODataUriResolver
             {
-//TODO biaol add the EnableNoDollarSignPrefixSystemQueryOption setting the after wiring in required ODL update.
-//                EnableNoDollarSignPrefixSystemQueryOption = true
+                EnableNoDollarSignPrefixSystemQueryOption = true,
                 EnableCaseInsensitive = enableCaseInsensitive
 
             };

--- a/test/UnitTest/System.Web.OData.Test/OData/Routing/DefaultODataPathHandlerTest.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Routing/DefaultODataPathHandlerTest.cs
@@ -2341,10 +2341,9 @@ namespace System.Web.OData.Routing
 
         [Theory]
         [PropertyData("PrefixFreeEnumCases")]
-        public void PrefixFreeEnumValue_Throws_DefaultResolver(string path, string template, string expect)
+        public void PrefixFreeEnumValue_Works_DefaultResolver(string path, string template, string expect)
         {
-            Assert.Throws<ODataException>(
-                () => new DefaultODataPathHandler().Parse(_model, _serviceRoot, path));
+            Assert.NotNull(new DefaultODataPathHandler().Parse(_model, _serviceRoot, path));
         }
 
         [Theory]

--- a/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
+++ b/test/UnitTest/System.Web.OData.Test/PublicApi/System.Web.OData.PublicApi.bsl
@@ -2322,6 +2322,7 @@ public class System.Web.OData.Query.ODataQueryOptions {
 	internal virtual ETag GetETag (System.Net.Http.Headers.EntityTagHeaderValue etagHeaderValue)
 	public bool IsSupportedQueryOption (string queryOptionName)
 	public static bool IsSystemQueryOption (string queryOptionName)
+	public static bool IsSystemQueryOption (string queryOptionName, bool isDollarSignOptional)
 	public static IQueryable`1 LimitResults (IQueryable`1 queryable, int limit, out System.Boolean& resultsLimited)
 	public virtual void Validate (ODataValidationSettings validationSettings)
 }

--- a/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
+++ b/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
@@ -16,30 +16,30 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>    
     <!--Reference Include="Microsoft.OData.Core, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference-->
-    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
-      <Private>True</Private>
-    </Reference>    
     <!--Reference Include="Microsoft.OData.Edm, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference-->
-    <Reference Include="Microsoft.Spatial, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
-      <Private>True</Private>
-    </Reference>    
     <!--Reference Include="Microsoft.Spatial, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference-->
+    <Reference Include="Microsoft.OData.Core, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.OData.Edm, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Spatial, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\sln\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>

--- a/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
+++ b/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
@@ -28,16 +28,16 @@
       <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference-->
-    <Reference Include="Microsoft.OData.Core, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.5.0-Nightly201801272139\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.5.0-Nightly201801272139\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.5.0-Nightly201801272139\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">

--- a/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
+++ b/test/UnitTest/System.Web.OData.Test/System.Web.OData.Test.csproj
@@ -16,18 +16,30 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.OData.Core, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>    
+    <!--Reference Include="Microsoft.OData.Core, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    </Reference-->
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+      <Private>True</Private>
+    </Reference>    
+    <!--Reference Include="Microsoft.OData.Edm, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    </Reference-->
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20124, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.5.0-Nightly201801240138\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+      <Private>True</Private>
+    </Reference>    
+    <!--Reference Include="Microsoft.Spatial, Version=7.3.1.10814, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.3.1\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
-    </Reference>
+    </Reference-->
     <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\sln\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>

--- a/test/UnitTest/System.Web.OData.Test/packages.config
+++ b/test/UnitTest/System.Web.OData.Test/packages.config
@@ -6,9 +6,9 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="7.3.1" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.3.1" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.3.1" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.5.0-Nightly201801240138" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0-Nightly201801240138" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0-Nightly201801240138" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/test/UnitTest/System.Web.OData.Test/packages.config
+++ b/test/UnitTest/System.Web.OData.Test/packages.config
@@ -6,9 +6,9 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="7.4.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.4.0" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.4.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.5.0-Nightly201801272139" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0-Nightly201801272139" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0-Nightly201801272139" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/test/UnitTest/System.Web.OData.Test/packages.config
+++ b/test/UnitTest/System.Web.OData.Test/packages.config
@@ -6,9 +6,9 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="7.5.0-Nightly201801240138" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.5.0-Nightly201801240138" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.5.0-Nightly201801240138" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.4.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.4.0" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.4.0" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request enables optionsDollarSign from WebAPI query parsing.*

### Description

*By setting ODataUriResolver.EnableNoDollarQueryOptions as true, WebAPI can parse OData system queries without the '$' prefixes (as those in $filter, $select, $orderby, etc) correctly and return expected response.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
