### PR TITLE
Fix non-OData routes throwing ArgumentNullException.

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
@@ -47,25 +47,28 @@ namespace Microsoft.AspNet.OData.Routing
             }
 
             HttpRequest request = context.HttpContext.Request;
-            IEnumerable<IODataRoutingConvention> routingConventions = request.GetRoutingConventions();
             ODataPath odataPath = context.HttpContext.ODataFeature().Path;
             RouteData routeData = context.RouteData;
 
-            if (odataPath == null || routingConventions == null || routeData.Values.ContainsKey(ODataRouteConstants.Action))
+            if (odataPath == null || routeData.Values.ContainsKey(ODataRouteConstants.Action))
             {
                 // If there is no path, no routing conventions or there is already and indication we routed it,
                 // let the _innerSelector handle the request.
                 return _innerSelector.SelectCandidates(context);
             }
 
-            foreach (IODataRoutingConvention convention in routingConventions)
+            IEnumerable<IODataRoutingConvention> routingConventions = request.GetRoutingConventions();
+            if (routingConventions != null)
             {
-                IEnumerable<ControllerActionDescriptor> actionDescriptor = convention.SelectAction(context);
-                if (actionDescriptor != null && actionDescriptor.Any())
+                foreach (IODataRoutingConvention convention in routingConventions)
                 {
-                    // All actions have the same name but may differ by number of parameters.
-                    context.RouteData.Values[ODataRouteConstants.Action] = actionDescriptor.First().ActionName;
-                    return actionDescriptor.ToList();
+                    IEnumerable<ControllerActionDescriptor> actionDescriptor = convention.SelectAction(context);
+                    if (actionDescriptor != null && actionDescriptor.Any())
+                    {
+                        // All actions have the same name but may differ by number of parameters.
+                        context.RouteData.Values[ODataRouteConstants.Action] = actionDescriptor.First().ActionName;
+                        return actionDescriptor.ToList();
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1175

### Description

In the AspNetCore version of WebApi, the ODataActionSelector is used for
all routes. If it is non-OData route, the route is handled by the default
IActionSelector.

However, a check was being made to see if the routing conventions are available,
which requires a route name to obtain the conventions from the request container.
This check failed due to a missing route name.

This fix delays the check for routing conventions until after the request has been
verified to match and OData route by checking for an ODataPath. If the conventions are
not available, the route is handled by the default IActionSelector.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*