### PR TITLE
Disable null propagation by default for EFCore.

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/HandleNullPropagationOptionHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/HandleNullPropagationOptionHelper.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNet.OData.Query
 
         private const string ObjectContextQueryProviderNamespaceEF5 = "System.Data.Objects.ELinq";
         private const string ObjectContextQueryProviderNamespaceEF6 = "System.Data.Entity.Core.Objects.ELinq";
+        private const string ObjectContextQueryProviderNamespaceEFCore2 = "Microsoft.EntityFrameworkCore.Query.Internal";
 
         private const string Linq2SqlQueryProviderNamespace = "System.Data.Linq";
         internal const string Linq2ObjectsQueryProviderNamespace = "System.Linq";
@@ -45,6 +46,7 @@ namespace Microsoft.AspNet.OData.Query
                 case Linq2SqlQueryProviderNamespace:
                 case ObjectContextQueryProviderNamespaceEF5:
                 case ObjectContextQueryProviderNamespaceEF6:
+                case ObjectContextQueryProviderNamespaceEFCore2:
                     options = HandleNullPropagationOption.False;
                     break;
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1205

### Description

Detection of null propagation is based on the Linq providers namespace. EFCore's provider
has been added to set the null propagation correctly.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
