### PR TITLE
Make SelectControllerResult public

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/SelectControllerResult.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/SelectControllerResult.cs
@@ -8,12 +8,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
     /// <summary>
     /// An return value for SelectController.
     /// </summary>
-    /// <remarks>
-    /// This class is not intended to be exposed publicly; it used for the internal
-    /// implementations of SelectControl(). Any design which makes this class public
-    /// should find an alternative design.
-    /// </remarks>
-    internal class SelectControllerResult
+    public class SelectControllerResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SelectControllerResult"/> class.

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/ActionRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/ActionRoutingConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
     {
         /// <inheritdoc/>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        internal override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
+        public override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
         {
             return SelectActionImpl(
                 routeContext.HttpContext.ODataFeature().Path,

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/DynamicPropertyRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/DynamicPropertyRoutingConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
     {
         /// <inheritdoc/>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        internal override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
+        public override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
         {
             return SelectActionImpl(
                 routeContext.HttpContext.ODataFeature().Path,

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/EntityRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/EntityRoutingConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
     {
         /// <inheritdoc/>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        internal override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
+        public override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
         {
             return SelectActionImpl(
                 routeContext.HttpContext.ODataFeature().Path,

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/EntitySetRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/EntitySetRoutingConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
     {
         /// <inheritdoc/>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        internal override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
+        public override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
         {
             return SelectActionImpl(
                 routeContext.HttpContext.ODataFeature().Path,

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/FunctionRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/FunctionRoutingConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
     {
         /// <inheritdoc/>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        internal override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
+        public override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
         {
             return SelectActionImpl(
                 routeContext.HttpContext.ODataFeature().Path,

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/NavigationRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/NavigationRoutingConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
     {
         /// <inheritdoc/>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        internal override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
+        public override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
         {
             return SelectActionImpl(
                 routeContext.HttpContext.ODataFeature().Path,

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/NavigationSourceRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/NavigationSourceRoutingConvention.cs
@@ -76,6 +76,6 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
         ///   <c>null</c> if the request isn't handled by this convention; otherwise, the action descriptor of the selected action.
         /// </returns>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        internal abstract string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors);
+        public abstract string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors);
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/PropertyRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/PropertyRoutingConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
     {
         /// <inheritdoc/>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        internal override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
+        public override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
         {
             return SelectActionImpl(
                 routeContext.HttpContext.ODataFeature().Path,

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/RefRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/RefRoutingConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
     {
         /// <inheritdoc/>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        internal override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
+        public override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
         {
             return SelectActionImpl(
                 routeContext.HttpContext.ODataFeature().Path,

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/SingletonRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/SingletonRoutingConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
     {
         /// <inheritdoc/>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        internal override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
+        public override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
         {
             return SelectActionImpl(
                 routeContext.HttpContext.ODataFeature().Path,

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/UnmappedRequestRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/UnmappedRequestRoutingConvention.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNet.OData.Adapters;
-using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNet.OData.Routing.Conventions
@@ -16,7 +15,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
     {
         /// <inheritdoc/>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        internal override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
+        public override string SelectAction(RouteContext routeContext, SelectControllerResult controllerResult, IEnumerable<ControllerActionDescriptor> actionDescriptors)
         {
             return SelectActionImpl(new WebApiActionMap(actionDescriptors));
         }

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -3425,6 +3425,13 @@ public class Microsoft.AspNet.OData.Routing.Conventions.RefRoutingConvention : N
 	public virtual string SelectAction (ODataPath odataPath, System.Web.Http.Controllers.HttpControllerContext controllerContext, System.Linq.ILookup`2[[System.String],[System.Web.Http.Controllers.HttpActionDescriptor]] actionMap)
 }
 
+public class Microsoft.AspNet.OData.Routing.Conventions.SelectControllerResult {
+	public SelectControllerResult (string controllerName, System.Collections.Generic.IDictionary`2[[System.String],[System.Object]] values)
+
+	string ControllerName  { public get; }
+	System.Collections.Generic.IDictionary`2[[System.String],[System.Object]] Values  { public get; }
+}
+
 public class Microsoft.AspNet.OData.Routing.Conventions.SingletonRoutingConvention : NavigationSourceRoutingConvention, IODataRoutingConvention {
 	public SingletonRoutingConvention ()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1251 

### Description

This change makes SelectControllerResult public, allowing derived classes of
NavigationSourceRoutingConvention to override SelectAction without access
to internal classes.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
