### PR TITLE
Enable ODataConventionModelBuilder for stand-alone scenarios

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Builder/ODataConventionModelBuilder.cs
+++ b/src/Microsoft.AspNetCore.OData/Builder/ODataConventionModelBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
-using System.Reflection;
 using Microsoft.AspNet.OData.Adapters;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Interfaces;
@@ -18,51 +17,82 @@ namespace Microsoft.AspNet.OData.Builder
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataConventionModelBuilder"/> class.
+        /// This constructor will work stand-alone scenarios and require using the
+        /// <see cref="AppDomain"/> to get a list of assemblies in the domain.
         /// </summary>
-        /// <remarks>
-        /// This constructor will work stand-alone scenarios but it does require using the
-        /// <see cref="AppDomain"/> to get a list of assemblies in the domain to build
-        /// the model. In contrast, this constructor will not work in ASP.NET Core 1.x
-        /// due to the lack of AppDomain.
-        /// </remarks>
-        private ODataConventionModelBuilder()
+        public ODataConventionModelBuilder()
             : this(WebApiAssembliesResolver.Default)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataConventionModelBuilder"/> class.
+        /// This constructor uses the <see cref="ApplicationPartManager"/> from AspNetCore obtained
+        /// from the <see cref="IServiceProvider"/> to get a list of assemblies for modeling.
         /// </summary>
         /// <param name="provider">The service provider to use.</param>
-        /// <remarks>
-        /// While this function does not use types that are AspNetCore-specific,
-        /// the functionality is due to the way assembly resolution is done in AspNet vs AspnetCore.
-        /// </remarks>
         public ODataConventionModelBuilder(IServiceProvider provider)
-            : this(provider, isQueryCompositionMode: false)
+            : this(provider, null, isQueryCompositionMode: false)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataConventionModelBuilder"/> class.
+        /// This constructor uses the <see cref="ApplicationPartManager"/> from AspNetCore
+        ///  to get a list of assemblies for modeling.
+        /// </summary>
+        /// <param name="applicationPartManager">The application part manager to use.</param>
+        /// <remarks> 
+        /// This function uses types that are AspNetCore-specific.
+        /// </remarks>
+        public ODataConventionModelBuilder(ApplicationPartManager applicationPartManager)
+            : this(null, applicationPartManager, isQueryCompositionMode: false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ODataConventionModelBuilder"/> class.
+        /// This constructor uses the <see cref="ApplicationPartManager"/> from AspNetCore obtained
+        /// from the <see cref="IServiceProvider"/> to get a list of assemblies for modeling.
+        /// The model built if <paramref name="isQueryCompositionMode"/> is <c>true</c> has more relaxed
+        /// inference rules and also treats all types as entity types. This constructor is intended
+        /// for use by unit testing only.
         /// </summary>
         /// <param name="provider">The service provider to use.</param>
         /// <param name="isQueryCompositionMode">If the model is being built for only querying.</param>
-        /// <remarks>The model built if <paramref name="isQueryCompositionMode"/> is <c>true</c> has more relaxed
-        /// inference rules and also treats all types as entity types. This constructor is intended for use by unit testing only.</remarks>
-        /// <remarks>
-        /// While this function does not use types that are AspNetCore-specific,
-        /// the functionality is due to the way assembly resolution is done in AspNet vs AspnetCore.
-        /// </remarks>
         public ODataConventionModelBuilder(IServiceProvider provider, bool isQueryCompositionMode)
+            : this(provider, null, isQueryCompositionMode)
         {
-            if (provider == null)
-            {
-                throw Error.ArgumentNull("provider");
-            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ODataConventionModelBuilder"/> class.
+        /// The model built if <paramref name="isQueryCompositionMode"/> is <c>true</c> has more relaxed
+        /// inference rules and also treats all types as entity types.
+        /// </summary>
+        /// <param name="provider">The service provider to use.</param>
+        /// <param name="applicationPartManager">
+        /// The application part manager to use. If null, the service
+        /// provider will be queried for the application part manager.
+        /// </param>
+        /// <param name="isQueryCompositionMode">If the model is being built for only querying.</param>
+        private ODataConventionModelBuilder(
+            IServiceProvider provider,
+            ApplicationPartManager applicationPartManager,
+            bool isQueryCompositionMode)
+        {
 
             // Create an IWebApiAssembliesResolver from configuration and initialize.
-            ApplicationPartManager applicationPartManager = provider.GetRequiredService<ApplicationPartManager>();
+            if (applicationPartManager == null)
+            {
+                if (provider == null)
+                {
+                    throw Error.ArgumentNull("provider");
+                }
+
+                applicationPartManager = provider.GetRequiredService<ApplicationPartManager>();
+            }
+
             IWebApiAssembliesResolver internalResolver = new WebApiAssembliesResolver(applicationPartManager);
             Initialize(internalResolver, isQueryCompositionMode);
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1252 

### Description

This change adds a constructor to ODataConventionModelBuilder to allow
an instance to be constructed using only an ApplicationPartManager.

While the ApplicationPartManager is an ASP.NET Core class, it is simply
to create and populate with one or more selected assemblies, allowing
for easy use of ODataConventionModelBuilder in scoped & stand-alone scenarios:

```
  var partManager = new ApplicationPartManager();
  var part = new AssemblyPart(typeof(<class>).Assembly);
  partManager.ApplicationParts.Add(part);

  var builder = new ODataConventionModelBuilder(partManager);

```
### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
