### PR TITLE
Batching support for AspNetCore.

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchContent.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchContent.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Encapsulates a collection of OData batch responses.
+    /// </summary>
+    public partial class ODataBatchContent
+    {
+        private IServiceProvider _requestContainer;
+        private ODataMessageWriterSettings _writerSettings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ODataBatchContent"/> class.
+        /// </summary>
+        /// <param name="responses">The batch responses.</param>
+        /// <param name="requestContainer">The dependency injection container for the request.</param>
+        private void Initialize(IEnumerable<ODataBatchResponseItem> responses, IServiceProvider requestContainer)
+        {
+            if (responses == null)
+            {
+                throw Error.ArgumentNull("responses");
+            }
+
+            Responses = responses;
+            _requestContainer = requestContainer;
+            _writerSettings = requestContainer.GetRequiredService<ODataMessageWriterSettings>();
+        }
+
+        /// <summary>
+        /// Gets the batch responses.
+        /// </summary>
+        public IEnumerable<ODataBatchResponseItem> Responses { get; private set; }
+
+        /// <summary>
+        ///  Serialize the batch responses to an <see cref="IODataResponseMessage"/>.
+        /// </summary>
+        /// <param name="responseMessage">The response message.</param>
+        /// <returns></returns>
+        private async Task WriteToResponseMessageAsync(IODataResponseMessage responseMessage)
+        {
+            ODataMessageWriter messageWriter = new ODataMessageWriter(responseMessage, _writerSettings);
+            ODataBatchWriter writer = messageWriter.CreateODataBatchWriter();
+
+            writer.WriteStartBatch();
+
+            foreach (ODataBatchResponseItem response in Responses)
+            {
+                await response.WriteResponseAsync(writer);
+            }
+
+            writer.WriteEndBatch();
+        }
+    }
+}

--- a/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchHandler.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.OData.Interfaces;
+using Microsoft.OData;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Defines the abstraction for handling OData batch requests.
+    /// </summary>
+    public abstract partial class ODataBatchHandler
+    {
+        // Maxing out the received message size as we depend on the hosting layer to enforce this limit.
+        private ODataMessageQuotas _messageQuotas = new ODataMessageQuotas { MaxReceivedMessageSize = Int64.MaxValue };
+
+        // Preference odata.continue-on-error.
+        internal const string PreferenceContinueOnError = "odata.continue-on-error";
+
+        /// <summary>
+        /// Gets the <see cref="ODataMessageQuotas"/> used for reading/writing the batch request/response.
+        /// </summary>
+        public ODataMessageQuotas MessageQuotas
+        {
+            get { return _messageQuotas; }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the OData route associated with this batch handler.
+        /// </summary>
+        public string ODataRouteName { get; set; }
+
+        /// <summary>
+        /// Gets or sets if the continue-on-error header is enable or not.
+        /// </summary>
+        internal bool ContinueOnError { get; private set; }
+
+        /// <summary>
+        /// Set ContinueOnError based on the request and headers.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="header">The request header.</param>
+        internal void SetContinueOnError(IWebApiRequestMessage request, IWebApiHeaders header)
+        {
+            string preferHeader = RequestPreferenceHelpers.GetRequestPreferHeader(header);
+            if ((preferHeader != null && preferHeader.Contains(PreferenceContinueOnError)) || (!request.Options.EnableContinueOnErrorHeader))
+            {
+                ContinueOnError = true;
+            }
+            else
+            {
+                ContinueOnError = false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.OData.Shared/Interfaces/IWebApiOptions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Interfaces/IWebApiOptions.cs
@@ -25,5 +25,11 @@ namespace Microsoft.AspNet.OData.Interfaces
         /// Gets or Sets a value indicating if value should be emitted for dynamic properties which are null.
         /// </summary>
         bool NullDynamicPropertyIsEnabled { get; }
+
+        /// <summary>
+        /// Check the continue-on-error header is enable or not.
+        /// </summary>
+        /// <returns>True if continue-on-error header is enable; false otherwise</returns>
+        bool EnableContinueOnErrorHeader { get; }
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
+++ b/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
@@ -9,6 +9,8 @@
     <Import_RootNamespace>Microsoft.AspNet.OData</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchContent.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\Conventions\Attributes\MaxLengthAttributeEdmPropertyConvention.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\DecimalPropertyConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\LengthPropertyConfiguration.cs" />

--- a/src/Microsoft.AspNet.OData/Adapters/WebApiOptions.cs
+++ b/src/Microsoft.AspNet.OData/Adapters/WebApiOptions.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNet.OData.Adapters
 
             this.NullDynamicPropertyIsEnabled = configuration.HasEnabledNullDynamicProperty();
             this.UrlKeyDelimiter = configuration.GetUrlKeyDelimiter();
+            this.EnableContinueOnErrorHeader = configuration.HasEnabledContinueOnErrorHeader();
         }
 
         /// <summary>
@@ -39,5 +40,11 @@ namespace Microsoft.AspNet.OData.Adapters
         /// Gets or Sets a value indicating if value should be emitted for dynamic properties which are null.
         /// </summary>
         public bool NullDynamicPropertyIsEnabled { get; private set; }
+
+        /// <summary>
+        /// Check the continue-on-error header is enable or not.
+        /// </summary>
+        /// <returns>True if continue-on-error header is enable; false otherwise</returns>
+        public bool EnableContinueOnErrorHeader { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.OData/Batch/DefaultODataBatchHandler.cs
+++ b/src/Microsoft.AspNet.OData/Batch/DefaultODataBatchHandler.cs
@@ -46,15 +46,7 @@ namespace Microsoft.AspNet.OData.Batch
 
             IList<ODataBatchRequestItem> subRequests = await ParseBatchRequestsAsync(request, cancellationToken);
 
-            string preferHeader = RequestPreferenceHelpers.GetRequestPreferHeader(new WebApiRequestHeaders(request.Headers));
-            if ((preferHeader != null && preferHeader.Contains(PreferenceContinueOnError)) || (!request.GetConfiguration().HasEnabledContinueOnErrorHeader()))
-            {
-                ContinueOnError = true;
-            }
-            else
-            {
-                ContinueOnError = false;
-            }
+            SetContinueOnError(new WebApiRequestMessage(request), new WebApiRequestHeaders(request.Headers));
 
             try
             {

--- a/src/Microsoft.AspNet.OData/Batch/ODataBatchContent.cs
+++ b/src/Microsoft.AspNet.OData/Batch/ODataBatchContent.cs
@@ -8,12 +8,8 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNet.OData.Common;
-using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Routing;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData;
 
 namespace Microsoft.AspNet.OData.Batch
@@ -21,35 +17,39 @@ namespace Microsoft.AspNet.OData.Batch
     /// <summary>
     /// Encapsulates a collection of OData batch responses.
     /// </summary>
-    public class ODataBatchContent : HttpContent
+    /// <remarks>
+    /// In AspNet, <see cref="ODataBatchContent"/> derives from <see cref="HttpContent"/>.
+    /// </remarks>
+    public partial class ODataBatchContent : HttpContent
     {
-        private readonly IServiceProvider _requestContainer;
-        private readonly ODataMessageWriterSettings _writerSettings;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataBatchContent"/> class.
         /// </summary>
         /// <param name="responses">The batch responses.</param>
         /// <param name="requestContainer">The dependency injection container for the request.</param>
+        /// <remarks>This signature uses types that are AspNet-specific.</remarks>
         public ODataBatchContent(IEnumerable<ODataBatchResponseItem> responses, IServiceProvider requestContainer)
         {
-            if (responses == null)
-            {
-                throw Error.ArgumentNull("responses");
-            }
-
-            Responses = responses;
-            _requestContainer = requestContainer;
-            _writerSettings = requestContainer.GetRequiredService<ODataMessageWriterSettings>();
+            this.Initialize(responses, requestContainer);
             Headers.ContentType = MediaTypeHeaderValue.Parse(String.Format(CultureInfo.InvariantCulture, "multipart/mixed;boundary=batchresponse_{0}", Guid.NewGuid()));
             ODataVersion version = _writerSettings.Version ?? ODataVersionConstraint.DefaultODataVersion;
             Headers.TryAddWithoutValidation(ODataVersionConstraint.ODataServiceVersionHeader, ODataUtils.ODataVersionToString(version));
         }
 
-        /// <summary>
-        /// Gets the batch responses.
-        /// </summary>
-        public IEnumerable<ODataBatchResponseItem> Responses { get; private set; }
+        /// <inheritdoc/>
+        /// <remarks>This function uses types that are AspNet-specific.</remarks>
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            IODataResponseMessage responseMessage = ODataMessageWrapperHelper.Create(stream, this.Headers, _requestContainer);
+            return WriteToResponseMessageAsync(responseMessage);
+        }
+
+        /// <inheritdoc/>
+        protected override bool TryComputeLength(out long length)
+        {
+            length = -1;
+            return false;
+        }
 
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
@@ -64,31 +64,8 @@ namespace Microsoft.AspNet.OData.Batch
                     }
                 }
             }
+
             base.Dispose(disposing);
-        }
-
-        /// <inheritdoc/>
-        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
-        {
-            IODataResponseMessage responseMessage = ODataMessageWrapperHelper.Create(stream, this.Headers, _requestContainer);
-            ODataMessageWriter messageWriter = new ODataMessageWriter(responseMessage, _writerSettings);
-            ODataBatchWriter writer = messageWriter.CreateODataBatchWriter();
-
-            writer.WriteStartBatch();
-
-            foreach (ODataBatchResponseItem response in Responses)
-            {
-                await response.WriteResponseAsync(writer, CancellationToken.None);
-            }
-
-            writer.WriteEndBatch();
-        }
-
-        /// <inheritdoc/>
-        protected override bool TryComputeLength(out long length)
-        {
-            length = -1;
-            return false;
         }
     }
 }

--- a/src/Microsoft.AspNet.OData/Batch/ODataBatchResponseItem.cs
+++ b/src/Microsoft.AspNet.OData/Batch/ODataBatchResponseItem.cs
@@ -89,6 +89,21 @@ namespace Microsoft.AspNet.OData.Batch
         public abstract Task WriteResponseAsync(ODataBatchWriter writer, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Writes the response.
+        /// </summary>
+        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
+        /// <remarks>
+        /// This method exists to provide a consistent API to <see cref="ODataBatchContent"/>.
+        /// The AspNetCore call does not need the CancellationToken passed in and instead of
+        /// adding an internal call on that side, I opted to add the internal call here since
+        /// the AspNetCore call would ignore the parameter and this one just assumes one.
+        /// </remarks>
+        internal Task WriteResponseAsync(ODataBatchWriter writer)
+        {
+            return WriteResponseAsync(writer, CancellationToken.None);
+        }
+
+        /// <summary>
         /// Gets a value that indicates if the responses in this item are successful.
         /// </summary>
         internal virtual bool IsResponseSuccessful()

--- a/src/Microsoft.AspNet.OData/Batch/UnbufferedODataBatchHandler.cs
+++ b/src/Microsoft.AspNet.OData/Batch/UnbufferedODataBatchHandler.cs
@@ -51,15 +51,8 @@ namespace Microsoft.AspNet.OData.Batch
             List<ODataBatchResponseItem> responses = new List<ODataBatchResponseItem>();
             Guid batchId = Guid.NewGuid();
 
-            string preferHeader = RequestPreferenceHelpers.GetRequestPreferHeader(new WebApiRequestHeaders(request.Headers));
-            if ((preferHeader != null && preferHeader.Contains(PreferenceContinueOnError)) || (!request.GetConfiguration().HasEnabledContinueOnErrorHeader()))
-            {
-                ContinueOnError = true;
-            }
-            else
-            {
-                ContinueOnError = false;
-            }
+            SetContinueOnError(new WebApiRequestMessage(request), new WebApiRequestHeaders(request.Headers));
+
             try
             {
                 while (batchReader.Read())

--- a/src/Microsoft.AspNet.OData/Extensions/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.AspNet.OData/Extensions/HttpConfigurationExtensions.cs
@@ -364,7 +364,7 @@ namespace Microsoft.AspNet.OData.Extensions
         /// <summary>
         /// Check the continue-on-error header is enable or not.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>True if continue-on-error header is enable; false otherwise</returns>
         internal static bool HasEnabledContinueOnErrorHeader(this HttpConfiguration configuration)
         {
             if (configuration == null)

--- a/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
+++ b/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
@@ -73,6 +73,8 @@
     <Compile Include="Adapters\WebApiRequestHeaders.cs" />
     <Compile Include="Adapters\WebApiRequestMessage.cs" />
     <Compile Include="Adapters\WebApiUrlHelper.cs" />
+    <Compile Include="Batch\LazyStreamContent.cs" />
+    <Compile Include="Batch\ODataBatchContent.cs" />
     <Compile Include="Extensions\HttpConfigurationExtensions.cs" />
     <Compile Include="Extensions\HttpErrorExtensions.cs" />
     <Compile Include="Extensions\HttpRequestMessageExtensions.cs" />
@@ -96,12 +98,10 @@
     <Compile Include="Batch\ODataBatchRequestItem.cs" />
     <Compile Include="Batch\OperationResponseItem.cs" />
     <Compile Include="Batch\ODataBatchReaderExtensions.cs" />
-    <Compile Include="Batch\LazyStreamContent.cs" />
     <Compile Include="Batch\ChangeSetRequestItem.cs" />
     <Compile Include="Batch\OperationRequestItem.cs" />
     <Compile Include="Batch\ChangeSetResponseItem.cs" />
     <Compile Include="Batch\ODataHttpContentExtensions.cs" />
-    <Compile Include="Batch\ODataBatchContent.cs" />
     <Compile Include="Batch\DefaultODataBatchHandler.cs" />
     <Compile Include="Formatter\QueryStringMediaTypeMapping.cs" />
     <Compile Include="Formatter\ODataRawValueMediaTypeMapping.cs" />

--- a/src/Microsoft.AspNetCore.OData/Adapters/WebApiOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Adapters/WebApiOptions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNet.OData.Adapters
 
             this.NullDynamicPropertyIsEnabled = options.NullDynamicPropertyIsEnabled;
             this.UrlKeyDelimiter = options.UrlKeyDelimiter;
+            this.EnableContinueOnErrorHeader = options.EnableContinueOnErrorHeader;
         }
 
         /// <summary>
@@ -37,5 +38,11 @@ namespace Microsoft.AspNet.OData.Adapters
         /// Gets or Sets a value indicating if value should be emitted for dynamic properties which are null.
         /// </summary>
         public bool NullDynamicPropertyIsEnabled { get; private set; }
+
+        /// <summary>
+        /// Check the continue-on-error header is enable or not.
+        /// </summary>
+        /// <returns>True if continue-on-error header is enable; false otherwise</returns>
+        public bool EnableContinueOnErrorHeader { get; private set; }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Batch/ChangeSetRequestItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ChangeSetRequestItem.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Represents a ChangeSet request.
+    /// </summary>
+    public class ChangeSetRequestItem : ODataBatchRequestItem
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangeSetRequestItem"/> class.
+        /// </summary>
+        /// <param name="contexts">The request contexts in the ChangeSet.</param>
+        public ChangeSetRequestItem(IEnumerable<HttpContext> contexts)
+        {
+            if (contexts == null)
+            {
+                throw Error.ArgumentNull("contexts");
+            }
+
+            Contexts = contexts;
+        }
+
+        /// <summary>
+        /// Gets the request contexts in the ChangeSet.
+        /// </summary>
+        public IEnumerable<HttpContext> Contexts { get; private set; }
+
+        /// <summary>
+        /// Sends the ChangeSet request.
+        /// </summary>
+        /// <param name="handler">The handler for processing a message.</param>
+        /// <returns>A <see cref="ChangeSetResponseItem"/>.</returns>
+        public override async Task<ODataBatchResponseItem> SendRequestAsync(RequestDelegate handler)
+        {
+            if (handler == null)
+            {
+                throw Error.ArgumentNull("handler");
+            }
+
+            Dictionary<string, string> contentIdToLocationMapping = new Dictionary<string, string>();
+            List<HttpContext> responseContexts = new List<HttpContext>();
+
+            foreach (HttpContext context in Contexts)
+            {
+                await SendRequestAsync(handler, context, contentIdToLocationMapping);
+
+                HttpResponse response = context.Response;
+                if (response.IsSuccessStatusCode())
+                {
+                    responseContexts.Add(context);
+                }
+                else
+                {
+                    responseContexts.Clear();
+                    responseContexts.Add(context);
+                    return new ChangeSetResponseItem(responseContexts);
+                }
+            }
+
+            return new ChangeSetResponseItem(responseContexts);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/ChangeSetResponseItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ChangeSetResponseItem.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.OData;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Represents a ChangeSet response.
+    /// </summary>
+    public class ChangeSetResponseItem : ODataBatchResponseItem
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangeSetResponseItem"/> class.
+        /// </summary>
+        /// <param name="contexts">The response contexts for the ChangeSet requests.</param>
+        public ChangeSetResponseItem(IEnumerable<HttpContext> contexts)
+        {
+            if (contexts == null)
+            {
+                throw Error.ArgumentNull("contexts");
+            }
+
+            Contexts = contexts;
+        }
+
+        /// <summary>
+        /// Gets the response contexts for the ChangeSet.
+        /// </summary>
+        public IEnumerable<HttpContext> Contexts { get; private set; }
+
+        /// <summary>
+        /// Writes the responses as a ChangeSet.
+        /// </summary>
+        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
+        public override async Task WriteResponseAsync(ODataBatchWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull("writer");
+            }
+
+            writer.WriteStartChangeset();
+
+            foreach (HttpContext context in Contexts)
+            {
+                await WriteMessageAsync(writer, context);
+            }
+
+            writer.WriteEndChangeset();
+        }
+
+        /// <summary>
+        /// Gets a value that indicates if the responses in this item are successful.
+        /// </summary>
+        internal override bool IsResponseSuccessful()
+        {
+            return Contexts.All(c => c.Response.IsSuccessStatusCode());
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/DefaultODataBatchHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/DefaultODataBatchHandler.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Adapters;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Default implementation of <see cref="ODataBatchHandler"/> for handling OData batch request.
+    /// </summary>
+    /// <remarks>
+    /// By default, it buffers the request content stream.
+    /// </remarks>
+    public class DefaultODataBatchHandler : ODataBatchHandler
+    {
+        /// <inheritdoc/>
+        public override async Task ProcessBatchAsync(HttpContext context, RequestDelegate nextHandler)
+        {
+            if (context == null)
+            {
+                throw Error.ArgumentNull("context");
+            }
+            if (nextHandler == null)
+            {
+                throw Error.ArgumentNull("nextHandler");
+            }
+
+            if (!await ValidateRequest(context.Request))
+            {
+                return;
+            }
+
+            IList<ODataBatchRequestItem> subRequests = await ParseBatchRequestsAsync(context);
+
+            SetContinueOnError(new WebApiRequestMessage(context.Request), new WebApiRequestHeaders(context.Request.Headers));
+
+            IList<ODataBatchResponseItem> responses = await ExecuteRequestMessagesAsync(subRequests, nextHandler);
+            await CreateResponseMessageAsync(responses, context.Request);
+        }
+
+        /// <summary>
+        /// Executes the OData batch requests.
+        /// </summary>
+        /// <param name="requests">The collection of OData batch requests.</param>
+        /// <param name="handler">The handler for processing a message.</param>
+        /// <returns>A collection of <see cref="ODataBatchResponseItem"/> for the batch requests.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "We need to return a collection of response messages asynchronously.")]
+        public virtual async Task<IList<ODataBatchResponseItem>> ExecuteRequestMessagesAsync(IEnumerable<ODataBatchRequestItem> requests, RequestDelegate handler)
+        {
+            if (requests == null)
+            {
+                throw Error.ArgumentNull("requests");
+            }
+            if (handler == null)
+            {
+                throw Error.ArgumentNull("handler");
+            }
+
+            IList<ODataBatchResponseItem> responses = new List<ODataBatchResponseItem>();
+
+            foreach (ODataBatchRequestItem request in requests)
+            {
+                ODataBatchResponseItem responseItem = await request.SendRequestAsync(handler);
+                responses.Add(responseItem);
+
+                if (responseItem != null && responseItem.IsResponseSuccessful() == false && ContinueOnError == false)
+                {
+                    break;
+                }
+            }
+
+            return responses;
+        }
+
+        /// <summary>
+        /// Converts the incoming OData batch request into a collection of request messages.
+        /// </summary>
+        /// <param name="context">The context containing the batch request messages.</param>
+        /// <returns>A collection of <see cref="ODataBatchRequestItem"/>.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "We need to return a collection of request messages asynchronously.")]
+        public virtual async Task<IList<ODataBatchRequestItem>> ParseBatchRequestsAsync(HttpContext context)
+        {
+            if (context == null)
+            {
+                throw Error.ArgumentNull("context");
+            }
+
+            HttpRequest request = context.Request;
+            IServiceProvider requestContainer = request.CreateRequestContainer(ODataRouteName);
+            requestContainer.GetRequiredService<ODataMessageReaderSettings>().BaseUri = GetBaseUri(request);
+
+            ODataMessageReader reader = request.GetODataMessageReader(requestContainer);
+
+            CancellationToken cancellationToken = context.RequestAborted;
+            List<ODataBatchRequestItem> requests = new List<ODataBatchRequestItem>();
+            ODataBatchReader batchReader = reader.CreateODataBatchReader();
+            Guid batchId = Guid.NewGuid();
+            while (batchReader.Read())
+            {
+                if (batchReader.State == ODataBatchReaderState.ChangesetStart)
+                {
+                    IList<HttpContext> changeSetContexts = await batchReader.ReadChangeSetRequestAsync(context, batchId, cancellationToken);
+                    foreach (HttpContext changeSetContext in changeSetContexts)
+                    {
+                        changeSetContext.Request.CopyBatchRequestProperties(request);
+                        changeSetContext.Request.DeleteRequestContainer(false);
+                    }
+                    requests.Add(new ChangeSetRequestItem(changeSetContexts));
+                }
+                else if (batchReader.State == ODataBatchReaderState.Operation)
+                {
+                    HttpContext operationContext = await batchReader.ReadOperationRequestAsync(context, batchId, true, cancellationToken);
+                    operationContext.Request.CopyBatchRequestProperties(request);
+                    operationContext.Request.DeleteRequestContainer(false);
+                    requests.Add(new OperationRequestItem(operationContext));
+                }
+            }
+
+            return requests;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/HttpRequestExtensions.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="HttpRequest"/> class.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class HttpRequestExtensions
+    {
+        /// <summary>
+        /// Gets the <see cref="IODataBatchFeature"/> from the services container.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>The <see cref="IODataBatchFeature"/> from the services container.</returns>
+        public static IODataBatchFeature ODataBatchFeature(this HttpRequest request)
+        {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
+            return request.HttpContext.ODataBatchFeature();
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ODataMessageReader"/> for the <see cref="HttpRequest"/> stream.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="requestContainer">The dependency injection container for the request.</param>
+        /// <returns>A task object that produces an <see cref="ODataMessageReader"/> when completed.</returns>
+        public static ODataMessageReader GetODataMessageReader(this HttpRequest request, IServiceProvider requestContainer)
+        {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
+            IODataRequestMessage oDataRequestMessage = ODataMessageWrapperHelper.Create(request.Body, request.Headers, requestContainer);
+            ODataMessageReaderSettings settings = requestContainer.GetRequiredService<ODataMessageReaderSettings>();
+            ODataMessageReader oDataMessageReader = new ODataMessageReader(oDataRequestMessage, settings);
+            return oDataMessageReader;
+        }
+
+        /// <summary>
+        /// Copy an absolute Uri to a <see cref="HttpRequest"/> stream.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="uri">The absolute uri to copy.</param>
+        public static void CopyAbsoluteUrl(this HttpRequest request, Uri uri)
+        {
+            request.Scheme = uri.Scheme;
+            request.Host = uri.IsDefaultPort ?
+                new HostString(uri.Host) :
+                new HostString(uri.Host, uri.Port);
+            request.QueryString = new QueryString(uri.Query);
+            request.Path = new PathString(uri.AbsolutePath);
+        }
+
+        /// <summary>
+        /// Copies the properties from another <see cref="HttpRequest"/>.
+        /// </summary>
+        /// <param name="subRequest">The sub-request.</param>
+        /// <param name="batchRequest">The batch request that contains the properties to copy.</param>
+        /// <remarks>
+        /// Currently, this method is unused but is retained to keep a similar API surface area
+        /// between the AspNet and AspNetCore versions of OData WebApi.
+        /// </remarks>
+        public static void CopyBatchRequestProperties(this HttpRequest subRequest, HttpRequest batchRequest)
+        {
+            if (subRequest == null)
+            {
+                throw new ArgumentNullException("subRequest");
+            }
+            if (batchRequest == null)
+            {
+                throw new ArgumentNullException("batchRequest");
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchContent.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchContent.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Routing;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using Microsoft.OData;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Encapsulates a collection of OData batch responses.
+    /// </summary>
+    /// <remarks>
+    /// In AspNet, <see cref="ODataBatchContent"/> derives from <see cref="IDisposable"/>.
+    /// </remarks>
+    public partial class ODataBatchContent
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ODataBatchContent"/> class.
+        /// </summary>
+        /// <param name="responses">The batch responses.</param>
+        /// <param name="requestContainer">The dependency injection container for the request.</param>
+        /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
+        public ODataBatchContent(IEnumerable<ODataBatchResponseItem> responses, IServiceProvider requestContainer)
+        {
+            Initialize(responses, requestContainer);
+            Headers[HeaderNames.ContentType] = String.Format(CultureInfo.InvariantCulture, "multipart/mixed;boundary=batchresponse_{0}", Guid.NewGuid());
+            ODataVersion version = _writerSettings.Version ?? ODataVersionConstraint.DefaultODataVersion;
+            Headers.Add(ODataVersionConstraint.ODataServiceVersionHeader, ODataUtils.ODataVersionToString(version));
+        }
+
+        /// <summary>
+        /// Gets the Headers for the batch content.
+        /// </summary>
+        public HeaderDictionary Headers { get; } = new HeaderDictionary();
+
+        /// <summary>
+        /// Serialize the batch content to a stream.
+        /// </summary>
+        /// <param name="stream">The stream to serialize to.</param>
+        /// <returns>A <see cref="Task"/> that can be awaited.</returns>
+        /// <remarks>This function uses types that are AspNetCore-specific.</remarks>
+        public Task SerializeToStreamAsync(Stream stream)
+        {
+            IODataResponseMessage responseMessage = ODataMessageWrapperHelper.Create(stream, Headers, _requestContainer);
+            return WriteToResponseMessageAsync(responseMessage);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs
@@ -1,0 +1,275 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Formatter;
+using Microsoft.AspNet.OData.Routing;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Http.Headers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Net.Http.Headers;
+using Microsoft.OData;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="HttpRequest"/> class.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class ODataBatchHttpRequestExtensions
+    {
+        private const string BatchIdKey = "BatchId";
+        private const string ChangeSetIdKey = "ChangesetId";
+        private const string ContentIdKey = "ContentId";
+        private const string ContentIdMappingKey = "ContentIdMapping";
+        private const string BatchMediaType = "multipart/mixed";
+        private const string Boundary = "boundary";
+
+        /// <summary>
+        /// Determine if the request is a batch request.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public static bool IsODataBatchRequest(this HttpRequest request)
+        {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
+            return request.ContentType?.StartsWith("multipart/", StringComparison.OrdinalIgnoreCase) ?? false;
+        }
+
+        /// <summary>
+        /// Retrieves the Batch ID associated with the request.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>The Batch ID associated with this request, or <c>null</c> if there isn't one.</returns>
+        public static Guid? GetODataBatchId(this HttpRequest request)
+        {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
+            return request.ODataBatchFeature().BatchId;
+        }
+
+        /// <summary>
+        /// Associates a given Batch ID with the request.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="batchId">The Batch ID.</param>
+        public static void SetODataBatchId(this HttpRequest request, Guid batchId)
+        {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
+            request.ODataBatchFeature().BatchId = batchId;
+        }
+
+        /// <summary>
+        /// Retrieves the ChangeSet ID associated with the request.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>The ChangeSet ID associated with this request, or <c>null</c> if there isn't one.</returns>
+        public static Guid? GetODataChangeSetId(this HttpRequest request)
+        {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
+            return request.ODataBatchFeature().ChangeSetId;
+        }
+
+        /// <summary>
+        /// Associates a given ChangeSet ID with the request.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="changeSetId">The ChangeSet ID.</param>
+        public static void SetODataChangeSetId(this HttpRequest request, Guid changeSetId)
+        {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
+            request.ODataBatchFeature().ChangeSetId = changeSetId;
+        }
+
+        /// <summary>
+        /// Retrieves the Content-ID associated with the sub-request of a batch.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>The Content-ID associated with this request, or <c>null</c> if there isn't one.</returns>
+        public static string GetODataContentId(this HttpRequest request)
+        {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
+            return request.ODataBatchFeature().ContentId;
+        }
+
+        /// <summary>
+        /// Associates a given Content-ID with the sub-request of a batch.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="contentId">The Content-ID.</param>
+        public static void SetODataContentId(this HttpRequest request, string contentId)
+        {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
+            request.ODataBatchFeature().ContentId = contentId;
+        }
+
+        /// <summary>
+        /// Retrieves the Content-ID to Location mapping associated with the request.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>The Content-ID to Location mapping associated with this request, or <c>null</c> if there isn't one.</returns>
+        public static IDictionary<string, string> GetODataContentIdMapping(this HttpRequest request)
+        {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
+            return request.ODataBatchFeature().ContentIdMapping;
+        }
+
+        /// <summary>
+        /// Associates a given Content-ID to Location mapping with the request.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="contentIdMapping">The Content-ID to Location mapping.</param>
+        public static void SetODataContentIdMapping(this HttpRequest request, IDictionary<string, string> contentIdMapping)
+        {
+            if (request == null)
+            {
+                throw Error.ArgumentNull("request");
+            }
+
+            request.ODataBatchFeature().ContentIdMapping = contentIdMapping;
+        }
+
+        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller is responsible for disposing the object.")]
+        internal static Task CreateODataBatchResponseAsync(this HttpRequest request, IEnumerable<ODataBatchResponseItem> responses, ODataMessageQuotas messageQuotas)
+        {
+            Contract.Assert(request != null);
+
+            ODataVersion odataVersion = ODataInputFormatter.GetODataResponseVersion(request);
+
+            IServiceProvider requestContainer = request.GetRequestContainer();
+            ODataMessageWriterSettings writerSettings = requestContainer.GetRequiredService<ODataMessageWriterSettings>();
+            writerSettings.Version = odataVersion;
+            writerSettings.MessageQuotas = messageQuotas;
+
+            HttpResponse response = request.HttpContext.Response;
+            response.StatusCode = (int)HttpStatusCode.OK;
+
+            // Need to get the stream from ODataBatchContent.
+            // maybe use the shared class to define bahaviour and put
+            // HttpContent and public stream getter in platform-specific?
+            ODataBatchContent batchContent = new ODataBatchContent(responses, requestContainer);
+            foreach (var header in batchContent.Headers)
+            {
+                // Copy headers from batch content, overwriting any existing headers.
+                response.Headers[header.Key] = header.Value;
+            }
+
+            return batchContent.SerializeToStreamAsync(response.Body);
+        }
+
+        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller is responsible for disposing the object.")]
+        internal static async Task<bool> ValidateODataBatchRequest(this HttpRequest request)
+        {
+            Contract.Assert(request != null);
+
+            HttpResponse response = request.HttpContext.Response;
+            if (request.Body == null)
+            {
+                response.StatusCode = (int)HttpStatusCode.BadRequest;
+                await response.WriteAsync(SRResources.BatchRequestMissingContent);
+                return false;
+            }
+
+            RequestHeaders headers = request.GetTypedHeaders();
+            MediaTypeHeaderValue contentType = headers.ContentType;
+            if (contentType == null)
+            {
+                response.StatusCode = (int)HttpStatusCode.BadRequest;
+                await response.WriteAsync(SRResources.BatchRequestMissingContentType);
+                return false;
+            }
+            if (!String.Equals(contentType.MediaType.ToString(), BatchMediaType, StringComparison.OrdinalIgnoreCase))
+            {
+                response.StatusCode = (int)HttpStatusCode.BadRequest;
+                await response.WriteAsync(Error.Format(SRResources.BatchRequestInvalidMediaType, BatchMediaType));
+                return false;
+            }
+            NameValueHeaderValue boundary = contentType.Parameters.FirstOrDefault(p => String.Equals(p.Name.ToString(), Boundary, StringComparison.OrdinalIgnoreCase));
+            if (boundary == null || String.IsNullOrEmpty(boundary.Value.ToString()))
+            {
+                response.StatusCode = (int)HttpStatusCode.BadRequest;
+                await response.WriteAsync(SRResources.BatchRequestMissingBoundary);
+                return false;
+            }
+
+            return true;
+        }
+
+        internal static Uri GetODataBatchBaseUri(this HttpRequest request, string oDataRouteName, IRouter route)
+        {
+            Contract.Assert(request != null);
+
+            if (oDataRouteName == null)
+            {
+                // Return request's base address.
+                return new Uri(request.GetDisplayUrl());
+            }
+
+            // The IActionContextAccessor and ActionContext will be present after routing but not before
+            // GetUrlHelper only uses the HttpContext and the Router, which we have so construct a dummy
+            // action context.
+            ActionContext actionContext = new ActionContext
+            {
+                HttpContext = request.HttpContext,
+                RouteData = new RouteData(),
+                ActionDescriptor = new ActionDescriptor()
+            };
+
+            actionContext.RouteData.Routers.Add(route);
+            IUrlHelperFactory factory = request.HttpContext.RequestServices.GetRequiredService<IUrlHelperFactory>();
+            IUrlHelper helper = factory.GetUrlHelper(actionContext);
+
+            string baseAddress = helper.Link(oDataRouteName, new RouteValueDictionary() { { ODataRouteConstants.ODataPath, String.Empty } });
+            if (baseAddress == null)
+            {
+                throw new InvalidOperationException(SRResources.UnableToDetermineBaseUrl);
+            }
+            return new Uri(baseAddress);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchMiddleware.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchMiddleware.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Defines the middleware for handling OData batch requests. This middleware essentially
+    /// acts like branching middleware, <see cref="MapExtensions "/>, and redirects OData batch
+    /// requests to the appropriate ODataBatchHandler.
+    /// </summary>
+    public class ODataBatchMiddleware
+    {
+        private readonly RequestDelegate next;
+
+        /// <summary>
+        /// Instantiates a new instance of <see cref="ODataBatchMiddleware"/>.
+        /// </summary>
+        public ODataBatchMiddleware(RequestDelegate next)
+        {
+            this.next = next;
+        }
+
+        /// <summary>
+        /// Invoke the middleware.
+        /// </summary>
+        /// <param name="context">The http context.</param>
+        /// <returns>A task that can be awaited.</returns>
+        public async Task Invoke(HttpContext context)
+        {
+            // Attempt to match the path to a bach route.
+            ODataBatchPathMapping batchMapping = context.RequestServices.GetRequiredService<ODataBatchPathMapping>();
+
+            string routeName;
+            if (batchMapping.TryGetRouteName(context.Request.Path, out routeName))
+            {
+                // Get the per-route continer and retrieve the batch handler.
+                IPerRouteContainer perRouteContainer = context.RequestServices.GetRequiredService<IPerRouteContainer>();
+                if (perRouteContainer == null)
+                {
+                    throw Error.InvalidOperation(SRResources.MissingODataServices, nameof(IPerRouteContainer));
+                }
+
+                IServiceProvider rootContainer = perRouteContainer.GetODataRootContainer(routeName);
+                ODataBatchHandler batchHandler = rootContainer.GetRequiredService<ODataBatchHandler>();
+
+                await batchHandler.ProcessBatchAsync(context, next);
+            }
+            else
+            {
+                await this.next(context);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchPathMapping.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchPathMapping.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// A class for storing batch route names and prefixes used to determine if a route is a
+    /// batch route.
+    /// </summary>
+    public class ODataBatchPathMapping
+    {
+        private Dictionary<string, string> templateMappings = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Add a route name and template for batching.
+        /// </summary>
+        /// <param name="routeName"></param>
+        /// <param name="routeTemplate"></param>
+        public void AddRoute(string routeName, string routeTemplate)
+        {
+            templateMappings[routeTemplate] = routeName;
+        }
+
+        /// <summary>
+        /// Try and get the batch handler for a given path.
+        /// </summary>
+        /// <param name="path">The request path to match against the templates.</param>
+        /// <param name="routeName">The route name if found or null.</param>
+        /// <returns>true if a route name is found, otherwise false.</returns>
+        public bool TryGetRouteName(string path, out string routeName)
+        {
+            return templateMappings.TryGetValue(path, out routeName);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -1,0 +1,233 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using Microsoft.OData;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="ODataBatchReader"/> class.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class ODataBatchReaderExtensions
+    {
+        /// <summary>
+        /// Reads a ChangeSet request.
+        /// </summary>
+        /// <param name="reader">The <see cref="ODataBatchReader"/>.</param>
+        /// <param name="context">The context containing the batch request messages.</param>
+        /// <param name="batchId">The Batch Id.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A collection of <see cref="HttpRequest"/> in the ChangeSet.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "We need to return a collection of request messages asynchronously.")]
+        public static async Task<IList<HttpContext>> ReadChangeSetRequestAsync(
+            this ODataBatchReader reader, HttpContext context, Guid batchId, CancellationToken cancellationToken)
+        {
+            if (reader == null)
+            {
+                throw Error.ArgumentNull("reader");
+            }
+            if (reader.State != ODataBatchReaderState.ChangesetStart)
+            {
+                throw Error.InvalidOperation(
+                    SRResources.InvalidBatchReaderState,
+                    reader.State.ToString(),
+                    ODataBatchReaderState.ChangesetStart.ToString());
+            }
+
+            Guid changeSetId = Guid.NewGuid();
+            List<HttpContext> contexts = new List<HttpContext>();
+            while (reader.Read() && reader.State != ODataBatchReaderState.ChangesetEnd)
+            {
+                if (reader.State == ODataBatchReaderState.Operation)
+                {
+                    contexts.Add(await ReadOperationInternalAsync(reader, context, batchId, changeSetId, cancellationToken));
+                }
+            }
+            return contexts;
+        }
+
+        /// <summary>
+        /// Reads an Operation request.
+        /// </summary>
+        /// <param name="reader">The <see cref="ODataBatchReader"/>.</param>
+        /// <param name="context">The context containing the batch request messages.</param>
+        /// <param name="batchId">The Batch ID.</param>
+        /// <param name="bufferContentStream">if set to <c>true</c> then the request content stream will be buffered.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A <see cref="HttpRequest"/> representing the operation.</returns>
+        public static Task<HttpContext> ReadOperationRequestAsync(
+            this ODataBatchReader reader, HttpContext context, Guid batchId, bool bufferContentStream, CancellationToken cancellationToken)
+        {
+            if (reader == null)
+            {
+                throw Error.ArgumentNull("reader");
+            }
+            if (reader.State != ODataBatchReaderState.Operation)
+            {
+                throw Error.InvalidOperation(
+                    SRResources.InvalidBatchReaderState,
+                    reader.State.ToString(),
+                    ODataBatchReaderState.Operation.ToString());
+            }
+
+            return ReadOperationInternalAsync(reader, context, batchId, null, cancellationToken, bufferContentStream);
+        }
+
+        /// <summary>
+        /// Reads an Operation request in a ChangeSet.
+        /// </summary>
+        /// <param name="reader">The <see cref="ODataBatchReader"/>.</param>
+        /// <param name="context">The context containing the batch request messages.</param>
+        /// <param name="batchId">The Batch ID.</param>
+        /// <param name="changeSetId">The ChangeSet ID.</param>
+        /// <param name="bufferContentStream">if set to <c>true</c> then the request content stream will be buffered.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A <see cref="HttpRequest"/> representing a ChangeSet operation</returns>
+        public static Task<HttpContext> ReadChangeSetOperationRequestAsync(
+            this ODataBatchReader reader, HttpContext context, Guid batchId, Guid changeSetId, bool bufferContentStream, CancellationToken cancellationToken)
+        {
+            if (reader == null)
+            {
+                throw Error.ArgumentNull("reader");
+            }
+            if (reader.State != ODataBatchReaderState.Operation)
+            {
+                throw Error.InvalidOperation(
+                    SRResources.InvalidBatchReaderState,
+                    reader.State.ToString(),
+                    ODataBatchReaderState.Operation.ToString());
+            }
+
+            return ReadOperationInternalAsync(reader, context, batchId, changeSetId, cancellationToken, bufferContentStream);
+        }
+
+        private static async Task<HttpContext> ReadOperationInternalAsync(
+            ODataBatchReader reader, HttpContext originalContext, Guid batchId, Guid? changeSetId, CancellationToken cancellationToken, bool bufferContentStream = true)
+        {
+            ODataBatchOperationRequestMessage batchRequest = reader.CreateOperationRequestMessage();
+
+            HttpContext context = CreateHttpContext(originalContext);
+            HttpRequest request = context.Request;
+
+            request.Method = batchRequest.Method;
+            request.CopyAbsoluteUrl(batchRequest.Url);
+
+            // Not using bufferContentStream. Unlike AspNet, AspNetCore cannot guarantee the disposal
+            // of the stream in the context of execution so there is no choice but to copy the stream
+            // from the batch reader.
+            using (Stream stream = batchRequest.GetStream())
+            {
+                MemoryStream bufferedStream = new MemoryStream();
+                // Passing in the default buffer size of 81920 so that we can also pass in a cancellation token
+                await stream.CopyToAsync(bufferedStream, bufferSize: 81920, cancellationToken: cancellationToken);
+                bufferedStream.Position = 0;
+                request.Body = bufferedStream;
+            }
+
+            foreach (var header in batchRequest.Headers)
+            {
+                // Copy headers from batch, overwriting any existing headers.
+                string headerName = header.Key;
+                string headerValue = header.Value;
+                request.Headers[headerName] = headerValue;
+            }
+
+            request.SetODataBatchId(batchId);
+            request.SetODataContentId(batchRequest.ContentId);
+
+            if (changeSetId != null && changeSetId.HasValue)
+            {
+                request.SetODataChangeSetId(changeSetId.Value);
+            }
+
+            return context;
+        }
+
+        private static HttpContext CreateHttpContext(HttpContext originalContext)
+        {
+            // Clone the features so that a new set is used for each context.
+            // The features themselves will be reused but not the collection. We
+            // store the request container as a feature of the request and we don't want
+            // the features added to one context/request to be visible on another.
+            //
+            // Note that just about everything inm the HttpContext and HttpRequest is
+            // backed by one of these features. So reusing the features means the HttContext
+            // and HttpRequests are the same without needing to copy properties. To make them
+            // different, we need to avoid copying certain features to that the objects don't
+            // share the same storage/
+            IFeatureCollection features = new FeatureCollection();
+            foreach (KeyValuePair<Type, object> kvp in originalContext.Features)
+            {
+                // Don't include the OData features. They may already
+                // be present. This will get re-created later.
+                //
+                // Also, clear out the items feature, which is used
+                // to store a few object, the one that is an issue here is the Url
+                // helper, which has an affinity to the context. If we leave it,
+                // the context of the helper no longer matches the new context and
+                // the resulting url helper doesn't have access to the OData feature
+                // because it's looking in the wrong context.
+                //
+                // Because we need a different request and response, leave those features
+                // out as well.
+                if (kvp.Key == typeof(IODataBatchFeature) ||
+                    kvp.Key == typeof(IODataFeature) ||
+                    kvp.Key == typeof(IItemsFeature) ||
+                    kvp.Key == typeof(IHttpRequestFeature) ||
+                    kvp.Key == typeof(IHttpResponseFeature))
+                {
+                    continue;
+                }
+
+                features[kvp.Key] = kvp.Value;
+            }
+
+            // Add in an items, request and response feature.
+            features[typeof(IItemsFeature)] = new ItemsFeature();
+            features[typeof(IHttpRequestFeature)] = new HttpRequestFeature();
+            features[typeof(IHttpResponseFeature)] = new HttpResponseFeature();
+
+            // Create a context from the factory or use the default context.
+            HttpContext context = null;
+            IHttpContextFactory httpContextFactory = originalContext.RequestServices.GetRequiredService<IHttpContextFactory>();
+            if (httpContextFactory != null)
+            {
+                context = httpContextFactory.Create(features);
+            }
+            else
+            {
+                context = new DefaultHttpContext(features);
+            }
+
+            // Clone parts of the request. All other parts of the request will be 
+            // populated during batch processing.
+            context.Request.Cookies = originalContext.Request.Cookies;
+            foreach (KeyValuePair<string, StringValues> header in originalContext.Request.Headers)
+            {
+                context.Request.Headers.Add(header);
+            }
+
+            // Create a response body as the default response feature does not
+            // have a valid stream.
+            context.Response.Body = new MemoryStream();
+
+            return context;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Represents an OData batch request.
+    /// </summary>
+    public abstract class ODataBatchRequestItem
+    {
+        /// <summary>
+        /// Routes a single OData batch request.
+        /// </summary>
+        /// <param name="handler">The handler for processing a message.</param>
+        /// <param name="context">The context.</param>
+        /// <param name="contentIdToLocationMapping">The Content-ID to Location mapping.</param>
+        /// <returns></returns>
+        public static async Task SendRequestAsync(RequestDelegate handler, HttpContext context, Dictionary<string, string> contentIdToLocationMapping)
+        {
+            if (handler == null)
+            {
+                throw Error.ArgumentNull("handler");
+            }
+            if (context == null)
+            {
+                throw Error.ArgumentNull("context");
+            }
+
+            if (contentIdToLocationMapping != null)
+            {
+                string queryString = context.Request.QueryString.HasValue ? context.Request.QueryString.Value : String.Empty;
+                string resolvedRequestUrl = ContentIdHelpers.ResolveContentId(queryString, contentIdToLocationMapping);
+                if (!string.IsNullOrEmpty(resolvedRequestUrl))
+                {
+                    Uri resolvedUri = new Uri(resolvedRequestUrl, UriKind.RelativeOrAbsolute);
+                    if (resolvedUri.IsAbsoluteUri)
+                    {
+                        context.Request.CopyAbsoluteUrl(resolvedUri);
+                    }
+                    else
+                    {
+                        context.Request.QueryString = new QueryString(resolvedRequestUrl);
+                    }
+                }
+
+                context.Request.SetODataContentIdMapping(contentIdToLocationMapping);
+            }
+
+            try
+            {
+                await handler(context);
+
+                string contentId = context.Request.GetODataContentId();
+
+                if (contentIdToLocationMapping != null && contentId != null)
+                {
+                    AddLocationHeaderToMapping(context.Response, contentIdToLocationMapping, contentId);
+                }
+            }
+            catch (Exception)
+            {
+                // Unlike AspNet, the exception handling is (by default) upstream of this middleware
+                // so we need to trap exceptions on our own. This code is similar to the
+                // ExceptionHandlerMiddleware class in AspNetCore.
+                context.Response.Clear();
+                context.Response.StatusCode = 500;
+            }
+        }
+
+        private static void AddLocationHeaderToMapping(
+            HttpResponse response,
+            IDictionary<string, string> contentIdToLocationMapping,
+            string contentId)
+        {
+            Contract.Assert(response != null);
+            Contract.Assert(response.Headers != null);
+            Contract.Assert(contentIdToLocationMapping != null);
+            Contract.Assert(contentId != null);
+
+            var headers = response.GetTypedHeaders();
+            if (headers.Location != null)
+            {
+                contentIdToLocationMapping.Add(contentId, headers.Location.AbsoluteUri);
+            }
+        }
+
+        /// <summary>
+        /// Routes the request.
+        /// </summary>
+        /// <param name="handler">The handler for processing a message.</param>
+        /// <returns>A <see cref="ODataBatchResponseItem"/>.</returns>
+        public abstract Task<ODataBatchResponseItem> SendRequestAsync(RequestDelegate handler);
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchResponseItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchResponseItem.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Microsoft.OData;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Represents an OData batch response.
+    /// </summary>
+    public abstract class ODataBatchResponseItem
+    {
+        /// <summary>
+        /// Writes a single OData batch response.
+        /// </summary>
+        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
+        /// <param name="context">The message context.</param>
+        public static async Task WriteMessageAsync(ODataBatchWriter writer, HttpContext context)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull("writer");
+            }
+            if (context == null)
+            {
+                throw Error.ArgumentNull("context");
+            }
+
+            string contentId = (context.Request != null) ? context.Request.GetODataContentId() : String.Empty;
+
+            ODataBatchOperationResponseMessage batchResponse = writer.CreateOperationResponseMessage(contentId);
+
+            batchResponse.StatusCode = context.Response.StatusCode;
+
+            foreach (KeyValuePair<string, StringValues> header in context.Response.Headers)
+            {
+                batchResponse.SetHeader(header.Key, String.Join(",", header.Value.ToArray()));
+            }
+
+            if (context.Response.Body != null)
+            {
+                using (Stream stream = batchResponse.GetStream())
+                {
+                    context.RequestAborted.ThrowIfCancellationRequested();
+                    await context.Response.Body.CopyToAsync(stream);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Writes the response.
+        /// </summary>
+        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
+        public abstract Task WriteResponseAsync(ODataBatchWriter writer);
+
+        /// <summary>
+        /// Gets a value that indicates if the responses in this item are successful.
+        /// </summary>
+        internal virtual bool IsResponseSuccessful()
+        {
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/OperationRequestItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/OperationRequestItem.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Represents an Operation request.
+    /// </summary>
+    public class OperationRequestItem : ODataBatchRequestItem
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationRequestItem"/> class.
+        /// </summary>
+        /// <param name="context">The Operation request context.</param>
+        public OperationRequestItem(HttpContext context)
+        {
+            if (context == null)
+            {
+                throw Error.ArgumentNull("context");
+            }
+
+            Context = context;
+        }
+
+        /// <summary>
+        /// Gets the Operation request context.
+        /// </summary>
+        public HttpContext Context { get; private set; }
+
+        /// <summary>
+        /// Sends the Operation request.
+        /// </summary>
+        /// <param name="handler">The handler for processing a message.</param>
+        /// <returns>A <see cref="OperationResponseItem"/>.</returns>
+        public override async Task<ODataBatchResponseItem> SendRequestAsync(RequestDelegate handler)
+        {
+            if (handler == null)
+            {
+                throw Error.ArgumentNull("handler");
+            }
+
+            await SendRequestAsync(handler, Context, null);
+            return new OperationResponseItem(Context);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/OperationResponseItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/OperationResponseItem.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.OData;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// Represents an Operation response.
+    /// </summary>
+    public class OperationResponseItem : ODataBatchResponseItem
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationResponseItem"/> class.
+        /// </summary>
+        /// <param name="context">The response context for the Operation request.</param>
+        public OperationResponseItem(HttpContext context)
+        {
+            if (context == null)
+            {
+                throw Error.ArgumentNull("context");
+            }
+
+            Context = context;
+        }
+
+        /// <summary>
+        /// Gets the response messages for the Operation.
+        /// </summary>
+        public HttpContext Context { get; private set; }
+
+        /// <summary>
+        /// Writes the response as an Operation.
+        /// </summary>
+        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
+        public override Task WriteResponseAsync(ODataBatchWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull("writer");
+            }
+
+            return WriteMessageAsync(writer, Context);
+        }
+
+        /// <summary>
+        /// Gets a value that indicates if the responses in this item are successful.
+        /// </summary>
+        internal override bool IsResponseSuccessful()
+        {
+            return Context.Response.IsSuccessStatusCode();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/UnbufferedODataBatchHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/UnbufferedODataBatchHandler.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Adapters;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    /// <summary>
+    /// An implementation of <see cref="ODataBatchHandler"/> that doesn't buffer the request content stream.
+    /// </summary>
+    public class UnbufferedODataBatchHandler : ODataBatchHandler
+    {
+        /// <inheritdoc/>
+        public override async Task ProcessBatchAsync(HttpContext context, RequestDelegate nextHandler)
+        {
+            if (context == null)
+            {
+                throw Error.ArgumentNull("context");
+            }
+            if (nextHandler == null)
+            {
+                throw Error.ArgumentNull("nextHandler");
+            }
+
+            if (!await ValidateRequest(context.Request))
+            {
+                return;
+            }
+
+            // This container is for the overall batch request.
+            HttpRequest request = context.Request;
+            IServiceProvider requestContainer = request.CreateRequestContainer(ODataRouteName);
+            requestContainer.GetRequiredService<ODataMessageReaderSettings>().BaseUri = GetBaseUri(request);
+
+            ODataMessageReader reader = request.GetODataMessageReader(requestContainer);
+
+            ODataBatchReader batchReader = reader.CreateODataBatchReader();
+            List<ODataBatchResponseItem> responses = new List<ODataBatchResponseItem>();
+            Guid batchId = Guid.NewGuid();
+
+            SetContinueOnError(new WebApiRequestMessage(request), new WebApiRequestHeaders(request.Headers));
+
+            while (batchReader.Read())
+            {
+                ODataBatchResponseItem responseItem = null;
+                if (batchReader.State == ODataBatchReaderState.ChangesetStart)
+                {
+                    responseItem = await ExecuteChangeSetAsync(batchReader, batchId, request, nextHandler);
+                }
+                else if (batchReader.State == ODataBatchReaderState.Operation)
+                {
+                    responseItem = await ExecuteOperationAsync(batchReader, batchId, request, nextHandler);
+                }
+                if (responseItem != null)
+                {
+                    responses.Add(responseItem);
+                    if (responseItem.IsResponseSuccessful() == false && ContinueOnError == false)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            await CreateResponseMessageAsync(responses, request);
+        }
+
+        /// <summary>
+        /// Executes the operation.
+        /// </summary>
+        /// <param name="batchReader">The batch reader.</param>
+        /// <param name="batchId">The batch id.</param>
+        /// <param name="originalRequest">The original request containing all the batch requests.</param>
+        /// <param name="handler">The handler for processing a message.</param>
+        /// <returns>The response for the operation.</returns>
+        public virtual async Task<ODataBatchResponseItem> ExecuteOperationAsync(ODataBatchReader batchReader, Guid batchId, HttpRequest originalRequest, RequestDelegate handler)
+        {
+            if (batchReader == null)
+            {
+                throw Error.ArgumentNull("batchReader");
+            }
+            if (originalRequest == null)
+            {
+                throw Error.ArgumentNull("originalRequest");
+            }
+            if (handler == null)
+            {
+                throw Error.ArgumentNull("handler");
+            }
+
+            CancellationToken cancellationToken = originalRequest.HttpContext.RequestAborted;
+            cancellationToken.ThrowIfCancellationRequested();
+            HttpContext operationContext = await batchReader.ReadOperationRequestAsync(originalRequest.HttpContext, batchId, false, cancellationToken);
+
+            operationContext.Request.CopyBatchRequestProperties(originalRequest);
+            operationContext.Request.DeleteRequestContainer(false);
+            OperationRequestItem operation = new OperationRequestItem(operationContext);
+
+            ODataBatchResponseItem responseItem = await operation.SendRequestAsync(handler);
+
+            return responseItem;
+        }
+
+        /// <summary>
+        /// Executes the ChangeSet.
+        /// </summary>
+        /// <param name="batchReader">The batch reader.</param>
+        /// <param name="batchId">The batch id.</param>
+        /// <param name="originalRequest">The original request containing all the batch requests.</param>
+        /// <param name="handler">The handler for processing a message.</param>
+        /// <returns>The response for the ChangeSet.</returns>
+        public virtual async Task<ODataBatchResponseItem> ExecuteChangeSetAsync(ODataBatchReader batchReader, Guid batchId, HttpRequest originalRequest, RequestDelegate handler)
+        {
+            if (batchReader == null)
+            {
+                throw Error.ArgumentNull("batchReader");
+            }
+            if (originalRequest == null)
+            {
+                throw Error.ArgumentNull("originalRequest");
+            }
+            if (handler == null)
+            {
+                throw Error.ArgumentNull("handler");
+            }
+
+            Guid changeSetId = Guid.NewGuid();
+            List<HttpContext> changeSetResponse = new List<HttpContext>();
+            Dictionary<string, string> contentIdToLocationMapping = new Dictionary<string, string>();
+            while (batchReader.Read() && batchReader.State != ODataBatchReaderState.ChangesetEnd)
+            {
+                if (batchReader.State == ODataBatchReaderState.Operation)
+                {
+                    CancellationToken cancellationToken = originalRequest.HttpContext.RequestAborted;
+                    HttpContext changeSetOperationContext = await batchReader.ReadChangeSetOperationRequestAsync(originalRequest.HttpContext, batchId, changeSetId, false, cancellationToken);
+                    changeSetOperationContext.Request.CopyBatchRequestProperties(originalRequest);
+                    changeSetOperationContext.Request.DeleteRequestContainer(false);
+
+                    await ODataBatchRequestItem.SendRequestAsync(handler, changeSetOperationContext, contentIdToLocationMapping);
+                    if (changeSetOperationContext.Response.IsSuccessStatusCode())
+                    {
+                        changeSetResponse.Add(changeSetOperationContext);
+                    }
+                    else
+                    {
+                        changeSetResponse.Clear();
+                        changeSetResponse.Add(changeSetOperationContext);
+                        return new ChangeSetResponseItem(changeSetResponse);
+                    }
+                }
+            }
+
+            return new ChangeSetResponseItem(changeSetResponse);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpContextExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpContextExtensions.cs
@@ -41,6 +41,28 @@ namespace Microsoft.AspNet.OData.Extensions
         }
 
         /// <summary>
+        /// Extension method to return the <see cref="IODataBatchFeature"/> from the <see cref="HttpContext"/>.
+        /// </summary>
+        /// <param name="httpContext">The Http context.</param>
+        /// <returns>The <see cref="IODataBatchFeature"/>.</returns>
+        public static IODataBatchFeature ODataBatchFeature(this HttpContext httpContext)
+        {
+            if (httpContext == null)
+            {
+                throw Error.ArgumentNull("httpContext");
+            }
+
+            IODataBatchFeature odataBatchFeature = httpContext.Features.Get<IODataBatchFeature>();
+            if (odataBatchFeature == null)
+            {
+                odataBatchFeature = new ODataBatchFeature();
+                httpContext.Features.Set<IODataBatchFeature>(odataBatchFeature);
+            }
+
+            return odataBatchFeature;
+        }
+
+        /// <summary>
         /// Extension method to return the <see cref="IUrlHelper"/> from the <see cref="HttpContext"/>.
         /// </summary>
         /// <param name="httpContext">The Http context.</param>

--- a/src/Microsoft.AspNetCore.OData/Extensions/ODataApplicationBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ODataApplicationBuilderExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.AspNet.OData.Batch;
+using Microsoft.AspNetCore.Builder;
+
+namespace Microsoft.AspNet.OData.Extensions
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="IApplicationBuilder"/> to add OData routes.
+    /// </summary>
+    public static class ODataApplicationBuilderExtensions
+    {
+        /// <summary>
+        /// USe OData batching middleware.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder "/> to use.</param>
+        public static void UseODataBatching(this IApplicationBuilder app)
+        {
+            app.UseMiddleware<ODataBatchMiddleware>();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Extensions/ODataRouteBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ODataRouteBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.OData.Adapters;
+using Microsoft.AspNet.OData.Batch;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Formatter;
 using Microsoft.AspNet.OData.Interfaces;
@@ -494,10 +495,35 @@ namespace Microsoft.AspNet.OData.Extensions
                 .GetRequiredService<IInlineConstraintResolver>();
 
             // Resolve HTTP handler, create the OData route and register it.
+            ODataRoute route = null;
             routePrefix = RemoveTrailingSlash(routePrefix);
-            ODataRoute route = new ODataRoute(builder.DefaultHandler, routeName, routePrefix, routeConstraint, inlineConstraintResolver);
-            builder.Routes.Add(route);
 
+            IRouter customRouter = serviceProvider.GetService<IRouter>();
+            route = new ODataRoute(
+                customRouter != null ? customRouter : builder.DefaultHandler,
+                routeName,
+                routePrefix,
+                routeConstraint,
+                inlineConstraintResolver);
+
+            // If a batch handler is present, register the route with the batch path mapper. This will be used
+            // by the batching middleware to handle the batch request. Batching still requires the injection
+            // of the batching middleware via UseODataBatching().
+            ODataBatchHandler batchHandler = serviceProvider.GetService<ODataBatchHandler>();
+            if (batchHandler != null)
+            {
+                batchHandler.ODataRoute = route;
+                batchHandler.ODataRouteName = routeName;
+
+                string batchPath = String.IsNullOrEmpty(routePrefix)
+                    ? '/' + ODataRouteConstants.Batch
+                    : '/' + routePrefix + '/' + ODataRouteConstants.Batch;
+
+                ODataBatchPathMapping batchMapping = builder.ServiceProvider.GetRequiredService<ODataBatchPathMapping>();
+                batchMapping.AddRoute(routeName, batchPath);
+            }
+
+            builder.Routes.Add(route);
             return route;
         }
 
@@ -515,6 +541,26 @@ namespace Microsoft.AspNet.OData.Extensions
             return builder.MapODataServiceRoute(routeName, routePrefix, containerBuilder =>
                 containerBuilder.AddService(Microsoft.OData.ServiceLifetime.Singleton, sp => model)
                        .AddService<IEnumerable<IODataRoutingConvention>>(Microsoft.OData.ServiceLifetime.Singleton, sp =>
+                           ODataRoutingConventions.CreateDefaultWithAttributeRouting(routeName, builder)));
+        }
+
+        /// <summary>
+        /// Maps the specified OData route and the OData route attributes. When the <paramref name="batchHandler"/> is
+        /// non-<c>null</c>, it will create a '$batch' endpoint to handle the batch requests.
+        /// </summary>
+        /// <param name="builder">The <see cref="IRouteBuilder"/> to add the route to.</param>
+        /// <param name="routeName">The name of the route to map.</param>
+        /// <param name="routePrefix">The prefix to add to the OData route's path template.</param>
+        /// <param name="model">The EDM model to use for parsing OData paths.</param>
+        /// <param name="batchHandler">The <see cref="ODataBatchHandler"/>.</param>
+        /// <returns>The added <see cref="ODataRoute"/>.</returns>
+        public static ODataRoute MapODataServiceRoute(this IRouteBuilder builder, string routeName,
+            string routePrefix, IEdmModel model, ODataBatchHandler batchHandler)
+        {
+            return builder.MapODataServiceRoute(routeName, routePrefix, containerBuilder =>
+                containerBuilder.AddService(ServiceLifetime.Singleton, sp => model)
+                       .AddService(ServiceLifetime.Singleton, sp => batchHandler)
+                       .AddService<IEnumerable<IODataRoutingConvention>>(ServiceLifetime.Singleton, sp =>
                            ODataRoutingConventions.CreateDefaultWithAttributeRouting(routeName, builder)));
         }
 
@@ -538,6 +584,31 @@ namespace Microsoft.AspNet.OData.Extensions
                 containerBuilder.AddService(Microsoft.OData.ServiceLifetime.Singleton, sp => model)
                        .AddService(Microsoft.OData.ServiceLifetime.Singleton, sp => pathHandler)
                        .AddService(Microsoft.OData.ServiceLifetime.Singleton, sp => routingConventions.ToList().AsEnumerable()));
+        }
+
+        /// <summary>
+        /// Maps the specified OData route. When the <paramref name="batchHandler"/> is non-<c>null</c>, it will
+        /// create a '$batch' endpoint to handle the batch requests.
+        /// </summary>
+        /// <param name="builder">The <see cref="IRouteBuilder"/> to add the route to.</param>
+        /// <param name="routeName">The name of the route to map.</param>
+        /// <param name="routePrefix">The prefix to add to the OData route's path template.</param>
+        /// <param name="model">The EDM model to use for parsing OData paths.</param>
+        /// <param name="pathHandler">The <see cref="IODataPathHandler" /> to use for parsing the OData path.</param>
+        /// <param name="routingConventions">
+        /// The OData routing conventions to use for controller and action selection.
+        /// </param>
+        /// <param name="batchHandler">The <see cref="ODataBatchHandler"/>.</param>
+        /// <returns>The added <see cref="ODataRoute"/>.</returns>
+        public static ODataRoute MapODataServiceRoute(this IRouteBuilder builder, string routeName,
+            string routePrefix, IEdmModel model, IODataPathHandler pathHandler,
+            IEnumerable<IODataRoutingConvention> routingConventions, ODataBatchHandler batchHandler)
+        {
+            return builder.MapODataServiceRoute(routeName, routePrefix, containerBuilder =>
+                containerBuilder.AddService(ServiceLifetime.Singleton, sp => model)
+                       .AddService(ServiceLifetime.Singleton, sp => pathHandler)
+                       .AddService(ServiceLifetime.Singleton, sp => routingConventions.ToList().AsEnumerable())
+                       .AddService(ServiceLifetime.Singleton, sp => batchHandler));
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Extensions/ODataServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ODataServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.AspNet.OData.Batch;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Formatter;
 using Microsoft.AspNet.OData.Interfaces;
@@ -41,6 +42,9 @@ namespace Microsoft.AspNet.OData.Extensions
             // fluent extensions APIs to IRouteBuilder.
             services.AddSingleton<ODataOptions>();
             services.AddSingleton<DefaultQuerySettings>();
+
+            // Add the batch path mapping class to store batch route names and prefixes.
+            services.AddSingleton<ODataBatchPathMapping>();
 
             // Configure MvcCore to use formatters. The OData formatters do go into the global service
             // provider and get picked up by the AspNetCore MVC framework. However, they ignore non-OData

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Headers;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.OData;
 
 namespace Microsoft.AspNet.OData.Formatter
@@ -129,7 +130,13 @@ namespace Microsoft.AspNet.OData.Formatter
 
                 Action<Exception> logErrorAction = (ex) =>
                 {
-                    throw ex;
+                    ILogger logger = context.HttpContext.RequestServices.GetService<ILogger>();
+                    if (logger == null)
+                    {
+                        throw ex;
+                    }
+
+                    logger.LogError(ex, String.Empty);
                 };
 
                 List<IDisposable> toDispose = new List<IDisposable>();

--- a/src/Microsoft.AspNetCore.OData/Interfaces/IODataBatchFeature.cs
+++ b/src/Microsoft.AspNetCore.OData/Interfaces/IODataBatchFeature.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.OData.Interfaces
+{
+    /// <summary>
+    /// Provide the interface for the details of a given OData batch request.
+    /// </summary>
+    public interface IODataBatchFeature
+    {
+        /// <summary>
+        /// Gets or sets the batch id.
+        /// </summary>
+        Guid? BatchId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the change set id.
+        /// </summary>
+        Guid? ChangeSetId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content id.
+        /// </summary>
+        string ContentId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content id mapping.
+        /// </summary>
+        IDictionary<string, string> ContentIdMapping { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/ODataBatchFeature.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataBatchFeature.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNet.OData.Interfaces;
+
+namespace Microsoft.AspNet.OData
+{
+    /// <summary>
+    /// Provide the interface for the details of a given OData batch request.
+    /// </summary>
+    public class ODataBatchFeature : IODataBatchFeature
+    {
+        /// <summary>
+        /// Gets or sets the batch id.
+        /// </summary>
+        public Guid? BatchId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the change set id.
+        /// </summary>
+        public Guid? ChangeSetId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content id.
+        /// </summary>
+        public string ContentId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content id mapping.
+        /// </summary>
+        public IDictionary<string, string> ContentIdMapping { get; set; }
+    }
+}

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -815,11 +815,7 @@ public class Microsoft.AspNet.OData.Batch.ODataBatchContent : System.Net.Http.Ht
 	System.Collections.Generic.IEnumerable`1[[Microsoft.AspNet.OData.Batch.ODataBatchResponseItem]] Responses  { public get; }
 
 	protected virtual void Dispose (bool disposing)
-	[
-	AsyncStateMachineAttribute(),
-	]
 	protected virtual System.Threading.Tasks.Task SerializeToStreamAsync (System.IO.Stream stream, System.Net.TransportContext context)
-
 	protected virtual bool TryComputeLength (out System.Int64& length)
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request makes progress on issues #975, #939, #772, #628, #229.

### Description

This change adds batching support.

Batching is configured the same as it is in the ASP.NET version with
the exception of the batching middleware which is configured using the
following extensions from the Microsoft.AspNet.OData.Extensions namespace
in the StartUp.Configure() method using the IApplicationBuilder object:

`  applicationBuilder.UseODataBatching()`

Each OData route may have its own batching handler which can be passed into
a call to MapODataServiceRoute(), in the StartUp.Configure() method using
the IApplicationBuilder object:

```
  app.UseMvc(routes =>
  {
      routes.MapODataServiceRoute("OData", "odata", edmModel, new DefaultODataBatchHandler());
  });
```

Since the APIs for batching use ASP.NET constructs directly, there is very little
shared code in the batching feature. The batching APIs use the same design patterns
but different in the ASP.NET objects the reference, e.g. HttpRequestMessage vs HttpRequest.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

Port Unit Tests to NetCore
Port E2E Tests to NetCore