### PR TITLE
Fix service detection for unbuffered batching.

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchHandler.cs
@@ -39,12 +39,12 @@ namespace Microsoft.AspNet.OData.Batch
         /// <summary>
         /// Set ContinueOnError based on the request and headers.
         /// </summary>
-        /// <param name="request">The request.</param>
         /// <param name="header">The request header.</param>
-        internal void SetContinueOnError(IWebApiRequestMessage request, IWebApiHeaders header)
+        /// <param name="enableContinueOnErrorHeader">Flag indicating if continue on error header is enabled.</param>
+        internal void SetContinueOnError(IWebApiHeaders header, bool enableContinueOnErrorHeader)
         {
             string preferHeader = RequestPreferenceHelpers.GetRequestPreferHeader(header);
-            if ((preferHeader != null && preferHeader.Contains(PreferenceContinueOnError)) || (!request.Options.EnableContinueOnErrorHeader))
+            if ((preferHeader != null && preferHeader.Contains(PreferenceContinueOnError)) || (!enableContinueOnErrorHeader))
             {
                 ContinueOnError = true;
             }

--- a/src/Microsoft.AspNet.OData.Shared/Interfaces/IWebApiOptions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Interfaces/IWebApiOptions.cs
@@ -25,11 +25,5 @@ namespace Microsoft.AspNet.OData.Interfaces
         /// Gets or Sets a value indicating if value should be emitted for dynamic properties which are null.
         /// </summary>
         bool NullDynamicPropertyIsEnabled { get; }
-
-        /// <summary>
-        /// Check the continue-on-error header is enable or not.
-        /// </summary>
-        /// <returns>True if continue-on-error header is enable; false otherwise</returns>
-        bool EnableContinueOnErrorHeader { get; }
     }
 }

--- a/src/Microsoft.AspNet.OData/Adapters/WebApiOptions.cs
+++ b/src/Microsoft.AspNet.OData/Adapters/WebApiOptions.cs
@@ -27,7 +27,6 @@ namespace Microsoft.AspNet.OData.Adapters
 
             this.NullDynamicPropertyIsEnabled = configuration.HasEnabledNullDynamicProperty();
             this.UrlKeyDelimiter = configuration.GetUrlKeyDelimiter();
-            this.EnableContinueOnErrorHeader = configuration.HasEnabledContinueOnErrorHeader();
         }
 
         /// <summary>
@@ -40,11 +39,5 @@ namespace Microsoft.AspNet.OData.Adapters
         /// Gets or Sets a value indicating if value should be emitted for dynamic properties which are null.
         /// </summary>
         public bool NullDynamicPropertyIsEnabled { get; private set; }
-
-        /// <summary>
-        /// Check the continue-on-error header is enable or not.
-        /// </summary>
-        /// <returns>True if continue-on-error header is enable; false otherwise</returns>
-        public bool EnableContinueOnErrorHeader { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.OData/Batch/DefaultODataBatchHandler.cs
+++ b/src/Microsoft.AspNet.OData/Batch/DefaultODataBatchHandler.cs
@@ -46,7 +46,12 @@ namespace Microsoft.AspNet.OData.Batch
 
             IList<ODataBatchRequestItem> subRequests = await ParseBatchRequestsAsync(request, cancellationToken);
 
-            SetContinueOnError(new WebApiRequestMessage(request), new WebApiRequestHeaders(request.Headers));
+            HttpConfiguration configuration = request.GetConfiguration();
+            bool enableContinueOnErrorHeader = (configuration != null)
+                ? configuration.HasEnabledContinueOnErrorHeader()
+                : false;
+
+            SetContinueOnError(new WebApiRequestHeaders(request.Headers), enableContinueOnErrorHeader);
 
             try
             {

--- a/src/Microsoft.AspNet.OData/Batch/UnbufferedODataBatchHandler.cs
+++ b/src/Microsoft.AspNet.OData/Batch/UnbufferedODataBatchHandler.cs
@@ -51,7 +51,12 @@ namespace Microsoft.AspNet.OData.Batch
             List<ODataBatchResponseItem> responses = new List<ODataBatchResponseItem>();
             Guid batchId = Guid.NewGuid();
 
-            SetContinueOnError(new WebApiRequestMessage(request), new WebApiRequestHeaders(request.Headers));
+            HttpConfiguration configuration = request.GetConfiguration();
+            bool enableContinueOnErrorHeader = (configuration != null)
+                ? configuration.HasEnabledContinueOnErrorHeader()
+                : false;
+
+            SetContinueOnError(new WebApiRequestHeaders(request.Headers), enableContinueOnErrorHeader);
 
             try
             {

--- a/src/Microsoft.AspNetCore.OData/Adapters/WebApiOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Adapters/WebApiOptions.cs
@@ -25,7 +25,6 @@ namespace Microsoft.AspNet.OData.Adapters
 
             this.NullDynamicPropertyIsEnabled = options.NullDynamicPropertyIsEnabled;
             this.UrlKeyDelimiter = options.UrlKeyDelimiter;
-            this.EnableContinueOnErrorHeader = options.EnableContinueOnErrorHeader;
         }
 
         /// <summary>
@@ -38,11 +37,5 @@ namespace Microsoft.AspNet.OData.Adapters
         /// Gets or Sets a value indicating if value should be emitted for dynamic properties which are null.
         /// </summary>
         public bool NullDynamicPropertyIsEnabled { get; private set; }
-
-        /// <summary>
-        /// Check the continue-on-error header is enable or not.
-        /// </summary>
-        /// <returns>True if continue-on-error header is enable; false otherwise</returns>
-        public bool EnableContinueOnErrorHeader { get; private set; }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Batch/DefaultODataBatchHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/DefaultODataBatchHandler.cs
@@ -42,7 +42,12 @@ namespace Microsoft.AspNet.OData.Batch
 
             IList<ODataBatchRequestItem> subRequests = await ParseBatchRequestsAsync(context);
 
-            SetContinueOnError(new WebApiRequestMessage(context.Request), new WebApiRequestHeaders(context.Request.Headers));
+            ODataOptions options = context.RequestServices.GetRequiredService<ODataOptions>();
+            bool enableContinueOnErrorHeader = (options != null)
+                ? options.EnableContinueOnErrorHeader
+                : false;
+
+            SetContinueOnError(new WebApiRequestHeaders(context.Request.Headers), enableContinueOnErrorHeader);
 
             IList<ODataBatchResponseItem> responses = await ExecuteRequestMessagesAsync(subRequests, nextHandler);
             await CreateResponseMessageAsync(responses, context.Request);

--- a/src/Microsoft.AspNetCore.OData/Batch/UnbufferedODataBatchHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/UnbufferedODataBatchHandler.cs
@@ -47,7 +47,12 @@ namespace Microsoft.AspNet.OData.Batch
             List<ODataBatchResponseItem> responses = new List<ODataBatchResponseItem>();
             Guid batchId = Guid.NewGuid();
 
-            SetContinueOnError(new WebApiRequestMessage(request), new WebApiRequestHeaders(request.Headers));
+            ODataOptions options = context.RequestServices.GetRequiredService<ODataOptions>();
+            bool enableContinueOnErrorHeader = (options != null)
+                ? options.EnableContinueOnErrorHeader
+                : false;
+
+            SetContinueOnError(new WebApiRequestHeaders(request.Headers), enableContinueOnErrorHeader);
 
             while (batchReader.Read())
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1266

### Description

This change fixes a bug in unbuffered batching.

The use of WebApiRequestMessage in the call to SetContinueOnError() cause an ODataProperties
object to be attached to the batch request. As a result, this subsequent
subrequests which copy their properties from the batch request to get the same
instance of ODataProperties(). As a result, the headers from the batch request were
used in some places where the subrequest headers should have been used, such as
service version detection. As a result, the subrequest and batch request would fail.

This change fixes the issue be decoupling SetContinueOnError() from WebApiRequestMessage,
resulting in no ODataProperties() being copied to the subrequests and correct service
detection, resulting in successful requests.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
