### PR TITLE
Fix NavigationLinksGenerationConvention_GeneratesLinksWithoutCast_ForBaseProperties

### DIFF
--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Builder/Conventions/NavigationLinksGenerationConventionTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Builder/Conventions/NavigationLinksGenerationConventionTest.cs
@@ -204,9 +204,15 @@ namespace Microsoft.Test.AspNet.OData.Builder.Conventions
             var serializerContext = ODataSerializerContextFactory.Create(model, vehiclesEdmEntitySet, request);
             var entityContext = new ResourceContext(serializerContext, sportbikeType.AsReference(), new SportBike { Model = 2009, Name = "Ninja" });
 
+            // We might get one of these:
+            // http://localhost/vehicles(Model=2009,Name='Ninja')/Manufacturer
+            // http://localhost/vehicles(Name='Ninja',Model=2009)/Manufacturer
             Uri uri = linkBuilder.BuildNavigationLink(entityContext, motorcycleManufacturerProperty, ODataMetadataLevel.MinimalMetadata);
-
-            Assert.Equal("http://localhost/vehicles(Model=2009,Name='Ninja')/Manufacturer", uri.AbsoluteUri);
+            string aboluteUri = uri.AbsoluteUri;
+            Assert.Contains("http://localhost/vehicles(", aboluteUri);
+            Assert.Contains("Model=2009", aboluteUri);
+            Assert.Contains("Name='Ninja'", aboluteUri);
+            Assert.Contains(")/Manufacturer", aboluteUri);
         }
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

The NavigationLinksGenerationConvention_GeneratesLinksWithoutCast_ForBaseProperties test
will occasionally return the keys in reversed order, causing the test to fail. The order of the
keys is not what is being tested so allow either both to succeed.

Variations:
http://localhost/vehicles(Model=2009,Name='Ninja')/Manufacturer
http://localhost/vehicles(Name='Ninja',Model=2009)/Manufacturer

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
