### PR TITLE
Fix for requesting a lower-case navigation property.

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Adapters/WebApiActionMap.cs
+++ b/src/Microsoft.AspNetCore.OData/Adapters/WebApiActionMap.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.OData.Common;
@@ -40,7 +41,7 @@ namespace Microsoft.AspNet.OData.Adapters
         /// <returns>True if the action name exist; false otherwise.</returns>
         public bool Contains(string name)
         {
-            return this.innerMap.Any(a => a.ActionName == name);
+            return this.innerMap.Any(a => String.Equals(a.ActionName, name, StringComparison.InvariantCultureIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1272 

### Description

In AspNet, the ILookup<> used for the action map would return a case
even if there was a case mismatch.

This change modifies the action map wrapper in AspNetCore to lookup
methods using a case insensitive search.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
