### PR TITLE
Allow results to be derived from SingleResult and SingleResult<>

### DIFF
--- a/src/Microsoft.AspNet.OData/Formatter/ODataMediaTypeFormatter.cs
+++ b/src/Microsoft.AspNet.OData/Formatter/ODataMediaTypeFormatter.cs
@@ -189,10 +189,19 @@ namespace Microsoft.AspNet.OData.Formatter
                 ODataSerializerProvider serializerProvider = Request.GetRequestContainer()
                     .GetRequiredService<ODataSerializerProvider>();
 
+                // See if this type is a SingleResult or is derived from SingleResult.
+                bool isSingleResult = false;
+                if (type.IsGenericType)
+                {
+                    Type genericType = type.GetGenericTypeDefinition();
+                    Type baseType = TypeHelper.GetBaseType(type);
+                    isSingleResult = (genericType == typeof(SingleResult<>) || baseType == typeof(SingleResult));
+                }
+
                 return ODataOutputFormatterHelper.CanWriteType(
                     type,
                     _payloadKinds,
-                    type.IsGenericType && type.GetGenericTypeDefinition() == typeof(SingleResult<>),
+                    isSingleResult,
                     new WebApiRequestMessage(Request),
                     (objectType) => serializerProvider.GetODataPayloadSerializer(objectType, Request));
             }

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
@@ -116,10 +116,19 @@ namespace Microsoft.AspNet.OData.Formatter
             ODataSerializerProvider serializerProvider = request.ODataFeature()
                 .RequestContainer.GetRequiredService<ODataSerializerProvider>();
 
+            // See if this type is a SingleResult or is derived from SingleResult.
+            bool isSingleResult = false;
+            if (type.IsGenericType)
+            {
+                Type genericType = type.GetGenericTypeDefinition();
+                Type baseType = TypeHelper.GetBaseType(type);
+                isSingleResult = (genericType == typeof(SingleResult<>) || baseType == typeof(SingleResult));
+            }
+
             return ODataOutputFormatterHelper.CanWriteType(
                 type,
                 _payloadKinds,
-                type.IsGenericType && type.GetGenericTypeDefinition() == typeof(SingleResult<>),
+                isSingleResult,
                 new WebApiRequestMessage(request),
                 (objectType) => serializerProvider.GetODataPayloadSerializer(objectType, request));
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1273 

### Description

When applying formatting to a SingleResult, the formatters looked strictly
for a class of type SingleResult or SingleResult<>.

This change allows a result to be derived from SingleResult or SingleResult<>.
While not likely useful in production, this scenario is used in E2E and UnitTests.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
