### PR TITLE
Fix Id generation for deserialized nested resources

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Adapters/WebApiContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Adapters/WebApiContext.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNet.OData.Adapters
         /// </summary>
         public string RouteName
         {
-            get { return string.Empty; }
+            get { return this.innerFeature.RouteName; }
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1274

### Description

When putting or posting a entity with a nested navigation item the service returns
a 500 instead for calling the put/post controller method.

This scenario requires that an Id is built for the nested resource, which requires
a route name. The builder uses an abstracted version of the request properties. On
AspNetCore, this abstraction did not return the correct route name, cause link
generation to fail. This fix returns the correct route name.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
