### PR TITLE
Allow the model builder to work with the same type in two different assemblies.

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/ODataConventionModelBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/ODataConventionModelBuilder.cs
@@ -1067,7 +1067,7 @@ namespace Microsoft.AspNet.OData.Builder
         private static Dictionary<Type, List<Type>> BuildDerivedTypesMapping(IWebApiAssembliesResolver assemblyResolver)
         {
             IEnumerable<Type> allTypes = TypeHelper.GetLoadedTypes(assemblyResolver).Where(t => TypeHelper.IsVisible(t) && TypeHelper.IsClass(t) && t != typeof(object));
-            Dictionary<Type, List<Type>> allTypeMapping = allTypes.ToDictionary(k => k, k => new List<Type>());
+            Dictionary<Type, List<Type>> allTypeMapping = allTypes.Distinct().ToDictionary(k => k, k => new List<Type>());
 
             foreach (Type type in allTypes)
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1270 

### Description

When building a model from two assemblies which contain the same type, the model builder throws an exception.

The change fixes the issue by ensuring that a distinct set of types is used
when building an internal type mapping dictionary.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
