### PR TITLE
Allow EnableQuery to ignore EmptyActionResult

### DIFF
--- a/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
@@ -77,42 +77,42 @@ namespace Microsoft.AspNet.OData
                 if (statusCodeResult == null || IsSuccessStatusCode(statusCodeResult.StatusCode))
                 {
                     ObjectResult responseContent = actionExecutedContext.Result as ObjectResult;
-                    if (responseContent == null)
+                    if (responseContent != null)
                     {
-                        throw Error.Argument("actionExecutedContext", SRResources.QueryingRequiresObjectContent,
-                            actionExecutedContext.Result.GetType().FullName);
-                    }
+                        //throw Error.Argument("actionExecutedContext", SRResources.QueryingRequiresObjectContent,
+                        //    actionExecutedContext.Result.GetType().FullName);
 
-                    // Get collection from SingleResult.
-                    IQueryable singleResultCollection = null;
-                    SingleResult singleResult = responseContent.Value as SingleResult;
-                    if (singleResult != null)
-                    {
-                        // This could be a SingleResult, which has the property Queryable.
-                        // But it could be a SingleResult() or SingleResult<T>. Sort by number of parameters
-                        // on the property and get the one with the most parameters.
-                        PropertyInfo propInfo = responseContent.Value.GetType().GetProperties()
-                            .OrderBy(p => p.GetIndexParameters().Count())
-                            .Where(p => p.Name.Equals("Queryable"))
-                            .LastOrDefault();
+                        // Get collection from SingleResult.
+                        IQueryable singleResultCollection = null;
+                        SingleResult singleResult = responseContent.Value as SingleResult;
+                        if (singleResult != null)
+                        {
+                            // This could be a SingleResult, which has the property Queryable.
+                            // But it could be a SingleResult() or SingleResult<T>. Sort by number of parameters
+                            // on the property and get the one with the most parameters.
+                            PropertyInfo propInfo = responseContent.Value.GetType().GetProperties()
+                                .OrderBy(p => p.GetIndexParameters().Count())
+                                .Where(p => p.Name.Equals("Queryable"))
+                                .LastOrDefault();
 
-                        singleResultCollection = propInfo.GetValue(singleResult) as IQueryable;
-                    }
+                            singleResultCollection = propInfo.GetValue(singleResult) as IQueryable;
+                        }
 
-                    // Execution the action.
-                    object queryResult = OnActionExecuted(
-                        responseContent.Value,
-                        singleResultCollection,
-                        new WebApiActionDescriptor(actionDescriptor as ControllerActionDescriptor),
-                        new WebApiRequestMessage(request),
-                        (elementClrType) => GetModel(elementClrType, request, actionDescriptor),
-                        (queryContext) => CreateAndValidateQueryOptions(request, queryContext),
-                        (statusCode) => actionExecutedContext.Result = new StatusCodeResult((int)statusCode),
-                        (statusCode, message, exception) => actionExecutedContext.Result = new BadRequestObjectResult(message));
+                        // Execution the action.
+                        object queryResult = OnActionExecuted(
+                            responseContent.Value,
+                            singleResultCollection,
+                            new WebApiActionDescriptor(actionDescriptor as ControllerActionDescriptor),
+                            new WebApiRequestMessage(request),
+                            (elementClrType) => GetModel(elementClrType, request, actionDescriptor),
+                            (queryContext) => CreateAndValidateQueryOptions(request, queryContext),
+                            (statusCode) => actionExecutedContext.Result = new StatusCodeResult((int)statusCode),
+                            (statusCode, message, exception) => actionExecutedContext.Result = new BadRequestObjectResult(message));
 
-                    if (queryResult != null)
-                    {
-                        responseContent.Value = queryResult;
+                        if (queryResult != null)
+                        {
+                            responseContent.Value = queryResult;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1271 

### Description

When using EnableQuery to filter a collection, the service returns a 500 error when the collection contains no records.

AspNetCore uses a special result type, EmptyActionResult, when the results
are empty. EnableQuery did not handle this case correctly so this fix
changes EnableQuery to handle content results only.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
