### PR TITLE
Enable ASP.NET core Unit test for DateAndTimeOfDayTest

### DIFF
--- a/test/UnitTest/Microsoft.Test.AspNet.OData/DateAndTimeOfDayTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/DateAndTimeOfDayTest.cs
@@ -208,7 +208,6 @@ namespace Microsoft.Test.AspNet.OData
             Assert.Equal(Expect, await response.Content.ReadAsStringAsync());
         }
 
-#if NETCORE
         private static HttpClient GetClient()
         {
             var controllers = new[] { typeof(MetadataController), typeof(DateAndTimeOfDayModelsController) };
@@ -221,16 +220,6 @@ namespace Microsoft.Test.AspNet.OData
             HttpClient client = TestServerFactory.CreateClient(server);
             return client;
         }
-#else
-        private static HttpClient GetClient()
-        {
-            HttpConfiguration config = RoutingConfigurationFactory.CreateWithTypes(
-                new[] { typeof(MetadataController), typeof(DateAndTimeOfDayModelsController) });
-            config.Count().OrderBy().Filter().Expand().MaxTop(null).Select();
-            config.MapODataServiceRoute("odata", "odata", GetEdmModel());
-            return new HttpClient(new HttpServer(config));
-        }
-#endif
 
         private static IEdmModel GetEdmModel()
         {

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/TestControllers.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/TestControllers.cs
@@ -4,6 +4,7 @@
 #if NETCORE
 using System.Threading.Tasks;
 using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Results;
 using Microsoft.AspNetCore.Mvc;
 #else
 using System.Net.Http;
@@ -12,8 +13,8 @@ using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.Results;
 using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Results;
 #endif
-
 
 namespace Microsoft.Test.AspNet.OData
 {
@@ -49,6 +50,19 @@ namespace Microsoft.Test.AspNet.OData
 #else
         public new TestOkObjectResult<T> Ok<T>(T value) { return new TestOkObjectResult<T>(base.Ok<T>(value)); }
 #endif
+
+        [NonAction]
+#if NETCORE
+        public new TestCreatedObjectResult<TEntity> Created<TEntity>(TEntity value)
+        {
+            return new TestCreatedObjectResult<TEntity>(new CreatedODataResult<TEntity>(value));
+        }
+#else
+        public new TestCreatedObjectResult<TEntity> Created<TEntity>(TEntity value)
+        {
+            return new TestCreatedObjectResult<TEntity>(base.Created<TEntity>(value));
+        }
+#endif
     }
 
     /// <summary>
@@ -68,6 +82,17 @@ namespace Microsoft.Test.AspNet.OData
     public class TestOkResult : TestActionResult
     {
         public TestOkResult(OkResult innerResult)
+            : base(innerResult)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Wrapper for CreatedResult
+    /// </summary>
+    public class TestCreatedObjectResult<T> : TestActionResult
+    {
+        public TestCreatedObjectResult(CreatedODataResult<T> innerResult)
             : base(innerResult)
         {
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* Enable the Unit test for Asp.NET Core.

### Description

*only Enable ASP.NET core t Unit test for DateAndTimeOfDayTest for Ramp up.

### Checklist (Uncheck if it is not completed)

- [] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
