### PR TITLE
add the System.Spatial into the classic e2e

### DIFF
--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/packages.config
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/packages.config
@@ -9,6 +9,7 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
   <package id="Microsoft.OData.Client" version="7.4.3" targetFramework="net45" />
   <package id="Microsoft.OData.Core" version="7.4.3" targetFramework="net45" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* add the System.Spatial into the classic e2e, to make E2E classic test pass.

### Description

* add the System.Spatial into the classic e2e

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
