### PR TITLE
Annotate ODataQueryOptions.cs with the non-validating attribute

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/Query/ODataQueryOptions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNet.OData.Query
     /// This defines a composite OData query options that can be used to perform query composition.
     /// Currently this only supports $filter, $orderby, $top, $skip, and $count.
     /// </summary>
+    [NonValidatingParameterBinding]
     public partial class ODataQueryOptions
     {
         /// <summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1308 

### Description

This change adds the non-validating attribute to ODataQueryOptions.cs
to avoid having AspNetCore validate the object, which may access properties
such as SelectClause which throw if the clause is invalid.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
