### PR TITLE
Enable ETagMessageHandler  for ObjectResults.

### DIFF
--- a/src/Microsoft.AspNetCore.OData/ETagMessageHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/ETagMessageHandler.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.OData
 
             // Need a value to operate on.
             ObjectResult result = actionExecutedContext.Result as ObjectResult;
-            if (result != null)
+            if (result == null)
             {
                 return;
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1306
### Description

This change modifies ETagMessageHandler to operate on ObjectResults instead
of ignoring them.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
