### PR TITLE
Fix E2E test failure for AspNetCore.

### DIFF
--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/QueryComposition/TopSkipOrderByTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/QueryComposition/TopSkipOrderByTests.cs
@@ -95,11 +95,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.QueryComposition
             var results = await response.Content.ReadAsObject<Dictionary<string, string>[]>();
             var result = results[0];
 
-            Assert.Equal("abc", result["SkipToken"]);
-            Assert.Equal("abc", result["Expand"]);
-            Assert.Equal("abc", result["Select"]);
-            Assert.Equal("abc", result["Count"]);
-            Assert.Equal("abc", result["DeltaToken"]);
+            Assert.Equal("abc", result["skipToken"]);
+            Assert.Equal("abc", result["expand"]);
+            Assert.Equal("abc", result["select"]);
+            Assert.Equal("abc", result["count"]);
+            Assert.Equal("abc", result["deltaToken"]);
         }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Singleton/SingletonClientTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Singleton/SingletonClientTest.cs
@@ -64,7 +64,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.Singleton
             Assert.Equal("UpdatedName", name);
 
             // $select
-            var category = ClientContext.Umbrella.Select(u => u.Category).Single();
+            var category = await Task.Factory.FromAsync(ClientContext.Umbrella.BeginExecute(null, null), (asyncResult) =>
+            {
+                return ClientContext.Umbrella.EndExecute(asyncResult).Select(u => u.Category).Single();
+            });
+
             Assert.Equal(Microsoft.Test.E2E.AspNet.OData.Singleton.Client.CompanyCategory.Communication, category);
 
             // Add navigation link


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request makes progress on issues #975, #939, #772, #628, #229.

### Description

This change reduces the E2E failure for AspNetCore. The current pass rate is:

AspNet    : 4648 pass, 0 fail - 100% enabled, 100% pass
AspNetCore: 4155 pass, 65 fail - 91% enabled, 98% pass

This change:

1.) Wrap EnableQueryAttribute and IActionFilter in a QueryFilterProvider() in the test fixture.
    This is similar to the configuration used in the product configuration extensions.

2.) Modifies the case of Json properties in TopSkipOrderByTests.cs.

3.) Implements async client query pattern in SingletonClientTest.cs.

4.) Implements CreateODataPath().

### Checklist (Uncheck if it is not completed)

- [] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
