### PR TITLE
Fixed that request.PathBase is a part of the generation of @odata.nex…

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -249,7 +249,7 @@ namespace Microsoft.AspNet.OData.Extensions
                 throw Error.ArgumentNull("request");
             }
 
-            UriBuilder uriBuilder = new UriBuilder(request.Scheme, request.Host.Host, request.Host.Port.HasValue ? request.Host.Port.Value : 80, request.Path.ToUriComponent());
+            UriBuilder uriBuilder = new UriBuilder(request.Scheme, request.Host.Host, request.Host.Port.HasValue ? request.Host.Port.Value : 80, (request.PathBase + request.Path).ToUriComponent());
             IEnumerable<KeyValuePair<string, string>> queryParameters = request.Query.SelectMany(kvp => kvp.Value, (kvp, value) => new KeyValuePair<string, string>(kvp.Key, value));
 
             return GetNextPageHelper.GetNextPageLink(uriBuilder.Uri, queryParameters, pageSize);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1315.

### Description

Prepended request.PathBase to the request.Path to ensure that the complete url path is correct for `@odata.nextLink` returned to caller.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
