### PR TITLE
fix ApplyTest Asp.net core failing test cases

### DIFF
--- a/test/UnitTest/Microsoft.Test.AspNet.OData/ApplyTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/ApplyTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Test.AspNet.OData
                 config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel());
                 config.Count().Filter().OrderBy().Expand().MaxTop(null).Select();
 
-                config.MapNonODataRoute("api", "api/{controller}", new { controller = "NonODataApplyTestCustomers" });
+                config.MapNonODataRoute("api", "api/{controller}", new { controller = "NonODataApplyTestCustomers", action="Get" });
                 config.EnableDependencyInjection();
             });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* to fix ApplyTest Asp.net core failing test cases, now all test cases in ApplyTest.cs are pass both in classic and asp.net core.

### Description

* to fix ApplyTest Asp.net core failing test cases, now all test cases in ApplyTest.cs are pass both in classic and asp.net core.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
