### PR TITLE
Make the failing test cases in InheritanceTests to work in non-odata Asp.NET Core 

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
@@ -65,20 +65,13 @@ namespace Microsoft.AspNet.OData.Formatter
                 throw Error.InvalidOperation(SRResources.ReadFromStreamAsyncMustHaveRequest);
             }
 
-            // Ignore non-OData requests.
-            if (request.ODataFeature().Path == null)
-            {
-                return false;
-            }
-
             Type type = context.ModelType;
             if (type == null)
             {
                 throw Error.ArgumentNull("type");
             }
 
-            ODataDeserializerProvider deserializerProvider = request.ODataFeature()
-                .RequestContainer.GetRequiredService<ODataDeserializerProvider>();
+            ODataDeserializerProvider deserializerProvider = request.GetRequestContainer().GetRequiredService<ODataDeserializerProvider>();
 
             return ODataInputFormatterHelper.CanReadType(
                 type,

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
@@ -77,12 +77,6 @@ namespace Microsoft.AspNet.OData.Formatter
                 throw Error.InvalidOperation(SRResources.ReadFromStreamAsyncMustHaveRequest);
             }
 
-            // Ignore non-OData requests.
-            if (request.ODataFeature().Path == null)
-            {
-                return false;
-            }
-
             // Allow the base class to make its determination, which includes
             // checks for SupportedMediaTypes.
             bool suportedMediaTypeFound = false;
@@ -113,8 +107,7 @@ namespace Microsoft.AspNet.OData.Formatter
                 return false;
             }
 
-            ODataSerializerProvider serializerProvider = request.ODataFeature()
-                .RequestContainer.GetRequiredService<ODataSerializerProvider>();
+            ODataSerializerProvider serializerProvider = request.GetRequestContainer().GetRequiredService<ODataSerializerProvider>();
 
             // See if this type is a SingleResult or is derived from SingleResult.
             bool isSingleResult = false;

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Factories/ServerFactory.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Factories/ServerFactory.cs
@@ -4,7 +4,6 @@
 #if NETCORE
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using Microsoft.AspNet.OData.Extensions;
@@ -18,7 +17,6 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OData.Edm;
 using Microsoft.Test.AspNet.OData.Common;
 #else
 using System;
@@ -44,15 +42,15 @@ namespace Microsoft.Test.AspNet.OData.Factories
         /// <param name="controllers">The controllers to use.</param>
         /// <param name="configureAction">The route configuration action.</param>
         /// <returns>An TestServer.</returns>
-        public static TestServer Create(
-            Type[] controllers,
-            Action<IRouteBuilder> configureAction)
+        public static TestServer Create(Type[] controllers, Action<IRouteBuilder> configureAction, Action<IServiceCollection> configureService = null)
         {
             IWebHostBuilder builder = WebHost.CreateDefaultBuilder();
             builder.ConfigureServices(services =>
             {
                 services.AddMvc();
                 services.AddOData();
+
+                configureService?.Invoke(services);
             });
 
             builder.Configure(app =>


### PR DESCRIPTION
…Asp.NET Core

<!-- markdownlint-disable MD002 MD041 -->

### Issues

* Make the failing test cases in InheritanceTests to work in non-odata Asp.NET Core 

### Description

* Make the failing test cases in InheritanceTests to work in non-odata Asp.NET Core 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
