### PR TITLE
Test fix: remove contained nav link from the expected metadata response.

### DIFF
--- a/test/E2ETest/WebStack.QA.Test.OData/ETags/JsonETagsTests.cs
+++ b/test/E2ETest/WebStack.QA.Test.OData/ETags/JsonETagsTests.cs
@@ -69,7 +69,6 @@ namespace WebStack.QA.Test.OData.ETags
             string expectMetadata =
                 "<EntitySet Name=\"ETagsCustomers\" EntityType=\"WebStack.QA.Test.OData.ETags.ETagsCustomer\">\r\n" +
                 "          <NavigationPropertyBinding Path=\"RelatedCustomer\" Target=\"ETagsCustomers\" />\r\n" +
-                "          <NavigationPropertyBinding Path=\"ContainedCustomer\" Target=\"ContainedCustomer\" />\r\n" +
                 "          <Annotation Term=\"Org.OData.Core.V1.OptimisticConcurrency\">\r\n" +
                 "            <Collection>\r\n" +
                 "              <PropertyPath>Id</PropertyPath>\r\n" +


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes test issue from previous commit from PR #1225.*

### Description

*Contained navigation link should not be included in the EntitySet's metadata document, reverted one edited line in JsonETagsTests.cs on PR #1225.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
