### PR TITLE
Ensure CreatedODataResult returns EntityId 

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Results/CreatedODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/CreatedODataResult.cs
@@ -37,14 +37,17 @@ namespace Microsoft.AspNet.OData.Results
         }
 
         /// <inheritdoc/>
-        public virtual Task ExecuteResultAsync(ActionContext context)
+        public async virtual Task ExecuteResultAsync(ActionContext context)
         {
             HttpRequest request = context.HttpContext.Request;
             HttpResponse response = context.HttpContext.Response;
             IActionResult result = GetInnerActionResult(request);
             response.Headers["Location"] = GenerateLocationHeader(request).ToString();
+
+            // Since AddEntityId relies on the response, make sure to execute the result
+            // before calling AddEntityId() to ensure the response code is set correctly.
+            await result.ExecuteResultAsync(context);
             ResultHelpers.AddEntityId(response, () => GenerateEntityId(request));
-            return result.ExecuteResultAsync(context);
         }
 
         // internal just for unit test.


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1330 

### Description

Fix CreatedODataResult by ensuring the result exists when adding
the EntityId. The response code is not set properly until after
ExecuteResultAsync() is completed.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
