### PR TITLE
Make failing test cases in InheritanceTests to work in ASP.NET Core

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
@@ -113,8 +113,7 @@ namespace Microsoft.AspNet.OData.Formatter
                 return false;
             }
 
-            ODataSerializerProvider serializerProvider = request.ODataFeature()
-                .RequestContainer.GetRequiredService<ODataSerializerProvider>();
+            ODataSerializerProvider serializerProvider = request.GetRequestContainer().GetRequiredService<ODataSerializerProvider>();
 
             // See if this type is a SingleResult or is derived from SingleResult.
             bool isSingleResult = false;
@@ -214,8 +213,7 @@ namespace Microsoft.AspNet.OData.Formatter
                     };
                 };
 
-                ODataSerializerProvider serializerProvider = request.ODataFeature()
-                    .RequestContainer.GetRequiredService<ODataSerializerProvider>();
+                ODataSerializerProvider serializerProvider = request.GetRequestContainer().GetRequiredService<ODataSerializerProvider>();
 
                 ODataOutputFormatterHelper.WriteToStream(
                     type,

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Factories/ServerFactory.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Factories/ServerFactory.cs
@@ -44,15 +44,14 @@ namespace Microsoft.Test.AspNet.OData.Factories
         /// <param name="controllers">The controllers to use.</param>
         /// <param name="configureAction">The route configuration action.</param>
         /// <returns>An TestServer.</returns>
-        public static TestServer Create(
-            Type[] controllers,
-            Action<IRouteBuilder> configureAction)
+        public static TestServer Create(Type[] controllers, Action<IRouteBuilder> configureAction, Action<IServiceCollection> configureService = null)
         {
             IWebHostBuilder builder = WebHost.CreateDefaultBuilder();
             builder.ConfigureServices(services =>
             {
                 services.AddMvc();
                 services.AddOData();
+                configureService?.Invoke(services);
             });
 
             builder.Configure(app =>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* Make the failing test cases in InheritanceTests to work in non-odata Asp.NET Core

### Description

* Make the failing test cases in InheritanceTests to work in non-odata Asp.NET Core

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
