### PR TITLE
Return model errors in ODataError

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/SerializableErrorExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/SerializableErrorExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Text;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNetCore.Mvc;
@@ -28,11 +29,17 @@ namespace Microsoft.AspNet.OData.Extensions
                 throw Error.ArgumentNull("serializableError");
             }
 
+            string message = serializableError.GetPropertyValue<string>(SerializableErrorKeys.MessageKey);
+            string details = ConvertModelStateErrors(serializableError);
+
             return new ODataError
             {
-                Message = serializableError.GetPropertyValue<string>(SerializableErrorKeys.MessageKey),
+                Message = string.IsNullOrEmpty(message) ? details : message,
                 ErrorCode = serializableError.GetPropertyValue<string>(SerializableErrorKeys.ErrorCodeKey),
-                InnerError = ToODataInnerError(serializableError)
+                InnerError = ToODataInnerError(serializableError),
+                Details = serializableError
+                    .Select(kvp => new ODataErrorDetail() { Message = kvp.Key + ":" + kvp.Value, })
+                    .AsCollection(),
             };
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1338.

### Description

Modify CreateODataError to return a message even if a message key is not present in the SerializableError.

Convert the errors in SerializableError into ODataErrorDetail
collection.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
