### PR TITLE
Fix E2E test failure for AspNetCore, part 3.

### DIFF
--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -1600,6 +1600,9 @@
     <Reference Include="Microsoft.AspNetCore.Mvc.Core, Version=2.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\sln\packages\Microsoft.AspNetCore.Mvc.Core.2.0.2\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.DataAnnotations, Version=2.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\Microsoft.AspNetCore.Mvc.DataAnnotations.2.0.2\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.DataAnnotations.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.AspNetCore.Mvc.Formatters.Json, Version=2.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\sln\packages\Microsoft.AspNetCore.Mvc.Formatters.Json.2.0.2\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Formatters.Json.dll</HintPath>
     </Reference>
@@ -1663,6 +1666,12 @@
     </Reference>
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=2.0.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\sln\packages\Microsoft.Extensions.Hosting.Abstractions.2.0.1\lib\netstandard2.0\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Localization, Version=2.0.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\Microsoft.Extensions.Localization.2.0.1\lib\netstandard2.0\Microsoft.Extensions.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Localization.Abstractions, Version=2.0.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\Microsoft.Extensions.Localization.Abstractions.2.0.1\lib\netstandard2.0\Microsoft.Extensions.Localization.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\sln\packages\Microsoft.Extensions.Logging.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/packages.config
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/packages.config
@@ -18,6 +18,7 @@
   <package id="Microsoft.AspNetCore.JsonPatch" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.AspNetCore.Mvc.Abstractions" version="2.0.2" targetFramework="net461" />
   <package id="Microsoft.AspNetCore.Mvc.Core" version="2.0.2" targetFramework="net461" />
+  <package id="Microsoft.AspNetCore.Mvc.DataAnnotations" version="2.0.2" targetFramework="net461" />
   <package id="Microsoft.AspNetCore.Mvc.Formatters.Json" version="2.0.2" targetFramework="net461" />
   <package id="Microsoft.AspNetCore.ResponseCaching.Abstractions" version="2.0.1" targetFramework="net461" />
   <package id="Microsoft.AspNetCore.Routing" version="2.0.1" targetFramework="net461" />
@@ -40,6 +41,8 @@
   <package id="Microsoft.Extensions.FileProviders.Physical" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.FileSystemGlobbing" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.0.1" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Localization" version="2.0.1" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Localization.Abstractions" version="2.0.1" targetFramework="net461" />
   <package id="Microsoft.Extensions.Logging" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.Logging.Debug" version="2.0.0" targetFramework="net461" />

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Common/Execution/WebRouteConfiguration.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Common/Execution/WebRouteConfiguration.cs
@@ -108,7 +108,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.Common.Execution
         /// </summary>
         public int? MaxReceivedMessageSize { get; set; }
 
-
         /// <summary>
         /// An instance of EnableQueryAttribute.
         /// </summary>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Containment/ContainmentTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Containment/ContainmentTests.cs
@@ -2,10 +2,25 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 #if NETCORE
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNet.OData;
 using Microsoft.AspNet.OData.Extensions;
+using Microsoft.OData;
+using Microsoft.OData.Client;
+using Microsoft.OData.Edm;
 using Microsoft.Test.E2E.AspNet.OData.Common;
 using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Microsoft.Test.E2E.AspNet.OData.Common.Extensions;
+using Microsoft.Test.E2E.AspNet.OData.ModelBuilder;
+using Newtonsoft.Json.Linq;
+using Xunit;
 #else
 using System;
 using System.Collections.Generic;
@@ -82,7 +97,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.Containment
             configuration.EnsureInitialized();
         }
 
-#if !NETCORE // TODO #939: Enable this test for AspNetCore
         [Theory]
         [InlineData("convention")]
         [InlineData("explicit")]
@@ -1130,7 +1144,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.Containment
 
             Assert.DoesNotContain(changedAccountsList, (x) => x.AccountID == accountToDelete.AccountID);
 
-            Proxy.Account account = newClient.Accounts.Where(a => a.AccountID == 100).Single();
+            Proxy.Account account = await Task.Factory.FromAsync(newClient.Accounts.BeginExecute(null, null), (asyncResult) =>
+            {
+                return newClient.Accounts.EndExecute(asyncResult).Where(a => a.AccountID == 100).Single();
+            });
+
             await newClient.LoadPropertyAsync(account, "PayinPIs");
             var payinPIList = account.PayinPIs.ToList();
 
@@ -1147,6 +1165,5 @@ namespace Microsoft.Test.E2E.AspNet.OData.Containment
             var response = await this.Client.PostAsync(uriReset, null);
             return response;
         }
-#endif
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/SecurityTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/SecurityTests.cs
@@ -3,11 +3,16 @@
 
 #if NETCORE
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using Microsoft.OData.Client;
 using Microsoft.OData.Edm;
 using Microsoft.Test.E2E.AspNet.OData.Common;
 using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
 using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Newtonsoft.Json;
+using Xunit;
 #else
 using System.Collections.Generic;
 using System.Net.Http;
@@ -19,6 +24,7 @@ using Microsoft.OData.Edm;
 using Microsoft.Test.E2E.AspNet.OData.Common;
 using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
 using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Newtonsoft.Json;
 using Xunit;
 #endif
 
@@ -109,6 +115,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter
             var content = await response.Content.ReadAsStringAsync();
             Assert.Contains("The depth limit for entries in nested expanded navigation links was reached", content);
         }
+#endif
 
         [Theory]
         [InlineData("application/json")]
@@ -132,7 +139,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter
             model.NavigationCollection = navigationList;
 
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, this.BaseAddress + "/Security_ArrayModel");
-            request.Content = new ObjectContent<Security_ArrayModel>(model, new JsonMediaTypeFormatter(), MediaTypeHeaderValue.Parse(mediaType));
+            request.Content = new StringContent(JsonConvert.SerializeObject(model));
+            request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(mediaType);
             var response = await this.Client.SendAsync(request);
 
             response.EnsureSuccessStatusCode();
@@ -146,13 +154,12 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter
             AttackStringBuilder asb = new AttackStringBuilder();
             asb.Append("3.0").Repeat("0", 100000);
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, this.BaseAddress + "/Security_ArrayModel");
-
-            request.Content = new ObjectContent<Security_ArrayModel>(model, new JsonMediaTypeFormatter(), MediaTypeHeaderValue.Parse("application/json"));
+            request.Content = new StringContent(JsonConvert.SerializeObject(model));
+            request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             request.Headers.Add("DataServiceVersion", asb.ToString());
             var response = await this.Client.SendAsync(request);
 
             Assert.False(response.IsSuccessStatusCode);
         }
-#endif
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/Untyped/UntypedSerializationTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/Untyped/UntypedSerializationTests.cs
@@ -119,7 +119,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter.Untyped
             request.Content = new StringContent(untypedCustomer.ToString());
             request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
             HttpResponseMessage response = await Client.SendAsync(request);
-            Console.WriteLine(await response.Content.ReadAsStringAsync());
             Assert.True(response.IsSuccessStatusCode);
 
             HttpRequestMessage getRequest = new HttpRequestMessage(HttpMethod.Get, string.Format("{0}{1}({2})?$expand=Orders", BaseAddress, url, i));

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/LowerCamelCase/LowerCamelCaseTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/LowerCamelCase/LowerCamelCaseTest.cs
@@ -168,12 +168,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.LowerCamelCase
             string requestUri = this.BaseAddress + "/odata/Employees(1)?$expand=manager($levels=-1)&$format=" + format;
 
             HttpResponseMessage response = await this.Client.GetAsync(requestUri);
-#if NETCORE
-            // This throws an error during model validation.
-            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-#else
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-#endif
 
             var result = await response.Content.ReadAsStringAsync();
             Assert.Contains("Levels option must be a non-negative integer or 'max', it is set to '-1' instead.", result);

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ModelBuilder/PropertyTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ModelBuilder/PropertyTests.cs
@@ -14,13 +14,12 @@ using Microsoft.AspNet.OData.Routing.Conventions;
 using Microsoft.OData.Edm;
 using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
 using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Microsoft.Test.E2E.AspNet.OData.Common.Extensions;
 using Xunit;
 #else
 using System;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Formatting;
 using System.Threading.Tasks;
 using Microsoft.AspNet.OData;
 using Microsoft.AspNet.OData.Builder;
@@ -30,6 +29,7 @@ using Microsoft.AspNet.OData.Routing.Conventions;
 using Microsoft.OData.Edm;
 using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
 using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Microsoft.Test.E2E.AspNet.OData.Common.Extensions;
 using Xunit;
 #endif
 
@@ -62,13 +62,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.ModelBuilder
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, BaseAddress + "/odata/PropertyCustomers(1)");
             HttpResponseMessage response = await Client.SendAsync(request);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-#if !NETCORE // TODO #939: Enable this check for AspNetCore
-            PropertyCustomer customer = await response.Content.ReadAsAsync<PropertyCustomer>(Enumerable.Range(0, 1).Select(f => new JsonMediaTypeFormatter()));
+            PropertyCustomer customer = await response.Content.ReadAsObject<PropertyCustomer>();
             Assert.NotNull(customer);
             Assert.Equal(1, customer.Id);
             Assert.Equal("Name 1", customer.Name);
             Assert.Null(customer.Secret);
-#endif
         }
     }
 
@@ -101,13 +99,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.ModelBuilder
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, BaseAddress + "/odata/PropertyCustomers(1)");
             HttpResponseMessage response = await Client.SendAsync(request);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-#if !NETCORE // TODO #939: Enable this check for AspNetCore
-            PropertyCustomer customer = await response.Content.ReadAsAsync<PropertyCustomer>(Enumerable.Range(0, 1).Select(f => new JsonMediaTypeFormatter()));
+            PropertyCustomer customer = await response.Content.ReadAsObject<PropertyCustomer>();
             Assert.NotNull(customer);
             Assert.Equal(1, customer.Id);
             Assert.Equal("Name 1", customer.Name);
             Assert.Null(customer.Secret);
-#endif
         }
     }
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ODataPathHandler/UnicodeRouteTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ODataPathHandler/UnicodeRouteTests.cs
@@ -60,6 +60,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.ODataPathHandler
             return mb.GetEdmModel();
         }
 
+#if NETFX
+        /// <remarks>
+        /// This test fails on AspNetCore due to Kestrel not allowing non-ASCII characters in headers.
+        /// See: https://github.com/aspnet/KestrelHttpServer/issues/1144
+        /// </remarks>
         [Fact]
         public async Task CRUDEntitySetShouldWork()
         {
@@ -99,7 +104,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.ODataPathHandler
             var entities = await GetEntitiesAsync(uri, entitySetName);
             Assert.Empty(entities.ToList());
         }
-
+#endif
         private DataServiceContext CreateClient(Uri address)
         {
             var client = new DataServiceContext(address, ODataProtocolVersion.V4);

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/QueryComposition/ComplextTypeCollectionTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/QueryComposition/ComplextTypeCollectionTests.cs
@@ -69,8 +69,13 @@ namespace Microsoft.Test.E2E.AspNet.OData.QueryComposition
             Assert.Equal("XXX/odata/$metadata#ComplextTypeCollectionTests_Persons(1)/PersonInfos".Replace("XXX", BaseAddress.ToLowerInvariant()),
                 result["@odata.context"]);
 
+#if NETCORE
+            Assert.Equal("XXX/odata/ComplextTypeCollectionTests_Persons(1)/PersonInfos?$skip=2".Replace("XXX", BaseAddress.ToLowerInvariant()),
+                result["@odata.nextLink"]);
+#else
             Assert.Equal("XXX/odata/ComplextTypeCollectionTests_Persons%281%29/PersonInfos?$skip=2".Replace("XXX", BaseAddress.ToLowerInvariant()),
                 result["@odata.nextLink"]);
+#endif
 
             JArray personInfos = result["value"] as JArray;
             Assert.NotNull(personInfos);

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/QueryComposition/IsOf/IsofFunctionTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/QueryComposition/IsOf/IsofFunctionTests.cs
@@ -146,14 +146,34 @@ namespace Microsoft.Test.E2E.AspNet.OData.QueryComposition.IsOf
             var requestUri = string.Format("{0}/EF/BillingCustomers{1}", this.BaseAddress, filter);
 
             // Act
-            HttpResponseMessage response = await Client.GetAsync(requestUri);
+            HttpResponseMessage response = null;
+            HttpRequestException exception = null;
+            try
+            {
+                response = await Client.GetAsync(requestUri);
+            }
+            catch (HttpRequestException e)
+            {
+                exception = e;
+            }
 
-            // Assert
+#if NETCORE
+            // AspNetCore does not encounter the error until after the headers have been sent, at which
+            // point is closes the connection.
             Assert.DoesNotContain("unused", expected);
+            Assert.Null(response);
+            Assert.NotNull(exception);
+            Assert.Contains("Error while copying content to a stream.", exception.Message);
+#else
+            // AspNet catches the exception and converts it to a 500.
+            Assert.DoesNotContain("unused", expected);
+            Assert.Null(exception);
+            Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
             Assert.Contains("Only entity types and complex types are supported in LINQ to Entities queries.",
                 await response.Content.ReadAsStringAsync());
+#endif
         }
 
         [Theory]
@@ -195,7 +215,16 @@ namespace Microsoft.Test.E2E.AspNet.OData.QueryComposition.IsOf
             var requestUri = string.Format("{0}/{1}/BillingCustomers{2}", this.BaseAddress, dataSourceMode, filter);
 
             // Act
-            HttpResponseMessage response = await Client.GetAsync(requestUri);
+            HttpResponseMessage response = null;
+            HttpRequestException exception = null;
+            try
+            {
+                response = await Client.GetAsync(requestUri);
+            }
+            catch (HttpRequestException e)
+            {
+                exception = e;
+            }
 
             // Assert
             if (work)
@@ -212,7 +241,18 @@ namespace Microsoft.Test.E2E.AspNet.OData.QueryComposition.IsOf
             }
             else
             {
+#if NETCORE
+                // AspNetCore does not encounter the error until after the headers have been sent, at which
+                // point is closes the connection.
+                Assert.Null(response);
+                Assert.NotNull(exception);
+                Assert.Contains("Error while copying content to a stream.", exception.Message);
+#else
+                // AspNet catches the exception and converts it to a 500.
+                Assert.Null(exception);
+                Assert.NotNull(response);
                 Assert.True(HttpStatusCode.InternalServerError == response.StatusCode);
+#endif
             }
         }
 
@@ -268,7 +308,16 @@ namespace Microsoft.Test.E2E.AspNet.OData.QueryComposition.IsOf
             var requestUri = string.Format("{0}/{1}/Billings{2}", this.BaseAddress, dataSourceMode, filter);
 
             // Act
-            HttpResponseMessage response = await Client.GetAsync(requestUri);
+            HttpResponseMessage response = null;
+            HttpRequestException exception = null;
+            try
+            {
+                response = await Client.GetAsync(requestUri);
+            }
+            catch (HttpRequestException e)
+            {
+                exception = e;
+            }
 
             // Assert
             if (work)
@@ -285,10 +334,20 @@ namespace Microsoft.Test.E2E.AspNet.OData.QueryComposition.IsOf
             }
             else
             {
+#if NETCORE
+                // AspNetCore does not encounter the error until after the headers have been sent, at which
+                // point is closes the connection.
+                Assert.Null(response);
+                Assert.NotNull(exception);
+                Assert.Contains("Error while copying content to a stream.", exception.Message);
+#else
+                // AspNet catches the exception and converts it to a 500.
+                Assert.Null(exception);
+                Assert.NotNull(response);
                 Assert.True(HttpStatusCode.InternalServerError == response.StatusCode);
-
                 Assert.Contains("DbIsOfExpression requires an expression argument with a polymorphic result type that is " +
                     "compatible with the type argument.", await response.Content.ReadAsStringAsync());
+#endif
             }
         }
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/QueryComposition/JsonSingleResultSelectExpandTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/QueryComposition/JsonSingleResultSelectExpandTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.QueryComposition
             configuration.Routes.Clear();
             configuration.Count().Filter().OrderBy().Expand().MaxTop(null).Select();
 #if NETCORE
-            configuration.MapHttpRoute("api", "api/{controller}/{id?}");
+            configuration.MapHttpRoute("api", "api/{controller}/{id?}", defaults: new { action = "Get" });
 #else
             configuration.MapHttpRoute("api", "api/{controller}/{id}", new { id = System.Web.Http.RouteParameter.Optional });
 #endif

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/QueryComposition/ODataQueryOptionsTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/QueryComposition/ODataQueryOptionsTests.cs
@@ -129,8 +129,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.QueryComposition
         public async Task OptionsOnStringShouldWork()
         {
             var response = await this.Client.GetAsync(this.BaseAddress + "/api/ODataQueryOptions/OptionsOnString?$filter=ID ge 50");
-            var actual = await response.Content.ReadAsObject<string>();
-            Assert.Equal("Test50", actual);
+            var actual = await response.Content.ReadAsStringAsync();
+            Assert.Contains("Test50", actual);
         }
 
         [Fact]

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/QueryComposition/QueryFuzzingTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/QueryComposition/QueryFuzzingTests.cs
@@ -71,8 +71,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.QueryComposition
         [MemberData(nameof(FuzzingQueries))]
         public async Task TestFuzzingQueries(string filter)
         {
-            var handler = typeof(HttpMessageInvoker).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(this.Client) as HttpMessageHandler;
-            this.Client = new HttpClient(handler);
             Stopwatch sw = new Stopwatch();
             sw.Start();
             var response = await this.Client.GetAsync(this.BaseAddress + "/api/Fuzzing?$top=1&" + filter);

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Routing/AddRelatedObjectTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Routing/AddRelatedObjectTests.cs
@@ -3,20 +3,9 @@
 
 #if NETCORE
 using System.Collections.Generic;
-using Microsoft.AspNet.OData;
-using Microsoft.AspNet.OData.Builder;
-using Microsoft.AspNet.OData.Extensions;
-using Microsoft.AspNet.OData.Routing;
-using Microsoft.AspNet.OData.Routing.Conventions;
-using Microsoft.OData.Edm;
-using Microsoft.Test.E2E.AspNet.OData.Common;
-using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
-using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
-#else
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Formatting;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.AspNet.OData;
 using Microsoft.AspNet.OData.Builder;
@@ -27,6 +16,24 @@ using Microsoft.OData.Edm;
 using Microsoft.Test.E2E.AspNet.OData.Common;
 using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
 using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Newtonsoft.Json;
+using Xunit;
+#else
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Routing;
+using Microsoft.AspNet.OData.Routing.Conventions;
+using Microsoft.OData.Edm;
+using Microsoft.Test.E2E.AspNet.OData.Common;
+using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Newtonsoft.Json;
 using Xunit;
 #endif
 
@@ -68,18 +75,17 @@ namespace Microsoft.Test.E2E.AspNet.OData.Routing
             }
         }
 
-#if !NETCORE // TODO #939: Enable this test for AspNetCore
         [Theory]
         [MemberData(nameof(AddRelatedObjectConventionsWorkPropertyData))]
         public async Task AddRelatedObjectConventionsWork(string method, string url)
         {
             object data = new AROOrder() { Id = 5 };
             HttpRequestMessage request = new HttpRequestMessage(new HttpMethod(method), BaseAddress + url);
-            request.Content = new ObjectContent(data.GetType(), data, new JsonMediaTypeFormatter());
+            request.Content = new StringContent(JsonConvert.SerializeObject(data));
+            request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             HttpResponseMessage response = await Client.SendAsync(request);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
-#endif
     }
 
     public class AROCustomer

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Singleton/MonstersIncController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Singleton/MonstersIncController.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Singleton
         #region Update
         [HttpPut]
         [ODataRoute]
-        public ITestActionResult UpdateCompanyByPut(Company newCompany)
+        public ITestActionResult UpdateCompanyByPut([FromBody] Company newCompany)
         {
             MonstersInc = newCompany;
             return StatusCode(HttpStatusCode.NoContent);
@@ -120,7 +120,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Singleton
 
         [HttpPut]
         [ODataRoute("Microsoft.Test.E2E.AspNet.OData.Singleton.SubCompany")]
-        public ITestActionResult UpdateCompanyByPutWithDerivedTypeObject(SubCompany newCompany)
+        public ITestActionResult UpdateCompanyByPutWithDerivedTypeObject([FromBody] SubCompany newCompany)
         {
             MonstersInc = newCompany;
             return StatusCode(HttpStatusCode.NoContent);
@@ -128,7 +128,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Singleton
 
         [HttpPatch]
         [ODataRoute]
-        public ITestActionResult UpdateCompanyByPatch(Delta<Company> item)
+        public ITestActionResult UpdateCompanyByPatch([FromBody] Delta<Company> item)
         {
             item.Patch(MonstersInc);
             return StatusCode(HttpStatusCode.NoContent);

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Singleton/SingletonClientTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Singleton/SingletonClientTest.cs
@@ -86,7 +86,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.Singleton
             Assert.NotNull(umbrella.Partners);
 
             // Add navigation target which is a singleton to entity
-            partner = ClientContext.Partners.Where(p => p.ID == partner2.ID).Single();
+            partner = await Task.Factory.FromAsync(ClientContext.Partners.BeginExecute(null, null), (asyncResult) =>
+            {
+                return ClientContext.Partners.EndExecute(asyncResult).Where(p => p.ID == partner2.ID).Single();
+            });
+
             ClientContext.SetLink(partner, "Company", umbrella);
             await ClientContext.SaveChangesAsync();
 
@@ -106,7 +110,12 @@ namespace Microsoft.Test.E2E.AspNet.OData.Singleton
             ClientContext.DeleteLink(umbrella, "Partners", partner);
             await ClientContext.SaveChangesAsync();
 
-            umbrella = ClientContext.Umbrella.Expand(u => u.Partners).Single();
+            var umbrellaQuery = ClientContext.Umbrella.Expand(u => u.Partners);
+            umbrella = await Task.Factory.FromAsync(umbrellaQuery.BeginExecute(null, null), (asyncResult) =>
+            {
+                return umbrellaQuery.EndExecute(asyncResult).Single();
+            });
+
             Assert.Single(umbrella.Partners);
         }
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Validation/DeltaOfTValidationTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Validation/DeltaOfTValidationTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Validation
             get
             {
                 TheoryDataSet<int, string> data = new TheoryDataSet<int, string>();
-                data.Add((int)HttpStatusCode.BadRequest, "ExtraProperty : The field ExtraProperty must match the regular expression 'Some value'.\r\n");
+                data.Add((int)HttpStatusCode.BadRequest, "The field ExtraProperty must match the regular expression 'Some value'");
                 data.Add((int)HttpStatusCode.OK, "");
                 return data;
             }
@@ -76,10 +76,9 @@ namespace Microsoft.Test.E2E.AspNet.OData.Validation
             Assert.Equal(expectedResponseCode, (int)response.StatusCode);
             if (response.StatusCode == HttpStatusCode.BadRequest)
             {
-                dynamic result = JObject.Parse(await response.Content.ReadAsStringAsync());
-                Assert.Equal(message, result["error"].innererror.message.Value);
+                var result = await response.Content.ReadAsStringAsync();
+                Assert.Contains(message, result);
             }
-
         }
     }
 
@@ -99,9 +98,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.Validation
         {
             PatchCustomer c = new PatchCustomer() { Id = key, ExtraProperty = "Some value" };
             patch.Patch(c);
-#if !NETCORE // TODO #939: Enable this check for AspNetCore
             Validate(c);
-#endif
+
             if (ModelState.IsValid)
             {
                 return Ok(c);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request makes progress on issues #975, #939, #772, #628, #229.

### Description

This change reduces the E2E failure for AspNetCore. The current pass rate is:

AspNet    : 4648 pass, 0 fail - 100% enabled, 100% pass
AspNetCore: 4424 pass, 0 fail - 95% enabled, 100% pass

This change:

1.) Fixes DelayLoadFilterProvider so it works.
2.) Adds coreBuilder.AddDataAnnotations() to enable DataAnnotation validation.
3.) Makes the default action "Get"
4.) Makes Created() and BadRequest() return action results.
5.) Includes route name in GetServiceRootUri()
6.) Fixes LowerCamelCaseTest to expect BadResult() now that ODataQueryOptions skips parameter validation.
7.) Disables CRUDEntitySetShouldWork() since unicode values in headers are not supported in Kestrel.
8.) Modifies IsofFunctionTests to expect an HttpRequestException since an error occurs during formatting
    after headers has been sent and AspNetCore returns HttpRequestException in this case.
9.) Modifies ODataValueProviderTests to inject an Id instead of an object due to AspNetCore parameter
    handle; this also work in AspNet.
10.) Fixes tests in DeltaOfTValidationTests, ComplextTypeCollectionTests, JsonSingleResultExpandTests,
     ODataQueryOptionsTests, QueryFuzzingTests, ValidatorTests, and DeltaOfTValidationTests
11.) Enables tests in ContainmentTests, DeltaTests, SecurityTests, PropertyTestsUsingConventionModelBuilder,
     CustomFilterValidator, AddRelatedObjectTests, SingletonTests

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
