### PR TITLE
fix the failing ASP.NET Core test cases in ODataResourceSerializerTests.cs

### DIFF
--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Factories/RequestFactory.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Factories/RequestFactory.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Linq;
 using System.Net.Http;
-using Microsoft.AspNet.OData;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNetCore.Http;
@@ -65,7 +64,15 @@ namespace Microsoft.Test.AspNet.OData.Factories
             // Add some routing info
             IRouter defaultRoute = routeBuilder.Routes.FirstOrDefault();
             RouteData routeData = new RouteData();
-            routeData.Routers.Add(defaultRoute);
+            if (defaultRoute != null)
+            {
+                routeData.Routers.Add(defaultRoute);
+            }
+            else
+            {
+                var resolver = routeBuilder.ServiceProvider.GetRequiredService<IInlineConstraintResolver>();
+                routeData.Routers.Add(new ODataRoute(routeBuilder.DefaultHandler, useRouteName, null, new ODataPathRouteConstraint(useRouteName), resolver));
+            }
 
             var mockAction = new Mock<ActionDescriptor>();
             ActionDescriptor actionDescriptor = mockAction.Object;

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Serialization/ODataResourceSerializerTests.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Serialization/ODataResourceSerializerTests.cs
@@ -50,14 +50,10 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
         {
             _model = SerializationTestsHelpers.SimpleCustomerOrderModel();
 
-            _model.SetAnnotationValue<ClrTypeAnnotation>(_model.FindType("Default.Customer"), new ClrTypeAnnotation(typeof(Customer)));
-            _model.SetAnnotationValue<ClrTypeAnnotation>(_model.FindType("Default.Order"), new ClrTypeAnnotation(typeof(Order)));
-            _model.SetAnnotationValue(
-                _model.FindType("Default.SpecialCustomer"),
-                new ClrTypeAnnotation(typeof(SpecialCustomer)));
-            _model.SetAnnotationValue(
-                _model.FindType("Default.SpecialOrder"),
-                new ClrTypeAnnotation(typeof(SpecialOrder)));
+            _model.SetAnnotationValue(_model.FindType("Default.Customer"), new ClrTypeAnnotation(typeof(Customer)));
+            _model.SetAnnotationValue(_model.FindType("Default.Order"), new ClrTypeAnnotation(typeof(Order)));
+            _model.SetAnnotationValue(_model.FindType("Default.SpecialCustomer"), new ClrTypeAnnotation(typeof(SpecialCustomer)));
+            _model.SetAnnotationValue(_model.FindType("Default.SpecialOrder"), new ClrTypeAnnotation(typeof(SpecialOrder)));
 
             _customerSet = _model.EntityContainer.FindEntitySet("Customers");
             _customer = new Customer()
@@ -1315,7 +1311,11 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
             ODataAction actualAction = _serializer.CreateODataAction(action, context);
 
             // Assert
+#if NETCORE
+            string expectedMetadata = expectedMetadataPrefix + "/$metadata#" + expectedNamespace + "." + expectedActionName;
+#else
             string expectedMetadata = expectedMetadataPrefix + "#" + expectedNamespace + "." + expectedActionName;
+#endif
             ODataAction expectedAction = new ODataAction
             {
                 Metadata = new Uri(expectedMetadata),
@@ -1374,7 +1374,11 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
 
             // Assert
             Assert.NotNull(actualAction);
+#if NETCORE
+            string expectedMetadata = expectedMetadataPrefix + "/$metadata#" + expectedNamespace + "." + expectedActionName;
+#else
             string expectedMetadata = expectedMetadataPrefix + "#" + expectedNamespace + "." + expectedActionName;
+#endif
             AssertEqual(new Uri(expectedMetadata), actualAction.Metadata);
         }
 

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Serialization/ODataResourceSerializerTests.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Serialization/ODataResourceSerializerTests.cs
@@ -1312,6 +1312,9 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
 
             // Assert
 #if NETCORE
+            // In ASP.NET Core, it's using the global UriHelper to pick up the first Router to generate the Uri.
+            // Owing that there's no router created in this case, a default OData router will be used to generate the Uri.
+            // The default OData router will add '$metadata' after the route prefix.
             string expectedMetadata = expectedMetadataPrefix + "/$metadata#" + expectedNamespace + "." + expectedActionName;
 #else
             string expectedMetadata = expectedMetadataPrefix + "#" + expectedNamespace + "." + expectedActionName;
@@ -1375,6 +1378,9 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
             // Assert
             Assert.NotNull(actualAction);
 #if NETCORE
+            // In ASP.NET Core, it's using the global UriHelper to pick up the first Router to generate the Uri.
+            // Owing that there's no router created in this case, a default OData router will be used to generate the Uri.
+            // The default OData router will add '$metadata' after the route prefix.
             string expectedMetadata = expectedMetadataPrefix + "/$metadata#" + expectedNamespace + "." + expectedActionName;
 #else
             string expectedMetadata = expectedMetadataPrefix + "#" + expectedNamespace + "." + expectedActionName;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* fix the failing ASP.NET Core test cases in ODataResourceSerializerTests.cs
### Description

* fix the failing ASP.NET Core test cases in ODataResourceSerializerTests.cs

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
