### PR TITLE
Change OptionalParameter as Nullable

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
@@ -195,8 +195,8 @@ namespace Microsoft.AspNet.OData.Builder
         {
             foreach (ParameterConfiguration parameter in operationConfiguration.Parameters)
             {
-                bool isParameterOptional = parameter.OptionalParameter;
-                IEdmTypeReference parameterTypeReference = GetEdmTypeReference(edmTypeMap, parameter.TypeConfiguration, nullable: isParameterOptional);
+                bool isParameterNullable = parameter.Nullable;
+                IEdmTypeReference parameterTypeReference = GetEdmTypeReference(edmTypeMap, parameter.TypeConfiguration, nullable: isParameterNullable);
                 IEdmOperationParameter operationParameter = new EdmOperationParameter(operation, parameter.Name, parameterTypeReference);
                 operation.AddParameter(operationParameter);
             }

--- a/src/Microsoft.AspNet.OData.Shared/Builder/ParameterConfiguration.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/ParameterConfiguration.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.OData.Builder
             TypeConfiguration = parameterType;
 
             Type elementType;
-            OptionalParameter = TypeHelper.IsCollection(parameterType.ClrType, out elementType)
+            Nullable = TypeHelper.IsCollection(parameterType.ClrType, out elementType)
                 ? EdmLibHelpers.IsNullable(elementType)
                 : EdmLibHelpers.IsNullable(parameterType.ClrType);
         }
@@ -48,8 +48,8 @@ namespace Microsoft.AspNet.OData.Builder
         public IEdmTypeConfiguration TypeConfiguration { get; protected set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this parameter is optional or not.
+        /// Gets or sets a value indicating whether this parameter is nullable or not.
         /// </summary>
-        public bool OptionalParameter { get; set; }
+        public bool Nullable { get; set; }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BoundOperation/BoundOperationEdmModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BoundOperation/BoundOperationEdmModel.cs
@@ -62,13 +62,13 @@ namespace Microsoft.Test.E2E.AspNet.OData.BoundOperation
 
             // Function with complex and collection of complex parameters
             function = entityTypeConfigurationOfEmployee.Collection.Function("ComplexFunction").ReturnsCollection<Address>();
-            function.Parameter<Address>("address").OptionalParameter = false;
+            function.Parameter<Address>("address").Nullable = false;
             function.Parameter<Address>("location"); // nullable
             function.CollectionParameter<Address>("addresses"); // collection with nullable element
 
             // Function with entity and collection of entity parameters
             function = entityTypeConfigurationOfEmployee.Collection.Function("EntityFunction").Returns<string>();
-            function.EntityParameter<Employee>("person").OptionalParameter = false;
+            function.EntityParameter<Employee>("person").Nullable = false;
             function.EntityParameter<Employee>("guard"); // nullable
             function.CollectionEntityParameter<Employee>("staff"); // collection with nullable element
 
@@ -109,13 +109,13 @@ namespace Microsoft.Test.E2E.AspNet.OData.BoundOperation
 
             // Action with complex and collection of complex parameters
             action = entityTypeConfigurationOfEmployee.Collection.Action("ComplexAction");
-            action.Parameter<Address>("address").OptionalParameter = false;
+            action.Parameter<Address>("address").Nullable = false;
             action.Parameter<Address>("location"); // nullable
             action.CollectionParameter<Address>("addresses"); // collection with nullable element
 
             // Action with entity and collection of entity parameters
             action = entityTypeConfigurationOfEmployee.Collection.Action("EntityAction");
-            action.EntityParameter<Employee>("person").OptionalParameter = false;
+            action.EntityParameter<Employee>("person").Nullable = false;
             action.EntityParameter<Employee>("guard"); // nullable
             action.CollectionEntityParameter<Employee>("staff"); // collection with nullable element
             #endregion

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Builder/ActionConfigurationTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Builder/ActionConfigurationTest.cs
@@ -304,40 +304,40 @@ namespace Microsoft.Test.AspNet.OData.Builder
             ODataModelBuilder builder = new ODataModelBuilder();
             ActionConfiguration action = builder.Action("MyAction");
             action.Parameter<string>("p0");
-            action.Parameter<string>("p1").OptionalParameter = false;
-            action.Parameter<int>("p2").OptionalParameter = true;
+            action.Parameter<string>("p1").Nullable = false;
+            action.Parameter<int>("p2").Nullable = true;
             action.Parameter<int>("p3");
             action.Parameter<Address>("p4");
-            action.Parameter<Address>("p5").OptionalParameter = false;
+            action.Parameter<Address>("p5").Nullable = false;
 
             action.CollectionParameter<ZipCode>("p6");
-            action.CollectionParameter<ZipCode>("p7").OptionalParameter = false;
+            action.CollectionParameter<ZipCode>("p7").Nullable = false;
 
             action.EntityParameter<Customer>("p8");
-            action.EntityParameter<Customer>("p9").OptionalParameter = false;
+            action.EntityParameter<Customer>("p9").Nullable = false;
 
             action.CollectionEntityParameter<Customer>("p10");
-            action.CollectionEntityParameter<Customer>("p11").OptionalParameter = false;
+            action.CollectionEntityParameter<Customer>("p11").Nullable = false;
             Dictionary<string, ParameterConfiguration> parameters = action.Parameters.ToDictionary(e => e.Name, e => e);
 
             // Assert
-            Assert.True(parameters["p0"].OptionalParameter);
-            Assert.False(parameters["p1"].OptionalParameter);
+            Assert.True(parameters["p0"].Nullable);
+            Assert.False(parameters["p1"].Nullable);
 
-            Assert.True(parameters["p2"].OptionalParameter);
-            Assert.False(parameters["p3"].OptionalParameter);
+            Assert.True(parameters["p2"].Nullable);
+            Assert.False(parameters["p3"].Nullable);
 
-            Assert.True(parameters["p4"].OptionalParameter);
-            Assert.False(parameters["p5"].OptionalParameter);
+            Assert.True(parameters["p4"].Nullable);
+            Assert.False(parameters["p5"].Nullable);
 
-            Assert.True(parameters["p6"].OptionalParameter);
-            Assert.False(parameters["p7"].OptionalParameter);
+            Assert.True(parameters["p6"].Nullable);
+            Assert.False(parameters["p7"].Nullable);
 
-            Assert.True(parameters["p8"].OptionalParameter);
-            Assert.False(parameters["p9"].OptionalParameter);
+            Assert.True(parameters["p8"].Nullable);
+            Assert.False(parameters["p9"].Nullable);
 
-            Assert.True(parameters["p10"].OptionalParameter);
-            Assert.False(parameters["p11"].OptionalParameter);
+            Assert.True(parameters["p10"].Nullable);
+            Assert.False(parameters["p11"].Nullable);
         }
 
         [Fact]
@@ -627,19 +627,19 @@ namespace Microsoft.Test.AspNet.OData.Builder
             EntityTypeConfiguration<Movie> movie = builder.EntitySet<Movie>("Movies").EntityType;
             var actionBuilder = movie.Action("Watch");
 
-            actionBuilder.Parameter<string>("string").OptionalParameter = false;
+            actionBuilder.Parameter<string>("string").Nullable = false;
             actionBuilder.Parameter<string>("nullaleString");
 
-            actionBuilder.Parameter<Address>("address").OptionalParameter = false;
+            actionBuilder.Parameter<Address>("address").Nullable = false;
             actionBuilder.Parameter<Address>("nullableAddress");
 
-            actionBuilder.EntityParameter<Customer>("customer").OptionalParameter = false;
+            actionBuilder.EntityParameter<Customer>("customer").Nullable = false;
             actionBuilder.EntityParameter<Customer>("nullableCustomer");
 
-            actionBuilder.CollectionParameter<Address>("addresses").OptionalParameter = false;
+            actionBuilder.CollectionParameter<Address>("addresses").Nullable = false;
             actionBuilder.CollectionParameter<Address>("nullableAddresses");
 
-            actionBuilder.CollectionEntityParameter<Customer>("customers").OptionalParameter = false;
+            actionBuilder.CollectionEntityParameter<Customer>("customers").Nullable = false;
             actionBuilder.CollectionEntityParameter<Customer>("nullableCustomers");
 
             // Act

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Builder/FunctionConfigurationTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Builder/FunctionConfigurationTest.cs
@@ -338,29 +338,29 @@ namespace Microsoft.Test.AspNet.OData.Builder
             ODataModelBuilder builder = new ODataModelBuilder();
             FunctionConfiguration function = builder.Function("MyFunction");
             function.Parameter<string>("p0");
-            function.Parameter<string>("p1").OptionalParameter = false;
-            function.Parameter<int>("p2").OptionalParameter = true;
+            function.Parameter<string>("p1").Nullable = false;
+            function.Parameter<int>("p2").Nullable = true;
             function.Parameter<int>("p3");
             function.Parameter<Address>("p4");
-            function.Parameter<Address>("p5").OptionalParameter = false;
+            function.Parameter<Address>("p5").Nullable = false;
 
             function.CollectionParameter<ZipCode>("p6");
-            function.CollectionParameter<ZipCode>("p7").OptionalParameter = false;
+            function.CollectionParameter<ZipCode>("p7").Nullable = false;
 
             Dictionary<string, ParameterConfiguration> parameters = function.Parameters.ToDictionary(e => e.Name, e => e);
 
             // Assert
-            Assert.True(parameters["p0"].OptionalParameter);
-            Assert.False(parameters["p1"].OptionalParameter);
+            Assert.True(parameters["p0"].Nullable);
+            Assert.False(parameters["p1"].Nullable);
 
-            Assert.True(parameters["p2"].OptionalParameter);
-            Assert.False(parameters["p3"].OptionalParameter);
+            Assert.True(parameters["p2"].Nullable);
+            Assert.False(parameters["p3"].Nullable);
 
-            Assert.True(parameters["p4"].OptionalParameter);
-            Assert.False(parameters["p5"].OptionalParameter);
+            Assert.True(parameters["p4"].Nullable);
+            Assert.False(parameters["p5"].Nullable);
 
-            Assert.True(parameters["p6"].OptionalParameter);
-            Assert.False(parameters["p7"].OptionalParameter);
+            Assert.True(parameters["p6"].Nullable);
+            Assert.False(parameters["p7"].Nullable);
         }
 
         [Fact]
@@ -697,13 +697,13 @@ namespace Microsoft.Test.AspNet.OData.Builder
             EntityTypeConfiguration<Movie> movie = builder.EntitySet<Movie>("Movies").EntityType;
             var functionBuilder = movie.Function("Watch");
 
-            functionBuilder.Parameter<string>("string").OptionalParameter = false;
+            functionBuilder.Parameter<string>("string").Nullable = false;
             functionBuilder.Parameter<string>("nullaleString");
 
-            functionBuilder.Parameter<Address>("address").OptionalParameter = false;
+            functionBuilder.Parameter<Address>("address").Nullable = false;
             functionBuilder.Parameter<Address>("nullableAddress");
 
-            functionBuilder.CollectionParameter<Address>("addresses").OptionalParameter = false;
+            functionBuilder.CollectionParameter<Address>("addresses").Nullable = false;
             functionBuilder.CollectionParameter<Address>("nullableAddresses");
             functionBuilder.Returns<int>();
 

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Builder/ParameterConfigurationTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Builder/ParameterConfigurationTest.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Test.AspNet.OData.Builder
                 edmTypeConfiguration);
 
             // Assert
-            Assert.Equal(isNullable, parameter.OptionalParameter);
+            Assert.Equal(isNullable, parameter.Nullable);
         }
 
         [Theory]
@@ -89,7 +89,7 @@ namespace Microsoft.Test.AspNet.OData.Builder
             NonbindingParameterConfiguration parameter = new NonbindingParameterConfiguration("name", collectionType);
 
             // Assert
-            Assert.Equal(isNullable, parameter.OptionalParameter);
+            Assert.Equal(isNullable, parameter.Nullable);
         }
     }
 }

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Deserialization/ODataActionPayloadDeserializerTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Deserialization/ODataActionPayloadDeserializerTest.cs
@@ -765,7 +765,7 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Deserialization
 
             ActionConfiguration unboundEntity = builder.Action("UnboundEntity");
             unboundEntity.Parameter<int>("Id");
-            unboundEntity.EntityParameter<Customer>("Customer").OptionalParameter = false;
+            unboundEntity.EntityParameter<Customer>("Customer").Nullable = false;
             unboundEntity.EntityParameter<Customer>("NullableCustomer");
 
             ActionConfiguration unboundEntityCollection = builder.Action("UnboundEntityCollection");

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/MetadataControllerTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/MetadataControllerTest.cs
@@ -575,7 +575,7 @@ namespace Microsoft.Test.AspNet.OData
 
             action = person.Action("NonNullableAction").Returns<FormatterAddress>();
             action.OptionalReturn = false;
-            action.Parameter<string>("param").OptionalParameter = false;
+            action.Parameter<string>("param").Nullable = false;
             IEdmModel model = builder.GetEdmModel();
 
             var config = RoutingConfigurationFactory.CreateWithTypes(new[] { typeof(MetadataController) });
@@ -622,7 +622,7 @@ namespace Microsoft.Test.AspNet.OData
 
             function = person.Function("NonNullableFunction").Returns<FormatterAddress>();
             function.OptionalReturn = false;
-            function.Parameter<string>("param").OptionalParameter = false;
+            function.Parameter<string>("param").Nullable = false;
             IEdmModel model = builder.GetEdmModel();
 
             var config = RoutingConfigurationFactory.CreateWithTypes(new[] { typeof(MetadataController) });

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -1002,7 +1002,7 @@ public abstract class Microsoft.AspNet.OData.Builder.ParameterConfiguration {
 	protected ParameterConfiguration (string name, IEdmTypeConfiguration parameterType)
 
 	string Name  { public get; protected set; }
-	bool OptionalParameter  { public get; public set; }
+	bool Nullable  { public get; public set; }
 	IEdmTypeConfiguration TypeConfiguration  { public get; protected set; }
 }
 

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -1047,7 +1047,7 @@ public abstract class Microsoft.AspNet.OData.Builder.ParameterConfiguration {
 	protected ParameterConfiguration (string name, IEdmTypeConfiguration parameterType)
 
 	string Name  { public get; protected set; }
-	bool OptionalParameter  { public get; public set; }
+	bool Nullable  { public get; public set; }
 	IEdmTypeConfiguration TypeConfiguration  { public get; protected set; }
 }
 
@@ -2765,6 +2765,9 @@ public sealed class Microsoft.AspNet.OData.Query.UnsortableAttribute : System.At
 public class Microsoft.AspNet.OData.Results.CreatedODataResult`1 : IActionResult {
 	public CreatedODataResult`1 (T entity)
 
+	[
+	AsyncStateMachineAttribute(),
+	]
 	public virtual System.Threading.Tasks.Task ExecuteResultAsync (Microsoft.AspNetCore.Mvc.ActionContext context)
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

* Parameters currently have a property named "Optional" that returns whether or not the property is nullable.  Nullable properties may be optional for an Action, where the value is passed in the payload,
but are required in functions where the parameter must be passed in the URL in order to resolve the correct overload.  True optional parameters were added in OData 4.01, and implemented in OData Library, but having an existing property named "Optional" on the parameter that really means "Nullable" is misleading, and makes it hard to expose true optional parameters through WebAPI OData.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
