### PR TITLE
Fix failung UTs bringing pass rate to 100%.

### DIFF
--- a/test/UnitTest/Microsoft.Test.AspNet.Common/AspNet/FormatterTestHelper.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.Common/AspNet/FormatterTestHelper.cs
@@ -2,65 +2,24 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Formatter;
-using Microsoft.AspNet.OData.Routing;
 using Microsoft.OData;
-using Microsoft.OData.Edm;
-using ODataPath = Microsoft.AspNet.OData.Routing.ODataPath;
 
 namespace Microsoft.Test.AspNet.OData
 {
     internal static class FormatterTestHelper
     {
-        internal static ODataMediaTypeFormatter GetFormatter(ODataPayloadKind[] payload, HttpRequestMessage request,
-            IEdmModel model = null,
-            string routeName = null,
-            ODataPath path = null)
+        internal static ODataMediaTypeFormatter GetFormatter(ODataPayloadKind[] payload, HttpRequestMessage request)
         {
             ODataMediaTypeFormatter formatter;
             formatter = new ODataMediaTypeFormatter(payload);
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataMinimalMetadata));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationXml));
 
-            if (model != null && routeName != null)
-            {
-                if (!request.GetConfiguration().Routes.Any(r =>
-                    {
-                        ODataRoute route = r as ODataRoute;
-                        return route == null ? false : route.PathRouteConstraint.RouteName == routeName;
-                    }))
-                {
-                    request.GetConfiguration().MapODataServiceRoute(routeName, null, model);
-                    request.EnableODataDependencyInjectionSupport(routeName);
-                }
-            }
-            else if (routeName != null)
-            {
-                request.EnableODataDependencyInjectionSupport(routeName);
-            }
-            else if (model != null)
-            {
-                request.GetConfiguration().EnableODataDependencyInjectionSupport(HttpRouteCollectionExtensions.RouteName, model);
-                request.EnableODataDependencyInjectionSupport(model);
-                request.GetConfiguration().Routes.MapFakeODataRoute();
-            }
-            else
-            {
-                request.GetConfiguration().EnableODataDependencyInjectionSupport(HttpRouteCollectionExtensions.RouteName);
-                request.EnableODataDependencyInjectionSupport();
-                request.GetConfiguration().Routes.MapFakeODataRoute();
-            }
-
-            if (path != null)
-            {
-                request.ODataProperties().Path = path;
-            }
-
+            request.GetConfiguration().Routes.MapFakeODataRoute();
             formatter.Request = request;
             return formatter;
         }

--- a/test/UnitTest/Microsoft.Test.AspNet.Common/AspNet/RequestFactory.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.Common/AspNet/RequestFactory.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Test.AspNet.OData
         /// Initializes a new instance of the routing configuration class.
         /// </summary>
         /// <returns>A new instance of the routing configuration class.</returns>
-        public static HttpRequestMessage Create(HttpMethod method, string uri, HttpConfiguration config, string routeName = null)
+        public static HttpRequestMessage Create(HttpMethod method, string uri, HttpConfiguration config, string routeName = null, ODataPath path = null)
         {
             var request = new HttpRequestMessage(method, uri);
             request.SetConfiguration(config);
@@ -62,6 +62,11 @@ namespace Microsoft.Test.AspNet.OData
             if (!string.IsNullOrEmpty(routeName))
             {
                 request.EnableODataDependencyInjectionSupport(routeName);
+            }
+
+            if (path != null)
+            {
+                request.ODataProperties().Path = path;
             }
 
             return request;

--- a/test/UnitTest/Microsoft.Test.AspNet.Common/AspNetCore/FormatterTestHelper.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.Common/AspNetCore/FormatterTestHelper.cs
@@ -18,10 +18,7 @@ namespace Microsoft.Test.AspNet.OData
 {
     internal static class FormatterTestHelper
     {
-        internal static ODataOutputFormatter GetFormatter(ODataPayloadKind[] payload, HttpRequest request,
-            IEdmModel model = null,
-            string routeName = null,
-            ODataPath path = null)
+        internal static ODataOutputFormatter GetFormatter(ODataPayloadKind[] payload, HttpRequest request)
         {
             // request is not needed on AspNetCore.
             ODataOutputFormatter formatter;

--- a/test/UnitTest/Microsoft.Test.AspNet.Common/AspNetCore/RequestFactory.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.Common/AspNetCore/RequestFactory.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Test.AspNet.OData
         /// Initializes a new instance of the routing configuration class.
         /// </summary>
         /// <returns>A new instance of the routing configuration class.</returns>
-        public static HttpRequest Create(HttpMethod method, string uri, IRouteBuilder routeBuilder = null, string routeName = null)
+        public static HttpRequest Create(HttpMethod method, string uri, IRouteBuilder routeBuilder = null, string routeName = null, ODataPath path = null)
         {
             HttpRequest request = Create(routeBuilder, routeName);
             request.Method = method.ToString();
@@ -100,6 +100,11 @@ namespace Microsoft.Test.AspNet.OData
                 new HostString(requestUri.Host, requestUri.Port);
             request.QueryString = new QueryString(requestUri.Query);
             request.Path = new PathString(requestUri.AbsolutePath);
+
+            if (path != null)
+            {
+                request.ODataFeature().Path = path;
+            }
 
             return request;
         }

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/CollectionsTests.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/CollectionsTests.cs
@@ -159,8 +159,7 @@ namespace Microsoft.Test.AspNet.OData.Formatter
             catch (Exception ex)
             {
                 // AspNetCore will throw, validate the exception.
-                Assert.Equal(typeof(AggregateException), ex.GetType());
-                Assert.Equal(typeof(InvalidOperationException), ex.InnerException.GetType());
+                Assert.Equal(typeof(InvalidOperationException), ex.GetType());
             }
         }
     }

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/ODataFormatterTests.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/ODataFormatterTests.cs
@@ -1002,6 +1002,7 @@ namespace Microsoft.Test.AspNet.OData.Formatter
 
             var server = TestServerFactory.CreateWithFormatters(controllers, null, (config) =>
             {
+                config.Count().OrderBy().Filter().Expand().MaxTop(null).Select();
                 config.MapODataServiceRoute("IgnoredRouteName", null, model != null ? model : ODataTestUtil.GetEdmModel());
 
                 if (modifyMediaTypes != null)

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Serialization/CollectionTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Serialization/CollectionTest.cs
@@ -37,10 +37,12 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
         public async Task ArrayOfIntsSerializesAsOData()
         {
             // Arrange
-            var config = RoutingConfigurationFactory.Create();
-            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config);
+            var routeName = "OData";
+            var model = GetSampleModel();
+            var config = RoutingConfigurationFactory.CreateWithRootContainer(routeName, b => b.AddService(ServiceLifetime.Singleton, s => model));
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config, routeName);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.Collection };
-            var formatter = FormatterTestHelper.GetFormatter(payload, request, GetSampleModel());
+            var formatter = FormatterTestHelper.GetFormatter(payload, request);
             var content = FormatterTestHelper.GetContent(new int[] { 10, 20, 30, 40, 50 }, formatter,
                 ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
 
@@ -52,10 +54,12 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
         public async Task ArrayOfBooleansSerializesAsOData()
         {
             // Arrange
-            var config = RoutingConfigurationFactory.Create();
-            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config);
+            var routeName = "OData";
+            var model = GetSampleModel();
+            var config = RoutingConfigurationFactory.CreateWithRootContainer(routeName, b => b.AddService(ServiceLifetime.Singleton, s => model));
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config, routeName);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.Collection };
-            var formatter = FormatterTestHelper.GetFormatter(payload, request, GetSampleModel());
+            var formatter = FormatterTestHelper.GetFormatter(payload, request);
             var content = FormatterTestHelper.GetContent(new bool[] { true, false, true, false }, formatter,
                 ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
 
@@ -73,10 +77,12 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
             listOfStrings.Add("Tom");
             listOfStrings.Add("Chandler");
 
-            var config = RoutingConfigurationFactory.Create();
-            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config);
+            var routeName = "OData";
+            var model = GetSampleModel();
+            var config = RoutingConfigurationFactory.CreateWithRootContainer(routeName, b => b.AddService(ServiceLifetime.Singleton, s => model));
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config, routeName);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.Collection };
-            var formatter = FormatterTestHelper.GetFormatter(payload, request, GetSampleModel());
+            var formatter = FormatterTestHelper.GetFormatter(payload, request);
             var content = FormatterTestHelper.GetContent(listOfStrings, formatter,
                 ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
 
@@ -100,10 +106,12 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
             listOfDates.Add(new Date(2015, 2, 26));
             listOfDates.Add(Date.MaxValue);
 
-            var config = RoutingConfigurationFactory.Create();
-            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config);
+            var routeName = "OData";
+            var model = GetSampleModel();
+            var config = RoutingConfigurationFactory.CreateWithRootContainer(routeName, b => b.AddService(ServiceLifetime.Singleton, s => model));
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config, routeName);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.Collection };
-            var formatter = FormatterTestHelper.GetFormatter(payload, request, GetSampleModel());
+            var formatter = FormatterTestHelper.GetFormatter(payload, request);
             var content = FormatterTestHelper.GetContent(listOfDates, formatter,
                 ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
 
@@ -128,10 +136,12 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
             listOfDates.Add(null);
             listOfDates.Add(Date.MaxValue);
 
-            var config = RoutingConfigurationFactory.Create();
-            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config);
+            var routeName = "OData";
+            var model = GetSampleModel();
+            var config = RoutingConfigurationFactory.CreateWithRootContainer(routeName, b => b.AddService(ServiceLifetime.Singleton, s => model));
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config, routeName);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.Collection };
-            var formatter = FormatterTestHelper.GetFormatter(payload, request, GetSampleModel());
+            var formatter = FormatterTestHelper.GetFormatter(payload, request);
             var content = FormatterTestHelper.GetContent(listOfDates, formatter,
                 ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
 
@@ -155,10 +165,12 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
             listOfDates.Add(new TimeOfDay(1, 2, 3, 4));
             listOfDates.Add(TimeOfDay.MaxValue);
 
-            var config = RoutingConfigurationFactory.Create();
-            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config);
+            var routeName = "OData";
+            var model = GetSampleModel();
+            var config = RoutingConfigurationFactory.CreateWithRootContainer(routeName, b => b.AddService(ServiceLifetime.Singleton, s => model));
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config, routeName);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.Collection };
-            var formatter = FormatterTestHelper.GetFormatter(payload, request, GetSampleModel());
+            var formatter = FormatterTestHelper.GetFormatter(payload, request);
             var content = FormatterTestHelper.GetContent(listOfDates, formatter,
                 ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
 
@@ -183,10 +195,12 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
             listOfDates.Add(null);
             listOfDates.Add(TimeOfDay.MaxValue);
 
-            var config = RoutingConfigurationFactory.Create();
-            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config);
+            var routeName = "OData";
+            var model = GetSampleModel();
+            var config = RoutingConfigurationFactory.CreateWithRootContainer(routeName, b => b.AddService(ServiceLifetime.Singleton, s => model));
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config, routeName);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.Collection };
-            var formatter = FormatterTestHelper.GetFormatter(payload,request,  GetSampleModel());
+            var formatter = FormatterTestHelper.GetFormatter(payload,request);
             var content = FormatterTestHelper.GetContent(listOfDates, formatter,
                 ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
 
@@ -202,10 +216,12 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
             DateTime dt2 = new DateTime(2014, 10, 27, 12, 25, 26, DateTimeKind.Local);
             List<DateTime> listOfDateTime = new List<DateTime> { dt1, dt2 };
 
-            var config = RoutingConfigurationFactory.Create();
-            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config);
+            var routeName = "OData";
+            var model = GetSampleModel();
+            var config = RoutingConfigurationFactory.CreateWithRootContainer(routeName, b => b.AddService(ServiceLifetime.Singleton, s => model));
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config, routeName);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.Collection };
-            var formatter = FormatterTestHelper.GetFormatter(payload, request, GetSampleModel());
+            var formatter = FormatterTestHelper.GetFormatter(payload, request);
             var content = FormatterTestHelper.GetContent(listOfDateTime, formatter,
                 ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
 
@@ -228,10 +244,12 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
             DateTime dt2 = new DateTime(2014, 10, 27, 12, 25, 26, DateTimeKind.Local);
             List<DateTime?> listOfDateTime = new List<DateTime?> { dt1, null, dt2 };
 
-            var config = RoutingConfigurationFactory.Create();
-            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config);
+            var routeName = "OData";
+            var model = GetSampleModel();
+            var config = RoutingConfigurationFactory.CreateWithRootContainer(routeName, b => b.AddService(ServiceLifetime.Singleton, s => model));
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config, routeName);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.Collection };
-            var formatter = FormatterTestHelper.GetFormatter(payload, request, GetSampleModel());
+            var formatter = FormatterTestHelper.GetFormatter(payload, request);
             var content = FormatterTestHelper.GetContent(listOfDateTime, formatter,
                 ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
 
@@ -264,12 +282,13 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
             listOfDateTime.Add(new DateTime(1978, 11, 15, 01, 12, 13, DateTimeKind.Utc));
             listOfDateTime.Add(new DateTime(2014, 10, 27, 12, 25, 26, DateTimeKind.Utc));
 
-            var config = RoutingConfigurationFactory.Create();
+            var routeName = "OData";
+            var model = GetSampleModel();
+            var config = RoutingConfigurationFactory.CreateWithRootContainer(routeName, b => b.AddService(ServiceLifetime.Singleton, s => model));
             config.SetTimeZoneInfo(TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
-
-            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config);
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config, routeName);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.Collection };
-            var formatter = FormatterTestHelper.GetFormatter(payload, request, GetSampleModel());
+            var formatter = FormatterTestHelper.GetFormatter(payload, request);
 
             var content = FormatterTestHelper.GetContent(listOfDateTime, formatter,
                 ODataMediaTypes.ApplicationJsonODataMinimalMetadata);

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Serialization/ComplexTypeTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Serialization/ComplexTypeTest.cs
@@ -19,12 +19,13 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
         public async Task ComplexTypeSerializesAsOData()
         {
             // Arrange
+            string routeName = "OData";
             IEdmModel model = GetSampleModel();
             var config = RoutingConfigurationFactory.Create();
-            config = RoutingConfigurationFactory.CreateWithRootContainer("OData", b => b.AddService(ServiceLifetime.Singleton, s => model));
-            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config);
+            config = RoutingConfigurationFactory.CreateWithRootContainer(routeName, b => b.AddService(ServiceLifetime.Singleton, s => model));
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config, routeName);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.Resource };
-            var formatter = FormatterTestHelper.GetFormatter(payload, request, model);
+            var formatter = FormatterTestHelper.GetFormatter(payload, request);
             var content = FormatterTestHelper.GetContent(new Person(0, new ReferenceDepthContext(7)), formatter,
                 ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
 

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Serialization/EntityTypeTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Serialization/EntityTypeTest.cs
@@ -23,14 +23,14 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
         public async Task EntityTypeSerializesAsODataEntry()
         {
             // Arrange
-            const string routeName = "Route";
+            const string routeName = "OData";
             IEdmEntitySet entitySet = _model.EntityContainer.FindEntitySet("employees");
             ODataPath path = new ODataPath(new EntitySetSegment(entitySet));
 
-            var config = RoutingConfigurationFactory.CreateWithRootContainer(routeName);
-            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config);
+            var config = RoutingConfigurationFactory.CreateWithRootContainer(routeName, b => b.AddService(ServiceLifetime.Singleton, s => _model));
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/property", config, routeName, path);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.Resource };
-            var formatter = FormatterTestHelper.GetFormatter(payload, request, _model, routeName, path);
+            var formatter = FormatterTestHelper.GetFormatter(payload, request);
             Employee employee = (Employee)TypeInitializer.GetInstance(SupportedTypes.Employee);
             var content = FormatterTestHelper.GetContent(employee, formatter,
                 ODataMediaTypes.ApplicationJsonODataMinimalMetadata);

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Serialization/ResourceSetTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Formatter/Serialization/ResourceSetTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Test.AspNet.OData.Formatter.Serialization
 
             var request = RequestFactory.CreateFromModel(_model, "http://localhost/property", "Route", path);
             var payload = new ODataPayloadKind[] { ODataPayloadKind.ResourceSet };
-            var formatter = FormatterTestHelper.GetFormatter(payload, request, _model, "Route", path);
+            var formatter = FormatterTestHelper.GetFormatter(payload, request);
 
             IEnumerable<Employee> collectionOfPerson = new Collection<Employee>()
             {

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/ODataNullValueMessageHandlerTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/ODataNullValueMessageHandlerTest.cs
@@ -79,7 +79,12 @@ namespace Microsoft.Test.AspNet.OData
         }
 #endif
 
+#if !NETCORE // TODO #939: Enable these test on AspNetCore.
         [Fact]
+        /// <remarks>
+        /// This test specifically test the AspNet behavior or ODataNullValueMessageHandler and whether it creates
+        /// a new response or returns the original response. AspNetCore always returns the original response.
+        /// </remarks>
         public async Task SendAsync_ReturnsNullIfResponseIsNull()
         {
             // Arrange
@@ -95,6 +100,10 @@ namespace Microsoft.Test.AspNet.OData
         }
 
         [Fact]
+        /// <remarks>
+        /// This test specifically test the AspNet behavior or ODataNullValueMessageHandler and whether it creates
+        /// a new response or returns the original response. AspNetCore always returns the original response.
+        /// </remarks>
         public async Task SendAsync_ReturnsOriginalResponseIfContentIsNull()
         {
             // Arrange
@@ -112,6 +121,10 @@ namespace Microsoft.Test.AspNet.OData
         }
 
         [Fact]
+        /// <remarks>
+        /// This test specifically test the AspNet behavior or ODataNullValueMessageHandler and whether it creates
+        /// a new response or returns the original response. AspNetCore always returns the original response.
+        /// </remarks>
         public async Task SendAsync_ReturnsOriginalResponseIfNoObjectContent()
         {
             // Arrange
@@ -128,8 +141,11 @@ namespace Microsoft.Test.AspNet.OData
             Assert.Same(originalResponse, response);
         }
 
-#if !NETCORE // TODO #939: Enable these test on AspNetCore.
         [Fact]
+        /// <remarks>
+        /// This test specifically test the AspNet behavior or ODataNullValueMessageHandler and whether it creates
+        /// a new response or returns the original response. AspNetCore always returns the original response.
+        /// </remarks>
         public async Task SendAsync_ReturnsOriginalResponseIfObjectContentHasValue()
         {
             // Arrange
@@ -159,6 +175,10 @@ namespace Microsoft.Test.AspNet.OData
         [InlineData(HttpStatusCode.Redirect)]
         [InlineData(HttpStatusCode.BadRequest)]
         [InlineData(HttpStatusCode.InternalServerError)]
+        /// <remarks>
+        /// This test specifically test the AspNet behavior or ODataNullValueMessageHandler and whether it creates
+        /// a new response or returns the original response. AspNetCore always returns the original response.
+        /// </remarks>
         public async Task SendAsync_ReturnsOriginalResponseIfStatusCodeIsNotOk(HttpStatusCode status)
         {
             // Arrange
@@ -188,6 +208,10 @@ namespace Microsoft.Test.AspNet.OData
         [InlineData("Post")]
         [InlineData("Put")]
         [InlineData("Patch")]
+        /// <remarks>
+        /// This test specifically test the AspNet behavior or ODataNullValueMessageHandler and whether it creates
+        /// a new response or returns the original response. AspNetCore always returns the original response.
+        /// </remarks>
         public async Task SendAsync_ReturnsOriginalResponseIfRequestIsNotGet(string method)
         {
             // Arrange
@@ -213,6 +237,10 @@ namespace Microsoft.Test.AspNet.OData
         }
 
         [Fact]
+        /// <remarks>
+        /// This test specifically test the AspNet behavior or ODataNullValueMessageHandler and whether it creates
+        /// a new response or returns the original response. AspNetCore always returns the original response.
+        /// </remarks>
         public async Task SendAsync_ReturnsOriginalResponseIfRequestDoesNotHaveODataPath()
         {
             // Arrange
@@ -237,6 +265,10 @@ namespace Microsoft.Test.AspNet.OData
         }
 
         [Fact]
+        /// <remarks>
+        /// This test specifically test the AspNet behavior or ODataNullValueMessageHandler and whether it creates
+        /// a new response or returns the original response. AspNetCore always returns the original response.
+        /// </remarks>
         public async Task SendAsync_ReturnsNotFoundForNullEntityResponse()
         {
             // Arrange
@@ -391,6 +423,10 @@ namespace Microsoft.Test.AspNet.OData
             public int ComplexTypeProperty { get; set; }
         }
 
+#if NETFX
+        /// <remarks>
+        /// This class is used to return a specific response for AspNet tests.
+        /// </remarks>
         private class TestMessageHandler : HttpMessageHandler
         {
             private readonly HttpResponseMessage _response;
@@ -406,5 +442,6 @@ namespace Microsoft.Test.AspNet.OData
                 return Task.FromResult(_response);
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

This changes fixes the following UTs:
1.) EntityTypeSerializesAsODataEntry - refactor FormatterTestHelper to allow model, routeName and
     path to be configured as part of the config & request instead of as part of the formatters. 
     This affects CollectionTest, ComplexTypeTest, and ResourceSetTest as well.
2.) Enable query options for ODataFormatterTests tests.
3.) Modify Posting_A_Feed_To_NonCollectionProperty_ODataLibThrows to look for the exception
     returned from the controller.
4.) Make the failing ODataNullValueMessageHandlerTest specific to AspNet. Additional work is needed
    to enable the ODataNullValueMessageHandlerTests.

Current pass rate for UTs is 100%.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

Additional work is needed to enable the ODataNullValueMessageHandlerTests.

