### PR TITLE
Support route-specific ODataRouteAttributes

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Routing/ODataRouteAttribute.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Routing/ODataRouteAttribute.cs
@@ -33,5 +33,10 @@ namespace Microsoft.AspNet.OData.Routing
         /// Gets the OData URL path template that this action handles.
         /// </summary>
         public string PathTemplate { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the OData route with which to associate the attribute.
+        /// </summary>
+        public string RouteName { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.OData/Routing/Conventions/AttributeRoutingConvention.cs
+++ b/src/Microsoft.AspNet.OData/Routing/Conventions/AttributeRoutingConvention.cs
@@ -266,6 +266,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
 
             return
                 routeAttributes
+                    .Where(route => String.IsNullOrEmpty(route.RouteName) || route.RouteName == _routeName)
                     .Select(route => GetODataPathTemplate(prefix, route.PathTemplate, requestContainer, controllerName, actionName))
                     .Where(template => template != null);
         }

--- a/src/Microsoft.AspNetCore.OData/Routing/Conventions/AttributeRoutingConvention.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/Conventions/AttributeRoutingConvention.cs
@@ -246,6 +246,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
 
             return
                 routeAttributes
+                    .Where(route => string.IsNullOrEmpty(route.RouteName) || route.RouteName == _routeName)
                     .Select(route => GetODataPathTemplate(prefix, route.PathTemplate, requestContainer, controllerName, actionName))
                     .Where(template => template != null);
         }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -1620,6 +1620,9 @@
     <Compile Include="..\Routing\AddRelatedObjectTests.cs">
       <Link>Routing\AddRelatedObjectTests.cs</Link>
     </Compile>
+    <Compile Include="..\Routing\AttributeRoutingTests.cs">
+      <Link>Routing\AttributeRoutingTests.cs</Link>
+    </Compile>
     <Compile Include="..\Routing\DynamicProperties\DynamicPropertiesController.cs">
       <Link>Routing\DynamicProperties\DynamicPropertiesController.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -69,6 +69,9 @@
     <Compile Include="..\QueryComposition\EFWideCustomer.cs">
       <Link>QueryComposition\EFWideCustomer.cs</Link>
     </Compile>
+    <Compile Include="..\Routing\AttributeRoutingTests.cs">
+      <Link>Routing\AttributeRoutingTests.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <None Include="App.config" />
     <None Include="packages.config">

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Routing/AttributeRoutingTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Routing/AttributeRoutingTests.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Routing;
+using Microsoft.AspNet.OData.Routing.Conventions;
+using Microsoft.OData.Edm;
+using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Microsoft.Test.E2E.AspNet.OData.Common.Extensions;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Test.E2E.AspNet.OData.Routing
+{
+    public class AttributeRoutingTests : WebHostTestBase
+    {
+        public AttributeRoutingTests(WebHostTestFixture fixture)
+            :base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration config)
+        {
+            config.Routes.Clear();
+            config.AddControllers(new Type[] { typeof(DogsController), typeof(CatsController), typeof(OwnersController) });
+
+            ODataModelBuilder builder = config.CreateConventionModelBuilder();
+            builder.EntitySet<Dog>("Dogs").EntityType.Collection.Function("BestDog").Returns<string>();
+            builder.EntitySet<Owner>("Owners").EntityType.Collection.Function("BestOwner").Returns<string>();
+            config.MapODataServiceRoute("Dog", "dog", builder.GetEdmModel());
+
+            builder = config.CreateConventionModelBuilder();
+            builder.EntitySet<Cat>("Cats").EntityType.Collection.Function("BestCat").Returns<string>();
+            builder.EntitySet<Owner>("Owners").EntityType.Collection.Function("BestOwner").Returns<string>();
+            config.MapODataServiceRoute("Cat", "cat", builder.GetEdmModel());
+        }
+
+        [Theory]
+        [InlineData("/dog/Dogs")]
+        [InlineData("/dog/Dogs/Default.BestDog")]
+        [InlineData("/dog/Owners")]
+        [InlineData("/dog/Owners/Default.BestOwner")]
+        [InlineData("/cat/Cats")]
+        [InlineData("/cat/Cats/Default.BestCat")]
+        [InlineData("/cat/Owners")]
+        [InlineData("/cat/Owners/Default.BestOwner")]
+        public async Task CanSupportMultipleAttributesRoutes(string url)
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, BaseAddress + url);
+            HttpResponseMessage response = await Client.SendAsync(request);
+            Assert.NotNull(response);
+            Assert.True(response.IsSuccessStatusCode);
+        }
+    }
+
+    public class DogsController : TestODataController
+    {
+        private static IList<Dog> dogs = Enumerable.Range(1, 5)
+            .Select(e => { return new Dog() { Id = e, Name = "Dog " + e.ToString() }; })
+            .ToList();
+
+        public ITestActionResult Get()
+        {
+            return Ok(dogs);
+        }
+
+        [HttpGet]
+        [ODataRoute("Dogs/Default.BestDog", RouteName = "Dog")]
+        public ITestActionResult WhoIsTheBestDog()
+        {
+            return Ok(dogs.First().Name);
+        }
+    }
+
+    public class CatsController : TestODataController
+    {
+        private static IList<Cat> cats = Enumerable.Range(1, 5)
+            .Select(e => { return new Cat() { Id = e, Name = "Cat " + e.ToString() }; })
+            .ToList();
+
+        public ITestActionResult Get()
+        {
+            return Ok(cats);
+        }
+
+        [HttpGet]
+        [ODataRoute("Cats/Default.BestCat", RouteName = "Cat")]
+        public ITestActionResult WhoIsTheBestCat()
+        {
+            return Ok(cats.First().Name);
+        }
+    }
+
+    public class OwnersController : TestODataController
+    {
+        private static IList<Owner> owners = Enumerable.Range(1, 5)
+            .Select(e => { return new Owner() { Id = e, Name = "Owner " + e.ToString() }; })
+            .ToList();
+
+        public ITestActionResult Get()
+        {
+            return Ok(owners);
+        }
+
+        [HttpGet]
+        [ODataRoute("Owners/Default.BestOwner")]
+        public ITestActionResult WhoIsTheBestOwner()
+        {
+            return Ok(owners.First().Name);
+        }
+    }
+
+    public class Dog
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class Cat
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class Owner
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -2910,6 +2910,7 @@ public sealed class Microsoft.AspNet.OData.Routing.ODataRouteAttribute : System.
 	public ODataRouteAttribute (string pathTemplate)
 
 	string PathTemplate  { public get; }
+	string RouteName  { public get; public set; }
 }
 
 [

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -3012,6 +3012,7 @@ public sealed class Microsoft.AspNet.OData.Routing.ODataRouteAttribute : System.
 	public ODataRouteAttribute (string pathTemplate)
 
 	string PathTemplate  { public get; }
+	string RouteName  { public get; public set; }
 }
 
 [


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1286

### Description

In the current implementation, the AttributeRoutingConvention references the model associated with the route to which the convention is associate to validate the templates specified in DataRouteAttribute. However, ODataRouteAttribute can be applied to controller actions and controllers are not associated with routes; they are global.

As a result, if an ODataRouteAttributes is used and the template reference a type that is specific to a particular route’s model, all other routes will fail to route requests as AttributeRoutingConvention will attempt to validate the ODataRouteAttributes using a model in which the ODataRouteAttribute template will not be valid.

AttributeRoutingConvention has a simple method, ShouldMapController() which can be used to customize its behavior. It is possible to create a custom AttributeRoutingConvention in which the ShouldMapController() essentially maps controllers to routes, getting around this issue. This method can be very powerful (with the exception that it can’t use the “this” pointer as the virtual method is called in the constructor) but is a bit complex for the simple scenario of associating certain ODataRouteAttributes with a specific route.

This change introduces a new parameter to ODataRouteAttribute, RouteName, that can be specified to limit the routes in which the ODataRouteAttribute is validated. Now, matching an ODataRouteAttribute to a route which contains the model that is required to validate the ODataRouteAttribute is a simple operation. Note that multiple ODataRouteAttributes are allowed on a single action and this is the method to apply a similar a template to one or more RouteName.

Note that an ODataRouteAttribute without a RouteName will be validated for all routes to maintain
backward-compatibility. It’s also important the AttributeRoutingConvention still throws for invalid
ODataRouteAttribute templates as it is the only mechanism to provide developer feedback that there is a
problem with the template. This change leaves those existing behaviors unchanged.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

Documentation needs to be added to explain the RouteName property of ODataRouteAttribute.
