### PR TITLE
Change the WebAPI default to enable KeyAsSegment

### DIFF
--- a/src/System.Web.OData/OData/Routing/DefaultODataPathHandler.cs
+++ b/src/System.Web.OData/OData/Routing/DefaultODataPathHandler.cs
@@ -128,10 +128,7 @@ namespace System.Web.OData.Routing
             }
             else
             {
-                // ODL changes to use ODataUrlKeyDelimiter.Slash as default value.
-                // Web API still uses the ODataUrlKeyDelimiter.Parentheses as default value.
-                // Please remove it after fix: https://github.com/OData/odata.net/issues/642
-                uriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
+                uriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Slash;
             }
 
             ODL.ODataPath path;

--- a/test/UnitTest/System.Web.OData.Test/OData/Routing/Conventions/AttributeRoutingConventionTest.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/Routing/Conventions/AttributeRoutingConventionTest.cs
@@ -161,12 +161,12 @@ namespace System.Web.OData.Routing.Conventions
                 "TestController", typeof(InvalidPathTemplateController));
 
             // Act & Assert
+            // When KeyAsSegent is enabled by default and trying to parse uri "Customers/Order", exception is thrown with
+            // message for invalid key segment.
             Assert.Throws<InvalidOperationException>(
                 () => new AttributeRoutingConvention(RouteName, new[] { controller }),
                 "The path template 'Customers/Order' on the action 'GetCustomers' in controller 'TestController' is not " +
-                "a valid OData path template. The request URI is not valid. Since the segment 'Customers' refers to a " +
-                "collection, this must be the last segment in the request URI or it must be followed by an function or " +
-                "action that can be bound to it otherwise all intermediate segments must refer to a single resource.");
+                "a valid OData path template. Bad Request - Error in query syntax.");
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request updates WebAPI to enable KeyAsSegment by default.*

### Description

*Enables KeyAsSegment by default on WebAPI layer. Key inside parentheses is still supported with this updated default value.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
