### PR TITLE
Change the WebAPI default to enable KeyAsSegment

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Routing/DefaultODataPathHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Routing/DefaultODataPathHandler.cs
@@ -132,10 +132,7 @@ namespace Microsoft.AspNet.OData.Routing
             }
             else
             {
-                // ODL changes to use ODataUrlKeyDelimiter.Slash as default value.
-                // Web API still uses the ODataUrlKeyDelimiter.Parentheses as default value.
-                // Please remove it after fix: https://github.com/OData/odata.net/issues/642
-                uriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
+                uriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Slash;
             }
 
             ODL.ODataPath path;

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Microsoft.Test.AspNet.OData.csproj
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Microsoft.Test.AspNet.OData.csproj
@@ -91,10 +91,6 @@
       <HintPath>..\..\..\sln\packages\xunit.assert.2.3.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\xunit.extensibility.core.2.3.1\lib\netstandard1.1\xunit.core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="xunit.execution.desktop, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\..\sln\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Routing/Conventions/AttributeRoutingConventionTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Routing/Conventions/AttributeRoutingConventionTest.cs
@@ -210,9 +210,7 @@ namespace Microsoft.Test.AspNet.OData.Routing.Conventions
             ExceptionAssert.Throws<InvalidOperationException>(
                 () => new AttributeRoutingConvention(RouteName, descriptors, new DefaultODataPathHandler()),
                 "The path template 'Customers/Order' on the action 'GetCustomers' in controller 'TestController' is not " +
-                "a valid OData path template. The request URI is not valid. Since the segment 'Customers' refers to a " +
-                "collection, this must be the last segment in the request URI or it must be followed by an function or " +
-                "action that can be bound to it otherwise all intermediate segments must refer to a single resource.");
+                "a valid OData path template. Bad Request - Error in query syntax.");
         }
 
 #if NETFX // AspNetCore version uses lazy initialization.

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Routing/DefaultODataPathHandlerTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Routing/DefaultODataPathHandlerTest.cs
@@ -427,6 +427,31 @@ namespace Microsoft.Test.AspNet.OData.Routing
         }
 
         [Fact]
+        public void CanParseUrlWithDefaultKeyAsSegment()
+        {
+            // Arrange: OData path specified with key as segment.
+            string odataPath = "RoutingCustomers/112";
+            string expectedText = "112";
+            IEdmEntitySet expectedSet = _model.EntityContainer.EntitySets().SingleOrDefault(s => s.Name == "RoutingCustomers");
+
+            // Create path handler (parser) with default UrlKeyDelimiter = null.
+            var simplifiedParser = new DefaultODataPathHandler();
+
+            // Act: The parse using default UrlKeyDemiliter can parse OData path with key as segment correctly.
+            ODataPath path = simplifiedParser.Parse(_model, _serviceRoot, odataPath);
+            ODataPathSegment segment = path.Segments.Last();
+
+            // Assert
+            Assert.NotNull(segment);
+
+            KeySegment keySegment = Assert.IsType<KeySegment>(segment);
+            Assert.Equal(expectedText, keySegment.ToUriLiteral());
+
+            Assert.Same(expectedSet, path.NavigationSource);
+            Assert.Same(expectedSet.EntityType(), path.EdmType);
+        }
+
+        [Fact]
         public void CanParseCastCollectionSegment()
         {
             // Arrange
@@ -917,7 +942,7 @@ namespace Microsoft.Test.AspNet.OData.Routing
             Assert.NotNull(segment);
             OperationSegment operation = Assert.IsType<OperationSegment>(segment);
             IEdmOperation edmOperation = Assert.Single(operation.Operations);
-            
+
             EdmAction action = Assert.IsType<EdmAction>(edmOperation);
             Assert.Equal(expectedText, action.FullName());
 
@@ -964,12 +989,23 @@ namespace Microsoft.Test.AspNet.OData.Routing
         [InlineData("RoutingCustomers/Default.FunctionBoundToVIPs()")]
         public void CannotParseOperationBoundToDerivedCollectionType(string uri)
         {
+            // When EnableKeyAsSegment is enabled, in ODataPathParser.CreateNextSegment(), after attempting to resolve
+            // function bound to derived type with no lucks, ODataPathParser will further attempt to resolve the segment text as Key
+            // resulting in exception thrown indicating invalid key.
+
             // Arrange & Act & Assert
             ExceptionAssert.Throws<ODataException>(
                 () => _parser.Parse(_model, _serviceRoot, _serviceRoot + uri),
-                "The request URI is not valid. Since the segment 'RoutingCustomers' refers to a collection," +
-                " this must be the last segment in the request URI or it must be followed by an function or action " +
-                "that can be bound to it otherwise all intermediate segments must refer to a single resource.");
+                "Bad Request - Error in query syntax.");
+        }
+
+        [Fact]
+        public void CanParseOperationBoundToCollectionType()
+        {
+            string uri = "RoutingCustomers/Default.FunctionBoundToRoutingCustomers()";
+            // Arrange & Act & Assert
+            ODataPath odataPath = _parser.Parse(_model, _serviceRoot, _serviceRoot + uri);
+            Assert.Equal(2, odataPath.Segments.Count);
         }
 
         [Fact]
@@ -984,12 +1020,14 @@ namespace Microsoft.Test.AspNet.OData.Routing
         [Fact]
         public void CannotParseUnboundOperationAfterEntityCollectionType()
         {
+            // The unbound operation cannot be resolved for the entity collection type. Subsequently, with EnableKeyAsSegment enabled,
+            // ODataPathParser will further attempt to resolve the segment text as Key
+            // resulting in exception thrown indicating invalid key.
+
             // Arrange & Act & Assert
             ExceptionAssert.Throws<ODataException>(
                 () => _parser.Parse(_model, _serviceRoot, _serviceRoot + "RoutingCustomers/Default.GetAllVIPs()"),
-                "The request URI is not valid. Since the segment 'RoutingCustomers' refers to a collection," +
-                " this must be the last segment in the request URI or it must be followed by an function or action " +
-                "that can be bound to it otherwise all intermediate segments must refer to a single resource.");
+                "Bad Request - Error in query syntax.");
         }
 
         [Fact]
@@ -1356,7 +1394,7 @@ namespace Microsoft.Test.AspNet.OData.Routing
             object stringParameter = functionSegment.GetParameterValue("StringParameter");
             object guidParameter = functionSegment.GetParameterValue("GuidParameter");
             object enumParameter = functionSegment.GetParameterValue("EnumParameter");
-            
+
             // Assert
             Assert.Equal(123, intParameter);
             Assert.Null(nullableDoubleParameter);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request updates WebAPI to enable KeyAsSegment by default.*

### Description

*Enables KeyAsSegment by default on WebAPI layer. Key inside parentheses is still supported with this updated default value.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
