### PR TITLE
Change the ModelBuilderFactory to directly access the types

### DIFF
--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ODataConventionModelBuilderFactory.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ODataConventionModelBuilderFactory.cs
@@ -27,12 +27,7 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
             // Create an application part manager with both the product and test assemblies.
             ApplicationPartManager applicationPartManager = new ApplicationPartManager();
             applicationPartManager.ApplicationParts.Add(new AssemblyPart(typeof(ODataConventionModelBuilder).Assembly));
-
-            // Make sure call Create() method from "Microsoft.Test.AspNet{Core}.OData"
-            Assembly assembly = Assembly.GetCallingAssembly();
-            Debug.Assert(assembly.FullName.Contains("Microsoft.Test.AspNet.OData") ||
-                assembly.FullName.Contains("Microsoft.Test.AspNetCore.OData"));
-            applicationPartManager.ApplicationParts.Add(new AssemblyPart(assembly));
+            applicationPartManager.ApplicationParts.Add(new AssemblyPart(typeof(ODataConventionModelBuilderFactory).Assembly));
 
             // Also, a few tests are built on CultureInfo so include it as well.
             applicationPartManager.ApplicationParts.Add(new AssemblyPart(typeof(CultureInfo).Assembly));


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* Change the ModelBuilderFactory to directly access the types

### Description

With the old codes, xunit will failed to run the test cases.

So, it's time to change the ModelBuilderFactory to directly access the types.


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
