### PR TITLE
Make Match as virtual in ODataPathRouteConstraint

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Routing/ODataPathRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataPathRouteConstraint.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
-using System.Text;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Interfaces;
@@ -29,7 +28,7 @@ namespace Microsoft.AspNet.OData.Routing
         /// True if this instance equals a specified route; otherwise, false.
         /// </returns>
         /// <remarks>This signature uses types that are AspNetCore-specific.</remarks>
-        public bool Match(HttpContext httpContext, IRouter route, string routeKey, RouteValueDictionary values, RouteDirection routeDirection)
+        public virtual bool Match(HttpContext httpContext, IRouter route, string routeKey, RouteValueDictionary values, RouteDirection routeDirection)
         {
             if (httpContext == null)
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* #1388

### Description

* Make the Match as virtual method in ODataPathRouteConstraint.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
