### PR TITLE
Patch nested structural resources

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
@@ -430,7 +430,18 @@ namespace Microsoft.AspNet.OData.Common
                 return ResourceManager.GetString("DeltaTypeMismatch", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot find nested resource name &apos;{0}&apos; in parent resource type &apos;{1}&apos;..
+        /// </summary>
+        internal static string DeltaNestedResourceNameNotFound
+        {
+            get
+            {
+                return ResourceManager.GetString("DeltaNestedResourceNameNotFound", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The dependent property type &apos;{0}&apos; is not same as the principal property type &apos;{1}. The dependent and principal properties must have must have same types in the same order..
         /// </summary>

--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -458,6 +458,9 @@
   </data>
   <data name="DeltaEntityTypeNotAssignable" xml:space="preserve">
     <value>The actual entity type '{0}' is not assignable to the expected type '{1}'.</value>
+  </data>
+  <data name="DeltaNestedResourceNameNotFound" xml:space="preserve">
+    <value>Cannot find nested resource name '{0}' in parent resource type '{1}'</value>
   </data>
   <data name="NotAllowedArithmeticOperator" xml:space="preserve">
     <value>Arithmetic operator '{0}' is not allowed. To allow it, set the '{1}' property on EnableQueryAttribute or QueryValidationSettings.</value>

--- a/src/Microsoft.AspNet.OData.Shared/Delta.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Delta.cs
@@ -44,17 +44,6 @@ namespace Microsoft.AspNet.OData
         public abstract bool TryGetPropertyValue(string name, out object value);
 
         /// <summary>
-        /// Attempts to add the delta nested resource.
-        /// </summary>
-        /// <param name="name">Name of the nested resource.</param>
-        /// <param name="deltaNestedResource">The delta object for the nested resource.</param>
-        /// <returns></returns>
-        public virtual bool TryAddNestedResource(string name, object deltaNestedResource)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
         /// Attempts to get the <see cref="Type"/> of the Property called <paramref name="name"/> from the underlying Entity.
         /// <remarks>
         /// Only properties that exist on Entity can be retrieved.

--- a/src/Microsoft.AspNet.OData.Shared/Delta.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Delta.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.OData
     /// A class the tracks changes (i.e. the Delta) for an entity.
     /// </summary>
     [NonValidatingParameterBinding]
-    public abstract class Delta : DynamicObject, IDelta 
+    public abstract class Delta : DynamicObject, IDelta
     {
         /// <summary>
         /// Clears the Delta and resets the underlying Entity.
@@ -42,6 +42,17 @@ namespace Microsoft.AspNet.OData
         /// <param name="value">The value of the Property</param>
         /// <returns>True if the Property was found</returns>
         public abstract bool TryGetPropertyValue(string name, out object value);
+
+        /// <summary>
+        /// Attempts to add the delta nested resource.
+        /// </summary>
+        /// <param name="name">Name of the nested resource.</param>
+        /// <param name="deltaNestedResource">The delta object for the nested resource.</param>
+        /// <returns></returns>
+        public virtual bool TryAddNestedResource(string name, object deltaNestedResource)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// Attempts to get the <see cref="Type"/> of the Property called <paramref name="name"/> from the underlying Entity.
@@ -84,14 +95,14 @@ namespace Microsoft.AspNet.OData
         }
 
         /// <summary>
-        /// Returns the Properties that have been modified through this Delta as an 
-        /// enumeration of Property Names 
+        /// Returns the Properties that have been modified through this Delta as an
+        /// enumeration of Property Names
         /// </summary>
         public abstract IEnumerable<string> GetChangedPropertyNames();
 
         /// <summary>
-        /// Returns the Properties that have not been modified through this Delta as an 
-        /// enumeration of Property Names 
+        /// Returns the Properties that have not been modified through this Delta as an
+        /// enumeration of Property Names
         /// </summary>
         public abstract IEnumerable<string> GetUnchangedPropertyNames();
     }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/DeserializationHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/DeserializationHelpers.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Reflection;
@@ -60,7 +59,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         internal static void SetDynamicProperty(object resource, IEdmStructuredTypeReference resourceType,
             EdmTypeKind propertyKind, string propertyName, object propertyValue, IEdmTypeReference propertyType,
             IEdmModel model)
-        {  
+        {
             if (propertyKind == EdmTypeKind.Collection && propertyValue.GetType() != typeof(EdmComplexObjectCollection)
                 && propertyValue.GetType() != typeof(EdmEnumObjectCollection))
             {
@@ -188,14 +187,6 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             {
                 delta.TrySetPropertyValue(propertyName, value);
             }
-        }
-
-        internal static void SetNestedResource(object resource, string nestedResourceName, object deltaNestedResource)
-        {
-            IDelta delta = resource as IDelta;
-            Debug.Assert(delta != null);
-
-            delta.TryAddNestedResource(nestedResourceName, deltaNestedResource);
         }
 
         internal static void SetDynamicProperty(object resource, string propertyName, object value,

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/DeserializationHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/DeserializationHelpers.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Reflection;
@@ -187,6 +188,14 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             {
                 delta.TrySetPropertyValue(propertyName, value);
             }
+        }
+
+        internal static void SetNestedResource(object resource, string nestedResourceName, object deltaNestedResource)
+        {
+            IDelta delta = resource as IDelta;
+            Debug.Assert(delta != null);
+
+            delta.TryAddNestedResource(nestedResourceName, deltaNestedResource);
         }
 
         internal static void SetDynamicProperty(object resource, string propertyName, object value,

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -434,8 +434,18 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
 
             object value = ReadNestedResourceInline(resourceWrapper, nestedProperty.Type, readContext);
 
+            // First resolve Data member alias or annotation, then set the regular
+            // or delta resource accordingly.
             string propertyName = EdmLibHelpers.GetClrPropertyName(nestedProperty, readContext.Model);
-            DeserializationHelpers.SetProperty(resource, propertyName, value);
+
+            if (readContext.IsDeltaOfT)
+            {
+                DeserializationHelpers.SetNestedResource(resource, propertyName, value);
+            }
+            else
+            {
+                DeserializationHelpers.SetProperty(resource, propertyName, value);
+            }
         }
 
         private void ApplyDynamicResourceInNestedProperty(string propertyName, object resource, IEdmStructuredTypeReference resourceStructuredType,
@@ -481,30 +491,27 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                 Model = readContext.Model,
             };
 
+            Type clrType = null;
             if (readContext.IsUntyped)
             {
-                if (structuredType.IsEntity())
-                {
-                    nestedReadContext.ResourceType = typeof(EdmEntityObject);
-                }
-                else
-                {
-                    nestedReadContext.ResourceType = typeof(EdmComplexObject);
-                }
+                clrType = structuredType.IsEntity()
+                    ? typeof(EdmEntityObject)
+                    : typeof(EdmComplexObject);
             }
             else
             {
-                Type clrType = EdmLibHelpers.GetClrType(structuredType, readContext.Model);
+                clrType = EdmLibHelpers.GetClrType(structuredType, readContext.Model);
 
                 if (clrType == null)
                 {
                     throw new ODataException(
                         Error.Format(SRResources.MappingDoesNotContainResourceType, structuredType.FullName()));
                 }
-
-                nestedReadContext.ResourceType = clrType;
             }
 
+            nestedReadContext.ResourceType = readContext.IsDeltaOfT
+                ? typeof(Delta<>).MakeGenericType(new Type[] { clrType })
+                : clrType;
             return deserializer.ReadInline(resourceWrapper, edmType, nestedReadContext);
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -438,14 +438,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             // or delta resource accordingly.
             string propertyName = EdmLibHelpers.GetClrPropertyName(nestedProperty, readContext.Model);
 
-            if (readContext.IsDeltaOfT)
-            {
-                DeserializationHelpers.SetNestedResource(resource, propertyName, value);
-            }
-            else
-            {
-                DeserializationHelpers.SetProperty(resource, propertyName, value);
-            }
+            DeserializationHelpers.SetProperty(resource, propertyName, value);
         }
 
         private void ApplyDynamicResourceInNestedProperty(string propertyName, object resource, IEdmStructuredTypeReference resourceStructuredType,
@@ -510,7 +503,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             }
 
             nestedReadContext.ResourceType = readContext.IsDeltaOfT
-                ? typeof(Delta<>).MakeGenericType(new Type[] { clrType })
+                ? typeof(Delta<>).MakeGenericType(clrType)
                 : clrType;
             return deserializer.ReadInline(resourceWrapper, edmType, nestedReadContext);
         }

--- a/src/Microsoft.AspNet.OData.Shared/IDelta.cs
+++ b/src/Microsoft.AspNet.OData.Shared/IDelta.cs
@@ -35,14 +35,6 @@ namespace Microsoft.AspNet.OData
         bool TrySetPropertyValue(string name, object value);
 
         /// <summary>
-        /// Attempts to add the delta nested resource.
-        /// </summary>
-        /// <param name="name">Name of the nested resource.</param>
-        /// <param name="deltaNestedResource">The delta object for the nested resource.</param>
-        /// <returns>True if the nested resource is added successfully; otherwise false.</returns>
-        bool TryAddNestedResource(string name, object deltaNestedResource);
-
-        /// <summary>
         /// Attempts to get the value of the Property called <paramref name="name"/> from the underlying Entity.
         /// </summary>
         /// <param name="name">The name of the Property</param>

--- a/src/Microsoft.AspNet.OData.Shared/IDelta.cs
+++ b/src/Microsoft.AspNet.OData.Shared/IDelta.cs
@@ -35,6 +35,14 @@ namespace Microsoft.AspNet.OData
         bool TrySetPropertyValue(string name, object value);
 
         /// <summary>
+        /// Attempts to add the delta nested resource.
+        /// </summary>
+        /// <param name="name">Name of the nested resource.</param>
+        /// <param name="deltaNestedResource">The delta object for the nested resource.</param>
+        /// <returns>True if the nested resource is added successfully; otherwise false.</returns>
+        bool TryAddNestedResource(string name, object deltaNestedResource);
+
+        /// <summary>
         /// Attempts to get the value of the Property called <paramref name="name"/> from the underlying Entity.
         /// </summary>
         /// <param name="name">The name of the Property</param>

--- a/src/Microsoft.AspNet.OData.Shared/TypedDelta.cs
+++ b/src/Microsoft.AspNet.OData.Shared/TypedDelta.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.AspNet.OData
 {
     /// <summary>
-    /// Represents a <see cref="Delta"/> that can be used when a backing CLR type exists for 
+    /// Represents a <see cref="Delta"/> that can be used when a backing CLR type exists for
     /// the entity type and complex type whose changes are tracked.
     /// </summary>
     public abstract class TypedDelta : Delta
@@ -20,5 +20,24 @@ namespace Microsoft.AspNet.OData
         /// Gets the expected type of the entity for which the changes are tracked.
         /// </summary>
         public abstract Type ExpectedClrType { get; }
+
+        /// <summary>
+        /// Returns the instance that holds all the changes at current level being tracked by this Delta.
+        /// </summary>
+        /// <returns>The internal resource instance.</returns>
+        internal virtual object GetInstance()
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Helper method to check whether the given type is Delta generic type.
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns>True if it is a Delta generic type; false otherwise.</returns>
+        internal static bool IsDeltaOfT(Type type)
+        {
+            return type != null && TypeHelper.IsGenericType(type) && type.GetGenericTypeDefinition() == typeof(Delta<>);
+        }
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/TypedDelta.cs
+++ b/src/Microsoft.AspNet.OData.Shared/TypedDelta.cs
@@ -14,21 +14,12 @@ namespace Microsoft.AspNet.OData
         /// <summary>
         /// Gets the actual type of the entity for which the changes are tracked.
         /// </summary>
-        public abstract Type EntityType { get; }
+        public abstract Type StructuredType { get; }
 
         /// <summary>
         /// Gets the expected type of the entity for which the changes are tracked.
         /// </summary>
         public abstract Type ExpectedClrType { get; }
-
-        /// <summary>
-        /// Returns the instance that holds all the changes at current level being tracked by this Delta.
-        /// </summary>
-        /// <returns>The internal resource instance.</returns>
-        internal virtual object GetInstance()
-        {
-            return null;
-        }
 
         /// <summary>
         /// Helper method to check whether the given type is Delta generic type.

--- a/src/Microsoft.AspNet.OData.Shared/TypedDelta.cs
+++ b/src/Microsoft.AspNet.OData.Shared/TypedDelta.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.OData
     public abstract class TypedDelta : Delta
     {
         /// <summary>
-        /// Gets the actual type of the entity for which the changes are tracked.
+        /// Gets the actual type of the structural object for which the changes are tracked.
         /// </summary>
         public abstract Type StructuredType { get; }
 

--- a/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
+++ b/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
@@ -16,6 +16,7 @@
     <DefineConstants>$(DefineConstants);ASPNETODATA;ASPNETWEBAPI;NETFX;NETFX45</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\sln\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
       <Private>True</Private>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceControllers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceControllers.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -100,7 +101,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance
                 return Created(window);
             }
 
-            delta.Patch(window);
+            try
+            {
+                delta.Patch(window);
+            }
+            catch (ArgumentException ae)
+            {
+                return BadRequest(ae.Message);
+            }
+
             return Ok(window);
         }
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceDataModels.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceDataModels.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance
         public Point TopLeft { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
-        
+
         public Rectangle()
         {
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceTests.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance
     },
     'OptionalShapes': [ ]
 }";
-            string contentOfString = await ExecuteHTTP(request, content);
+            string contentOfString = await ExecuteAsync(request, content);
 
             // Only 'HasBoarder' is updated; 'Vertexes' still has the correct value.
             Assert.Contains("\"HasBorder\":true", contentOfString);
@@ -346,14 +346,14 @@ namespace Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance
     },
     'OptionalShapes': [ ]
 }";
-            contentOfString = await ExecuteHTTP(request, content);
+            contentOfString = await ExecuteAsync(request, content);
 
             // Only 'Vertexes' is updated;  'HasBoarder' still has the correct value.
             Assert.Contains("\"Vertexes\":[{\"X\":1,\"Y\":2},{\"X\":2,\"Y\":3},{\"X\":4,\"Y\":8}]", contentOfString);
             Assert.Contains("\"HasBorder\":false", contentOfString);
         }
 
-        private async Task<string> ExecuteHTTP(HttpRequestMessage request, string content)
+        private async Task<string> ExecuteAsync(HttpRequestMessage request, string content)
         {
             StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
             request.Content = stringContent;

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/DeltaTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/DeltaTest.cs
@@ -597,7 +597,7 @@ namespace Microsoft.AspNet.OData.Test
             TypedDelta delta = new Delta<Customer>(actualType);
 
             // Act
-            Type actualActualType = delta.EntityType;
+            Type actualActualType = delta.StructuredType;
             Type actualExpectedType = delta.ExpectedClrType;
 
             // Assert

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/DeltaTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/DeltaTest.cs
@@ -516,7 +516,7 @@ namespace Microsoft.AspNet.OData.Test
             }
 
             // Assert
-            Assert.Equal(delta.GetChangedPropertyNames(), new[] { propertyName });
+            Assert.Equal(new[] { propertyName }, delta.GetChangedPropertyNames());
             object value;
             Assert.True(delta.TryGetPropertyValue(propertyName, out value));
             Assert.Equal(expectedValue, value);
@@ -570,7 +570,7 @@ namespace Microsoft.AspNet.OData.Test
             }
 
             // Assert
-            Assert.Equal(delta.GetChangedPropertyNames(), new[] { propertyName });
+            Assert.Equal(new[] { propertyName }, delta.GetChangedPropertyNames() );
             object value;
             Assert.True(delta.TryGetPropertyValue(propertyName, out value));
             Assert.Equal(expectedValue, value);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -10,6 +10,7 @@ public interface Microsoft.AspNet.OData.IDelta {
 	void Clear ()
 	System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
 	System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
+	bool TryAddNestedResource (string name, object deltaNestedResource)
 	bool TryGetPropertyType (string name, out System.Type& type)
 	bool TryGetPropertyValue (string name, out System.Object& value)
 	bool TrySetPropertyValue (string name, object value)
@@ -70,6 +71,7 @@ public abstract class Microsoft.AspNet.OData.Delta : System.Dynamic.DynamicObjec
 	public abstract void Clear ()
 	public abstract System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
 	public abstract System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
+	public virtual bool TryAddNestedResource (string name, object deltaNestedResource)
 	public virtual bool TryGetMember (System.Dynamic.GetMemberBinder binder, out System.Object& result)
 	public abstract bool TryGetPropertyType (string name, out System.Type& type)
 	public abstract bool TryGetPropertyValue (string name, out System.Object& value)
@@ -148,6 +150,8 @@ public abstract class Microsoft.AspNet.OData.TypedDelta : Delta, IDynamicMetaObj
 
 	System.Type EntityType  { public abstract get; }
 	System.Type ExpectedClrType  { public abstract get; }
+
+	internal virtual object GetInstance ()
 }
 
 [
@@ -243,10 +247,11 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public void CopyChangedValues (TStructuralType original)
 	public void CopyUnchangedValues (TStructuralType original)
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
-	public TStructuralType GetInstance ()
+	internal virtual object GetInstance ()
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
 	public void Patch (TStructuralType original)
 	public void Put (TStructuralType original)
+	public virtual bool TryAddNestedResource (string name, object deltaNestedResource)
 	public virtual bool TryGetPropertyType (string name, out System.Type& type)
 	public virtual bool TryGetPropertyValue (string name, out System.Object& value)
 	public virtual bool TrySetPropertyValue (string name, object value)

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -10,7 +10,6 @@ public interface Microsoft.AspNet.OData.IDelta {
 	void Clear ()
 	System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
 	System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
-	bool TryAddNestedResource (string name, object deltaNestedResource)
 	bool TryGetPropertyType (string name, out System.Type& type)
 	bool TryGetPropertyValue (string name, out System.Object& value)
 	bool TrySetPropertyValue (string name, object value)
@@ -71,7 +70,6 @@ public abstract class Microsoft.AspNet.OData.Delta : System.Dynamic.DynamicObjec
 	public abstract void Clear ()
 	public abstract System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
 	public abstract System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
-	public virtual bool TryAddNestedResource (string name, object deltaNestedResource)
 	public virtual bool TryGetMember (System.Dynamic.GetMemberBinder binder, out System.Object& result)
 	public abstract bool TryGetPropertyType (string name, out System.Type& type)
 	public abstract bool TryGetPropertyValue (string name, out System.Object& value)
@@ -148,10 +146,8 @@ public abstract class Microsoft.AspNet.OData.PerRouteContainerBase : IPerRouteCo
 public abstract class Microsoft.AspNet.OData.TypedDelta : Delta, IDynamicMetaObjectProvider, IDelta {
 	protected TypedDelta ()
 
-	System.Type EntityType  { public abstract get; }
 	System.Type ExpectedClrType  { public abstract get; }
-
-	internal virtual object GetInstance ()
+	System.Type StructuredType  { public abstract get; }
 }
 
 [
@@ -240,18 +236,17 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties)
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo)
 
-	System.Type EntityType  { public virtual get; }
 	System.Type ExpectedClrType  { public virtual get; }
+	System.Type StructuredType  { public virtual get; }
 
 	public virtual void Clear ()
 	public void CopyChangedValues (TStructuralType original)
 	public void CopyUnchangedValues (TStructuralType original)
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
-	internal virtual object GetInstance ()
+	public TStructuralType GetInstance ()
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
 	public void Patch (TStructuralType original)
 	public void Put (TStructuralType original)
-	public virtual bool TryAddNestedResource (string name, object deltaNestedResource)
 	public virtual bool TryGetPropertyType (string name, out System.Type& type)
 	public virtual bool TryGetPropertyValue (string name, out System.Object& value)
 	public virtual bool TrySetPropertyValue (string name, object value)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -10,7 +10,6 @@ public interface Microsoft.AspNet.OData.IDelta {
 	void Clear ()
 	System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
 	System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
-	bool TryAddNestedResource (string name, object deltaNestedResource)
 	bool TryGetPropertyType (string name, out System.Type& type)
 	bool TryGetPropertyValue (string name, out System.Object& value)
 	bool TrySetPropertyValue (string name, object value)
@@ -71,7 +70,6 @@ public abstract class Microsoft.AspNet.OData.Delta : System.Dynamic.DynamicObjec
 	public abstract void Clear ()
 	public abstract System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
 	public abstract System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
-	public virtual bool TryAddNestedResource (string name, object deltaNestedResource)
 	public virtual bool TryGetMember (System.Dynamic.GetMemberBinder binder, out System.Object& result)
 	public abstract bool TryGetPropertyType (string name, out System.Type& type)
 	public abstract bool TryGetPropertyValue (string name, out System.Object& value)
@@ -155,10 +153,8 @@ public abstract class Microsoft.AspNet.OData.SingleResult {
 public abstract class Microsoft.AspNet.OData.TypedDelta : Delta, IDynamicMetaObjectProvider, IDelta {
 	protected TypedDelta ()
 
-	System.Type EntityType  { public abstract get; }
 	System.Type ExpectedClrType  { public abstract get; }
-
-	internal virtual object GetInstance ()
+	System.Type StructuredType  { public abstract get; }
 }
 
 [
@@ -247,18 +243,17 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties)
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo)
 
-	System.Type EntityType  { public virtual get; }
 	System.Type ExpectedClrType  { public virtual get; }
+	System.Type StructuredType  { public virtual get; }
 
 	public virtual void Clear ()
 	public void CopyChangedValues (TStructuralType original)
 	public void CopyUnchangedValues (TStructuralType original)
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
-	internal virtual object GetInstance ()
+	public TStructuralType GetInstance ()
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
 	public void Patch (TStructuralType original)
 	public void Put (TStructuralType original)
-	public virtual bool TryAddNestedResource (string name, object deltaNestedResource)
 	public virtual bool TryGetPropertyType (string name, out System.Type& type)
 	public virtual bool TryGetPropertyValue (string name, out System.Object& value)
 	public virtual bool TrySetPropertyValue (string name, object value)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -10,6 +10,7 @@ public interface Microsoft.AspNet.OData.IDelta {
 	void Clear ()
 	System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
 	System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
+	bool TryAddNestedResource (string name, object deltaNestedResource)
 	bool TryGetPropertyType (string name, out System.Type& type)
 	bool TryGetPropertyValue (string name, out System.Object& value)
 	bool TrySetPropertyValue (string name, object value)
@@ -70,6 +71,7 @@ public abstract class Microsoft.AspNet.OData.Delta : System.Dynamic.DynamicObjec
 	public abstract void Clear ()
 	public abstract System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
 	public abstract System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
+	public virtual bool TryAddNestedResource (string name, object deltaNestedResource)
 	public virtual bool TryGetMember (System.Dynamic.GetMemberBinder binder, out System.Object& result)
 	public abstract bool TryGetPropertyType (string name, out System.Type& type)
 	public abstract bool TryGetPropertyValue (string name, out System.Object& value)
@@ -155,6 +157,8 @@ public abstract class Microsoft.AspNet.OData.TypedDelta : Delta, IDynamicMetaObj
 
 	System.Type EntityType  { public abstract get; }
 	System.Type ExpectedClrType  { public abstract get; }
+
+	internal virtual object GetInstance ()
 }
 
 [
@@ -250,10 +254,11 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public void CopyChangedValues (TStructuralType original)
 	public void CopyUnchangedValues (TStructuralType original)
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
-	public TStructuralType GetInstance ()
+	internal virtual object GetInstance ()
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
 	public void Patch (TStructuralType original)
 	public void Put (TStructuralType original)
+	public virtual bool TryAddNestedResource (string name, object deltaNestedResource)
 	public virtual bool TryGetPropertyType (string name, out System.Type& type)
 	public virtual bool TryGetPropertyValue (string name, out System.Object& value)
 	public virtual bool TrySetPropertyValue (string name, object value)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1263.*

### Description

*Change Delta<T> class to represents delta payload in hierarchical structure, so that payload deserialization during request dispatching and patch functionality invoked by service controller can process the delta payload correctly, eventually resource is patched correctly without overwriting valid, unchanged properties in the resource.*

Build on PR branch: https://github.com/biaol-odata/WebApi/commits/patchNestedProperties

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
