### PR TITLE
Applying fix for using ClrPropertyInfoAnnotation

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/DeserializationHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/DeserializationHelpers.cs
@@ -25,7 +25,16 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             string propertyName = property.Name;
             if (edmProperty != null)
             {
-                propertyName = EdmLibHelpers.GetClrPropertyName(edmProperty, readContext.Model);
+                // The bellow code gets the actual CLR property name which might be diffrent than the one that 
+                // was provided when the model was built. E.g. CLR property ProductId might be exposed as Id
+                // The code that takes care of setting the annotation is the method AddClrPropertyInfoAnnotations in the class EdmModelHelperMethods.
+                // The propertyName must remain the same when working with the IDelta object type, as it does not know the name of the
+                // underlying CLR property. If this name is changed than the property will not be set in the IDelta object in the SetProperty method bellow
+                var isDelta = resource is IDelta;
+                if (!isDelta)
+                {
+                    propertyName = EdmLibHelpers.GetClrPropertyName(edmProperty, readContext.Model);
+                }
             }
             else
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

No public issue.

### Description

The code fixes the case where a ClrPropertyInfo Annotation is used. During the deserialization process, an attempt is made to set the property into the IDelta object with the wrong name

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
