### PR TITLE
Handling filtering with the Edm.Date values

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -243,6 +243,10 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             {
                 return source;
             }
+            else if(conversionType == typeof(DateTimeOffset?) && source.Type == typeof(Date))
+            {
+                return source;
+            }
             else if (source == NullConstant)
             {
                 return source;


### PR DESCRIPTION
To fix a bug when a Date or DateTime property is compared to a date constant. For example:
~/Operations?$filter=EffectiveDate eq 2018-06-11
Without this change, the above code throws the following exception:

> No coercion operator is defined between types 'Microsoft.OData.Edm.Date' and 'System.Nullable`1[System.DateTimeOffset]'.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1473.*

### Description

*Comparing the Date or DateTime fields with date constants needs to a conversion. This patch handles the conversion*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

