### PR TITLE
fix the BaseAddressFactory in ODataMediaTypeFormatter

### DIFF
--- a/src/Microsoft.AspNet.OData/Formatter/ODataMediaTypeFormatter.cs
+++ b/src/Microsoft.AspNet.OData/Formatter/ODataMediaTypeFormatter.cs
@@ -83,6 +83,9 @@ namespace Microsoft.AspNet.OData.Formatter
 
             // Parameter 3: request
             Request = request;
+
+            // BaseAddressFactory
+            BaseAddressFactory = formatter.BaseAddressFactory;
         }
 
         /// <summary>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -1135,6 +1135,9 @@
     <Compile Include="..\ForeignKey\ForeignKeyTest.cs">
       <Link>ForeignKey\ForeignKeyTest.cs</Link>
     </Compile>
+    <Compile Include="..\Formatter\BaseAddressFactoryTest.cs">
+      <Link>Formatter\BaseAddressFactoryTest.cs</Link>
+    </Compile>
     <Compile Include="..\Formatter\CollectionPropertyTests.cs">
       <Link>Formatter\CollectionPropertyTests.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/BaseAddressFactoryTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/BaseAddressFactoryTest.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Dispatcher;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Formatter;
+using Microsoft.OData.Edm;
+using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Microsoft.Test.E2E.AspNet.OData.Common.Extensions;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Test.E2E.AspNet.OData.Formatter
+{
+    public class BaseAddressFactoryModel
+    {
+        public int ID { get; set; }
+    }
+
+    public class BaseAddressFactoryModelsController : TestODataController
+    {
+        public ITestActionResult Get()
+        {
+            return Ok(new BaseAddressFactoryModel[] { new BaseAddressFactoryModel { ID = 1 } });
+        }
+    }
+
+    public class BaseAddressFactoryTest : WebHostTestBase
+    {
+        public BaseAddressFactoryTest(WebHostTestFixture fixture)
+            :base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            var controllers = new[] { typeof(BaseAddressFactoryModelsController) };
+            configuration.AddControllers(controllers);
+            var model = GetEdmModel(configuration);
+            configuration.Routes.Clear();
+            configuration.MapODataServiceRoute("odata", "odata", model);
+            configuration.EnsureInitialized();
+
+            ServicesContainer services = configuration.Services;
+            IHttpControllerSelector controllerSelector = services.GetHttpControllerSelector();
+            var controllerMappings = controllerSelector.GetControllerMapping().Values;
+
+            foreach (var c in controllerMappings)
+            {
+                var odataFormatter = c.Configuration.Formatters.OfType<ODataMediaTypeFormatter>();
+                foreach (var f in odataFormatter)
+                {
+                    f.BaseAddressFactory = (m) => new Uri("http://foo.bar/", UriKind.Absolute);
+                }
+            }
+        }
+
+        protected static IEdmModel GetEdmModel(WebRouteConfiguration configuration)
+        {
+            var mb = configuration.CreateConventionModelBuilder();
+            mb.EntitySet<BaseAddressFactoryModel>("BaseAddressFactoryModels");
+            return mb.GetEdmModel();
+        }
+
+        [Fact]
+        public async Task ShouldReturnTheCustomizedBaseAddress()
+        {
+            string requestUri = string.Format("{0}/odata/BaseAddressFactoryModels", BaseAddress);
+
+            HttpResponseMessage response = await Client.GetAsync(requestUri);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            JObject content = await response.Content.ReadAsObject<JObject>();
+
+            Assert.Contains("http://foo.bar/", (string)content["@odata.context"]);
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* #1407 

### Description

* In Web API OData classic class "ODataMediaTypeFormatter", BaseAddressFactory property should be copy to the internal created formatter object.

This PR try to fix that and add a test to verify it.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
