### PR TITLE
Change the OptionalReturn to ReturnNullable in OperationConfiguration

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
@@ -270,7 +270,7 @@ namespace Microsoft.AspNet.OData.Builder
             {
                 IEdmTypeReference returnReference = GetEdmTypeReference(edmTypeMap,
                     operationConfiguration.ReturnType,
-                    operationConfiguration.ReturnType != null && operationConfiguration.OptionalReturn);
+                    operationConfiguration.ReturnType != null && operationConfiguration.ReturnNullable);
                 IEdmExpression expression = GetEdmEntitySetExpression(edmNavigationSourceMap, operationConfiguration);
                 IEdmPathExpression pathExpression = operationConfiguration.EntitySetPath != null
                     ? new EdmPathExpression(operationConfiguration.EntitySetPath)

--- a/src/Microsoft.AspNet.OData.Shared/Builder/OperationConfiguration.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/OperationConfiguration.cs
@@ -94,9 +94,9 @@ namespace Microsoft.AspNet.OData.Builder
         public IEdmTypeConfiguration ReturnType { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the return is optional or not.
+        /// Gets or sets a value indicating whether the return is nullable or not.
         /// </summary>
-        public bool OptionalReturn { get; set; }
+        public bool ReturnNullable { get; set; }
 
         /// <summary>
         /// The Navigation Source that are returned from.
@@ -157,7 +157,7 @@ namespace Microsoft.AspNet.OData.Builder
             ModelBuilder.EntitySet<TEntityType>(entitySetName);
             NavigationSource = ModelBuilder.EntitySets.Single(s => s.Name == entitySetName);
             ReturnType = ModelBuilder.GetTypeConfigurationOrNull(typeof(TEntityType));
-            OptionalReturn = true;
+            ReturnNullable = true;
         }
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace Microsoft.AspNet.OData.Builder
             NavigationSource = ModelBuilder.EntitySets.Single(s => s.Name == entitySetName);
             IEdmTypeConfiguration elementType = ModelBuilder.GetTypeConfigurationOrNull(typeof(TElementEntityType));
             ReturnType = new CollectionTypeConfiguration(elementType, clrCollectionType);
-            OptionalReturn = true;
+            ReturnNullable = true;
         }
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace Microsoft.AspNet.OData.Builder
         {
             ReturnType = ModelBuilder.GetTypeConfigurationOrNull(typeof(TEntityType));
             EntitySetPath = entitySetPath;
-            OptionalReturn = true;
+            ReturnNullable = true;
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace Microsoft.AspNet.OData.Builder
             IEdmTypeConfiguration elementType = ModelBuilder.GetTypeConfigurationOrNull(typeof(TElementEntityType));
             ReturnType = new CollectionTypeConfiguration(elementType, clrCollectionType);
             EntitySetPath = entitySetPath;
-            OptionalReturn = true;
+            ReturnNullable = true;
         }
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace Microsoft.AspNet.OData.Builder
         {
             IEdmTypeConfiguration configuration = GetOperationTypeConfiguration(clrReturnType);
             ReturnType = configuration;
-            OptionalReturn = EdmLibHelpers.IsNullable(clrReturnType);
+            ReturnNullable = EdmLibHelpers.IsNullable(clrReturnType);
         }
 
         /// <summary>
@@ -229,7 +229,7 @@ namespace Microsoft.AspNet.OData.Builder
             Type clrElementType = typeof(TReturnElementType);
             IEdmTypeConfiguration edmElementType = GetOperationTypeConfiguration(clrElementType);
             ReturnType = new CollectionTypeConfiguration(edmElementType, clrCollectionType);
-            OptionalReturn = EdmLibHelpers.IsNullable(clrElementType);
+            ReturnNullable = EdmLibHelpers.IsNullable(clrElementType);
         }
 
         /// <summary>

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/ActionConfigurationTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/ActionConfigurationTest.cs
@@ -282,7 +282,7 @@ namespace Microsoft.AspNet.OData.Test.Builder
             ActionConfiguration action = builder.Action("MyAction").Returns<Address>();
 
             // Assert
-            Assert.True(action.OptionalReturn);
+            Assert.True(action.ReturnNullable);
         }
 
         [Fact]
@@ -291,10 +291,10 @@ namespace Microsoft.AspNet.OData.Test.Builder
             // Arrange & Act
             ODataModelBuilder builder = new ODataModelBuilder();
             ActionConfiguration action = builder.Action("MyAction").Returns<Address>();
-            action.OptionalReturn = false;
+            action.ReturnNullable = false;
 
             // Assert
-            Assert.False(action.OptionalReturn);
+            Assert.False(action.ReturnNullable);
         }
 
         [Fact]
@@ -672,7 +672,7 @@ namespace Microsoft.AspNet.OData.Test.Builder
             ODataModelBuilder builder = ODataModelBuilderMocks.GetModelBuilderMock<ODataModelBuilder>();
             EntityTypeConfiguration<Movie> movie = builder.EntitySet<Movie>("Movies").EntityType;
             movie.Action("Watch1").Returns<Address>();
-            movie.Action("Watch2").Returns<Address>().OptionalReturn = false;
+            movie.Action("Watch2").Returns<Address>().ReturnNullable = false;
 
             // Act
             IEdmModel model = builder.GetEdmModel();

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/FunctionConfigurationTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/FunctionConfigurationTest.cs
@@ -315,7 +315,7 @@ namespace Microsoft.AspNet.OData.Test.Builder
             FunctionConfiguration function = builder.Function("MyFunction").Returns<Address>();
 
             // Assert
-            Assert.True(function.OptionalReturn);
+            Assert.True(function.ReturnNullable);
         }
 
         [Fact]
@@ -324,10 +324,10 @@ namespace Microsoft.AspNet.OData.Test.Builder
             // Arrange & Act
             ODataModelBuilder builder = new ODataModelBuilder();
             FunctionConfiguration function = builder.Function("MyFunction").Returns<Address>();
-            function.OptionalReturn = false;
+            function.ReturnNullable = false;
 
             // Assert
-            Assert.False(function.OptionalReturn);
+            Assert.False(function.ReturnNullable);
         }
 
         [Fact]
@@ -729,7 +729,7 @@ namespace Microsoft.AspNet.OData.Test.Builder
             ODataModelBuilder builder = ODataModelBuilderMocks.GetModelBuilderMock<ODataModelBuilder>();
             EntityTypeConfiguration<Movie> movie = builder.EntitySet<Movie>("Movies").EntityType;
             movie.Function("Watch1").Returns<Address>();
-            movie.Function("Watch2").Returns<Address>().OptionalReturn = false;
+            movie.Function("Watch2").Returns<Address>().ReturnNullable = false;
 
             // Act
             IEdmModel model = builder.GetEdmModel();

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/MetadataControllerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/MetadataControllerTest.cs
@@ -579,7 +579,7 @@ namespace Microsoft.AspNet.OData.Test
             action.Parameter<string>("param");
 
             action = person.Action("NonNullableAction").Returns<FormatterAddress>();
-            action.OptionalReturn = false;
+            action.ReturnNullable = false;
             action.Parameter<string>("param").Nullable = false;
             IEdmModel model = builder.GetEdmModel();
             HttpClient client = GetClient(model);
@@ -622,7 +622,7 @@ namespace Microsoft.AspNet.OData.Test
             function.Parameter<string>("param");
 
             function = person.Function("NonNullableFunction").Returns<FormatterAddress>();
-            function.OptionalReturn = false;
+            function.ReturnNullable = false;
             function.Parameter<string>("param").Nullable = false;
             IEdmModel model = builder.GetEdmModel();
             HttpClient client = GetClient(model);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -986,8 +986,8 @@ public abstract class Microsoft.AspNet.OData.Builder.OperationConfiguration {
 	string Namespace  { public get; public set; }
 	NavigationSourceConfiguration NavigationSource  { public get; public set; }
 	OperationLinkBuilder OperationLinkBuilder  { protected get; protected set; }
-	bool OptionalReturn  { public get; public set; }
 	System.Collections.Generic.IEnumerable`1[[Microsoft.AspNet.OData.Builder.ParameterConfiguration]] Parameters  { public virtual get; }
+	bool ReturnNullable  { public get; public set; }
 	IEdmTypeConfiguration ReturnType  { public get; public set; }
 	string Title  { public get; public set; }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -1034,8 +1034,8 @@ public abstract class Microsoft.AspNet.OData.Builder.OperationConfiguration {
 	string Namespace  { public get; public set; }
 	NavigationSourceConfiguration NavigationSource  { public get; public set; }
 	OperationLinkBuilder OperationLinkBuilder  { protected get; protected set; }
-	bool OptionalReturn  { public get; public set; }
 	System.Collections.Generic.IEnumerable`1[[Microsoft.AspNet.OData.Builder.ParameterConfiguration]] Parameters  { public virtual get; }
+	bool ReturnNullable  { public get; public set; }
 	IEdmTypeConfiguration ReturnType  { public get; public set; }
 	string Title  { public get; public set; }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This is the continue on for PR #1353.

### Description

Operation (function/action) currently have a property named "OptionalReturn" that returns whether or not the return type is nullable. 

The existing property named "OptionalReturn" on the operation that really means "Nullable" is misleading, and makes it hard to expose true optional parameters through WebAPI OData.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
1353