### PR TITLE
Only add Instance for the select all binder for perf

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -318,13 +318,12 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             wrapperProperty = wrapperType.GetProperty("ModelID");
             wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, Expression.Constant(_modelID)));
 
-            // Initialize property 'Instance' on the wrapper class
-            // source => new Wrapper { Instance = element }
-            wrapperProperty = wrapperType.GetProperty("Instance");
-            wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, source));
-
             if (IsSelectAll(selectExpandClause))
             {
+                // Initialize property 'Instance' on the wrapper class
+                wrapperProperty = wrapperType.GetProperty("Instance");
+                wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, source));
+
                 wrapperProperty = wrapperType.GetProperty("UseInstanceForProperties");
                 wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, Expression.Constant(true)));
                 isInstancePropertySet = true;
@@ -336,6 +335,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 if (typeName != null)
                 {
                     isTypeNamePropertySet = true;
+                    wrapperProperty = wrapperType.GetProperty("InstanceType");
+                    wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, typeName));
                 }
             }
 
@@ -665,7 +666,6 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         internal static Expression CreateTypeNameExpression(Expression source, IEdmEntityType elementType, IEdmModel model)
         {
             IReadOnlyList<IEdmEntityType> derivedTypes = GetAllDerivedTypes(elementType, model);
-
             if (derivedTypes.Count == 0)
             {
                 // no inheritance.

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
@@ -34,6 +34,11 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         public object UntypedInstance { get; set; }
 
         /// <summary>
+        /// Gets or sets the instance type name
+        /// </summary>
+        public string InstanceType { get; set; }
+
+        /// <summary>
         /// Indicates whether the underlying instance can be used to obtain property values.
         /// </summary>
         public bool UseInstanceForProperties { get; set; }
@@ -42,6 +47,13 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         public IEdmTypeReference GetEdmType()
         {
             IEdmModel model = GetModel();
+
+            if (InstanceType != null)
+            {
+                IEdmEntityType entityType = model.FindType(InstanceType) as IEdmEntityType;
+                return entityType.ToEdmTypeReference(true);
+            }
+
             Type elementType = GetElementType();
             return model.GetEdmTypeReference(elementType);
         }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
@@ -78,7 +78,8 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             Assert.True(enumerator.MoveNext());
             var partialCustomer = Assert.IsAssignableFrom<SelectExpandWrapper<Customer>>(enumerator.Current);
             Assert.False(enumerator.MoveNext());
-            Assert.Same(_queryable.Single(), partialCustomer.Instance);
+            Assert.Null(partialCustomer.Instance);
+            Assert.Equal("NS.Customer", partialCustomer.InstanceType);
             IEnumerable<SelectExpandWrapper<Order>> innerOrders = partialCustomer.Container
                 .ToDictionary(mapper)["Orders"] as IEnumerable<SelectExpandWrapper<Order>>;
             Assert.NotNull(innerOrders);
@@ -344,9 +345,11 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
 
             // Assert
             Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
-            Assert.NotEmpty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "Instance"));
+            Assert.Empty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "Instance"));
+            Assert.NotEmpty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "InstanceType"));
             SelectExpandWrapper<Customer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Customer>;
-            Assert.Same(customer, customerWrapper.Instance);
+            Assert.Null(customerWrapper.Instance);
+            Assert.Equal("NS.Customer", customerWrapper.InstanceType);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*  #1387.*

### Description

* Without the changes, when we use $select=xxx, the SQL statement will retrieve all the properties, that's not expected.
* With this change, when we use $select=xxx, only the xxx property will be retrieved.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
