### PR TITLE
Add parameter IEEE754Compatible for input/output json mediaType.

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataMediaTypes.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataMediaTypes.cs
@@ -14,17 +14,42 @@ namespace Microsoft.AspNet.OData.Formatter
     internal static class ODataMediaTypes
     {
         public static readonly string ApplicationJson = "application/json";
+        public static readonly string ApplicationJsonIEEE754CompatibleTrue  = "application/json;IEEE754Compatible=true";
+        public static readonly string ApplicationJsonIEEE754CompatibleFalse = "application/json;IEEE754Compatible=false";
         public static readonly string ApplicationJsonODataFullMetadata = "application/json;odata.metadata=full";
+        public static readonly string ApplicationJsonODataFullMetadataIEEE754CompatibleTrue  = "application/json;odata.metadata=full;IEEE754Compatible=true";
+        public static readonly string ApplicationJsonODataFullMetadataIEEE754CompatibleFalse = "application/json;odata.metadata=full;IEEE754Compatible=false";
         public static readonly string ApplicationJsonODataFullMetadataStreamingFalse = "application/json;odata.metadata=full;odata.streaming=false";
+        public static readonly string ApplicationJsonODataFullMetadataStreamingFalseIEEE754CompatibleTrue  = "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=true";
+        public static readonly string ApplicationJsonODataFullMetadataStreamingFalseIEEE754CompatibleFalse = "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=false";
         public static readonly string ApplicationJsonODataFullMetadataStreamingTrue = "application/json;odata.metadata=full;odata.streaming=true";
+        public static readonly string ApplicationJsonODataFullMetadataStreamingTrueIEEE754CompatibleTrue  = "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=true";
+        public static readonly string ApplicationJsonODataFullMetadataStreamingTrueIEEE754CompatibleFalse = "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=false";
         public static readonly string ApplicationJsonODataMinimalMetadata = "application/json;odata.metadata=minimal";
+        public static readonly string ApplicationJsonODataMinimalMetadataIEEE754CompatibleTrue  = "application/json;odata.metadata=minimal;IEEE754Compatible=true";
+        public static readonly string ApplicationJsonODataMinimalMetadataIEEE754CompatibleFalse = "application/json;odata.metadata=minimal;IEEE754Compatible=false";
         public static readonly string ApplicationJsonODataMinimalMetadataStreamingFalse = "application/json;odata.metadata=minimal;odata.streaming=false";
+        public static readonly string ApplicationJsonODataMinimalMetadataStreamingFalseIEEE754CompatibleTrue  = "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=true";
+        public static readonly string ApplicationJsonODataMinimalMetadataStreamingFalseIEEE754CompatibleFalse = "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=false";
         public static readonly string ApplicationJsonODataMinimalMetadataStreamingTrue = "application/json;odata.metadata=minimal;odata.streaming=true";
+        public static readonly string ApplicationJsonODataMinimalMetadataStreamingTrueIEEE754CompatibleTrue  = "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=true";
+        public static readonly string ApplicationJsonODataMinimalMetadataStreamingTrueIEEE754CompatibleFalse = "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false";
         public static readonly string ApplicationJsonODataNoMetadata = "application/json;odata.metadata=none";
+        public static readonly string ApplicationJsonODataNoMetadataIEEE754CompatibleTrue  = "application/json;odata.metadata=none;IEEE754Compatible=true";
+        public static readonly string ApplicationJsonODataNoMetadataIEEE754CompatibleFalse = "application/json;odata.metadata=none;IEEE754Compatible=false";
         public static readonly string ApplicationJsonODataNoMetadataStreamingFalse = "application/json;odata.metadata=none;odata.streaming=false";
+        public static readonly string ApplicationJsonODataNoMetadataStreamingFalseIEEE754CompatibleTrue  = "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=true";
+        public static readonly string ApplicationJsonODataNoMetadataStreamingFalseIEEE754CompatibleFalse = "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=false";
         public static readonly string ApplicationJsonODataNoMetadataStreamingTrue = "application/json;odata.metadata=none;odata.streaming=true";
+        public static readonly string ApplicationJsonODataNoMetadataStreamingTrueIEEE754CompatibleTrue  = "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=true";
+        public static readonly string ApplicationJsonODataNoMetadataStreamingTrueIEEE754CompatibleFalse = "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false";
         public static readonly string ApplicationJsonStreamingFalse = "application/json;odata.streaming=false";
+        public static readonly string ApplicationJsonStreamingFalseIEEE754CompatibleTrue  = "application/json;odata.streaming=false;IEEE754Compatible=true";
+        public static readonly string ApplicationJsonStreamingFalseIEEE754CompatibleFalse = "application/json;odata.streaming=false;IEEE754Compatible=false";
         public static readonly string ApplicationJsonStreamingTrue = "application/json;odata.streaming=true";
+        public static readonly string ApplicationJsonStreamingTrueIEEE754CompatibleTrue  = "application/json;odata.streaming=true;IEEE754Compatible=true";
+        public static readonly string ApplicationJsonStreamingTrueIEEE754CompatibleFalse = "application/json;odata.streaming=true;IEEE754Compatible=false";
+
         public static readonly string ApplicationXml = "application/xml";
 
         public static ODataMetadataLevel GetMetadataLevel(string mediaType, IEnumerable<KeyValuePair<string, string>> parameters)

--- a/src/Microsoft.AspNet.OData/Formatter/ODataMediaTypeFormatters.cs
+++ b/src/Microsoft.AspNet.OData/Formatter/ODataMediaTypeFormatters.cs
@@ -69,17 +69,43 @@ namespace Microsoft.AspNet.OData.Formatter
 
             // Add minimal metadata as the first media type so it gets used when the request doesn't
             // ask for a specific content type
+            // IEEE754Compatible default value: false. Add more specific media types first so that best match
+            // is always hit first during enumeration.
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrueIEEE754CompatibleFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrueIEEE754CompatibleTrue));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrue));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalseIEEE754CompatibleFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalseIEEE754CompatibleTrue));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataMinimalMetadataIEEE754CompatibleFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataMinimalMetadataIEEE754CompatibleTrue));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataMinimalMetadata));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrueIEEE754CompatibleFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrueIEEE754CompatibleTrue));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrue));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalseIEEE754CompatibleFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalseIEEE754CompatibleTrue));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataFullMetadataIEEE754CompatibleFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataFullMetadataIEEE754CompatibleTrue));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataFullMetadata));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrueIEEE754CompatibleFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrueIEEE754CompatibleTrue));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrue));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalseIEEE754CompatibleFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalseIEEE754CompatibleTrue));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataNoMetadataIEEE754CompatibleFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataNoMetadataIEEE754CompatibleTrue));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonODataNoMetadata));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonStreamingTrueIEEE754CompatibleFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonStreamingTrueIEEE754CompatibleTrue));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonStreamingTrue));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonStreamingFalseIEEE754CompatibleFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonStreamingFalseIEEE754CompatibleTrue));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonStreamingFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonIEEE754CompatibleFalse));
+            formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJsonIEEE754CompatibleTrue));
             formatter.SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse(ODataMediaTypes.ApplicationJson));
 
             formatter.AddDollarFormatQueryStringMappings();

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatterFactory.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatterFactory.cs
@@ -56,17 +56,43 @@ namespace Microsoft.AspNet.OData.Formatter
 
             // Add minimal metadata as the first media type so it gets used when the request doesn't
             // ask for a specific content type
+            // IEEE754Compatible default value: false. Add more specific media types first so that best match 
+            // is always hit first during enumeration.
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrueIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrueIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrue);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalseIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalseIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrueIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrueIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrue);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalseIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalseIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadata);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrueIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrueIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrue);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalseIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalseIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadata);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonStreamingTrueIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonStreamingTrueIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonStreamingTrue);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonStreamingFalseIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonStreamingFalseIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonStreamingFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJson);
 
             return formatter;

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterFactory.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatterFactory.cs
@@ -68,17 +68,42 @@ namespace Microsoft.AspNet.OData.Formatter
 
             // Add minimal metadata as the first media type so it gets used when the request doesn't
             // ask for a specific content type
+            // Add more specific media types first so that best match is always hit first during enumeration.
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrueIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrueIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrue);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalseIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalseIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadataIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrueIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrueIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrue);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalseIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalseIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadataIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataFullMetadata);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrueIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrueIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrue);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalseIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalseIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadataIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonODataNoMetadata);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonStreamingTrueIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonStreamingTrueIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonStreamingTrue);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonStreamingFalseIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonStreamingFalseIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonStreamingFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonIEEE754CompatibleFalse);
+            formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJsonIEEE754CompatibleTrue);
             formatter.SupportedMediaTypes.Add(ODataMediaTypes.ApplicationJson);
 
             formatter.AddDollarFormatQueryStringMappings();

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataMediaTypeFormattersTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataMediaTypeFormattersTests.cs
@@ -46,6 +46,47 @@ namespace Microsoft.AspNet.OData.Test.Formatter
 {
     public class ODataMediaTypeFormattersTests
     {
+
+        private static string[] expectedSupportedJsonMediaTypes =
+            {
+                "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false",
+                "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=true",
+                "application/json;odata.metadata=minimal;odata.streaming=true",
+                "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=false",
+                "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=true",
+                "application/json;odata.metadata=minimal;odata.streaming=false",
+                "application/json;odata.metadata=minimal;IEEE754Compatible=false",
+                "application/json;odata.metadata=minimal;IEEE754Compatible=true",
+                "application/json;odata.metadata=minimal",
+                "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=false",
+                "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=true",
+                "application/json;odata.metadata=full;odata.streaming=true",
+                "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=false",
+                "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=true",
+                "application/json;odata.metadata=full;odata.streaming=false",
+                "application/json;odata.metadata=full;IEEE754Compatible=false",
+                "application/json;odata.metadata=full;IEEE754Compatible=true",
+                "application/json;odata.metadata=full",
+                "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false",
+                "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=true",
+                "application/json;odata.metadata=none;odata.streaming=true",
+                "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=false",
+                "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=true",
+                "application/json;odata.metadata=none;odata.streaming=false",
+                "application/json;odata.metadata=none;IEEE754Compatible=false",
+                "application/json;odata.metadata=none;IEEE754Compatible=true",
+                "application/json;odata.metadata=none",
+                "application/json;odata.streaming=true;IEEE754Compatible=false",
+                "application/json;odata.streaming=true;IEEE754Compatible=true",
+                "application/json;odata.streaming=true",
+                "application/json;odata.streaming=false;IEEE754Compatible=false",
+                "application/json;odata.streaming=false;IEEE754Compatible=true",
+                "application/json;odata.streaming=false",
+                "application/json;IEEE754Compatible=false",
+                "application/json;IEEE754Compatible=true",
+                "application/json",
+            };
+
         [Fact]
         public void TestCreate_CombinedFormatters_SupportedEncodings()
         {
@@ -77,22 +118,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             var supportedMediaTypes = formatters.SelectMany(f => f.SupportedMediaTypes).Distinct();
 
             // Assert
-            var expectedMediaTypes = GetMediaTypes(new string[]
-            {
-                "application/json;odata.metadata=minimal;odata.streaming=true",
-                "application/json;odata.metadata=minimal;odata.streaming=false",
-                "application/json;odata.metadata=minimal",
-                "application/json;odata.metadata=full;odata.streaming=true",
-                "application/json;odata.metadata=full;odata.streaming=false",
-                "application/json;odata.metadata=full",
-                "application/json;odata.metadata=none;odata.streaming=true",
-                "application/json;odata.metadata=none;odata.streaming=false",
-                "application/json;odata.metadata=none",
-                "application/json;odata.streaming=true",
-                "application/json;odata.streaming=false",
-                "application/json",
-                "application/xml"
-            });
+            string[] expectedSupportedMediaType = expectedSupportedJsonMediaTypes.Concat(new string[] {"application/xml" }).ToArray();
+            var expectedMediaTypes = GetMediaTypes(expectedSupportedMediaType);
 
             Assert.True(expectedMediaTypes.SequenceEqual(supportedMediaTypes));
         }
@@ -112,21 +139,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
                 f => f.SupportedMediaTypes).Distinct();
 
             // Assert
-            var expectedMediaTypes = GetMediaTypes(new string[]
-            {
-                "application/json;odata.metadata=minimal;odata.streaming=true",
-                "application/json;odata.metadata=minimal;odata.streaming=false",
-                "application/json;odata.metadata=minimal",
-                "application/json;odata.metadata=full;odata.streaming=true",
-                "application/json;odata.metadata=full;odata.streaming=false",
-                "application/json;odata.metadata=full",
-                "application/json;odata.metadata=none;odata.streaming=true",
-                "application/json;odata.metadata=none;odata.streaming=false",
-                "application/json;odata.metadata=none",
-                "application/json;odata.streaming=true",
-                "application/json;odata.streaming=false",
-                "application/json",
-            });
+            var expectedMediaTypes = GetMediaTypes(expectedSupportedJsonMediaTypes);
 
             Assert.True(expectedMediaTypes.SequenceEqual(supportedMediaTypes));
         }
@@ -146,21 +159,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
                 f => f.SupportedMediaTypes).Distinct();
 
             // Assert
-            var expectedMediaTypes = GetMediaTypes(new string[]
-            {
-                "application/json;odata.metadata=minimal;odata.streaming=true",
-                "application/json;odata.metadata=minimal;odata.streaming=false",
-                "application/json;odata.metadata=minimal",
-                "application/json;odata.metadata=full;odata.streaming=true",
-                "application/json;odata.metadata=full;odata.streaming=false",
-                "application/json;odata.metadata=full",
-                "application/json;odata.metadata=none;odata.streaming=true",
-                "application/json;odata.metadata=none;odata.streaming=false",
-                "application/json;odata.metadata=none",
-                "application/json;odata.streaming=true",
-                "application/json;odata.streaming=false",
-                "application/json",
-            });
+            var expectedMediaTypes = GetMediaTypes(expectedSupportedJsonMediaTypes);
 
             Assert.True(expectedMediaTypes.SequenceEqual(supportedMediaTypes));
         }
@@ -180,21 +179,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
                 f => f.SupportedMediaTypes).Distinct();
 
             // Assert
-            var expectedMediaTypes = GetMediaTypes(new string[]
-            {
-                "application/json;odata.metadata=minimal;odata.streaming=true",
-                "application/json;odata.metadata=minimal;odata.streaming=false",
-                "application/json;odata.metadata=minimal",
-                "application/json;odata.metadata=full;odata.streaming=true",
-                "application/json;odata.metadata=full;odata.streaming=false",
-                "application/json;odata.metadata=full",
-                "application/json;odata.metadata=none;odata.streaming=true",
-                "application/json;odata.metadata=none;odata.streaming=false",
-                "application/json;odata.metadata=none",
-                "application/json;odata.streaming=true",
-                "application/json;odata.streaming=false",
-                "application/json",
-            });
+            var expectedMediaTypes = GetMediaTypes(expectedSupportedJsonMediaTypes);
 
             Assert.True(expectedMediaTypes.SequenceEqual(supportedMediaTypes));
         }
@@ -214,21 +199,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
                 f => f.SupportedMediaTypes).Distinct();
 
             // Assert
-            var expectedMediaTypes = GetMediaTypes(new string[]
-            {
-                "application/json;odata.metadata=minimal;odata.streaming=true",
-                "application/json;odata.metadata=minimal;odata.streaming=false",
-                "application/json;odata.metadata=minimal",
-                "application/json;odata.metadata=full;odata.streaming=true",
-                "application/json;odata.metadata=full;odata.streaming=false",
-                "application/json;odata.metadata=full",
-                "application/json;odata.metadata=none;odata.streaming=true",
-                "application/json;odata.metadata=none;odata.streaming=false",
-                "application/json;odata.metadata=none",
-                "application/json;odata.streaming=true",
-                "application/json;odata.streaming=false",
-                "application/json",
-            });
+            var expectedMediaTypes = GetMediaTypes(expectedSupportedJsonMediaTypes);
 
             Assert.True(expectedMediaTypes.SequenceEqual(supportedMediaTypes));
         }
@@ -248,21 +219,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
                 f => f.SupportedMediaTypes).Distinct();
 
             // Assert
-            var expectedMediaTypes = GetMediaTypes(new string[]
-            {
-                "application/json;odata.metadata=minimal;odata.streaming=true",
-                "application/json;odata.metadata=minimal;odata.streaming=false",
-                "application/json;odata.metadata=minimal",
-                "application/json;odata.metadata=full;odata.streaming=true",
-                "application/json;odata.metadata=full;odata.streaming=false",
-                "application/json;odata.metadata=full",
-                "application/json;odata.metadata=none;odata.streaming=true",
-                "application/json;odata.metadata=none;odata.streaming=false",
-                "application/json;odata.metadata=none",
-                "application/json;odata.streaming=true",
-                "application/json;odata.streaming=false",
-                "application/json",
-            });
+            var expectedMediaTypes = GetMediaTypes(expectedSupportedJsonMediaTypes);
 
             Assert.True(expectedMediaTypes.SequenceEqual(supportedMediaTypes));
         }
@@ -282,21 +239,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
                 f => f.SupportedMediaTypes).Distinct();
 
             // Assert
-            var expectedMediaTypes = GetMediaTypes(new string[]
-            {
-                "application/json;odata.metadata=minimal;odata.streaming=true",
-                "application/json;odata.metadata=minimal;odata.streaming=false",
-                "application/json;odata.metadata=minimal",
-                "application/json;odata.metadata=full;odata.streaming=true",
-                "application/json;odata.metadata=full;odata.streaming=false",
-                "application/json;odata.metadata=full",
-                "application/json;odata.metadata=none;odata.streaming=true",
-                "application/json;odata.metadata=none;odata.streaming=false",
-                "application/json;odata.metadata=none",
-                "application/json;odata.streaming=true",
-                "application/json;odata.streaming=false",
-                "application/json",
-            });
+            var expectedMediaTypes = GetMediaTypes(expectedSupportedJsonMediaTypes);
 
             Assert.True(expectedMediaTypes.SequenceEqual(supportedMediaTypes));
         }
@@ -339,21 +282,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
                 f => f.SupportedMediaTypes).Distinct();
 
             // Assert
-            var expectedMediaTypes = GetMediaTypes(new string[]
-            {
-                "application/json;odata.metadata=minimal;odata.streaming=true",
-                "application/json;odata.metadata=minimal;odata.streaming=false",
-                "application/json;odata.metadata=minimal",
-                "application/json;odata.metadata=full;odata.streaming=true",
-                "application/json;odata.metadata=full;odata.streaming=false",
-                "application/json;odata.metadata=full",
-                "application/json;odata.metadata=none;odata.streaming=true",
-                "application/json;odata.metadata=none;odata.streaming=false",
-                "application/json;odata.metadata=none",
-                "application/json;odata.streaming=true",
-                "application/json;odata.streaming=false",
-                "application/json",
-            });
+            var expectedMediaTypes = GetMediaTypes(expectedSupportedJsonMediaTypes);
 
             Assert.True(expectedMediaTypes.SequenceEqual(supportedMediaTypes));
         }
@@ -372,23 +301,9 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             var supportedMediaTypes = parameterFormatters.SelectMany(f => f.SupportedMediaTypes).Distinct();
 
             // Assert
-            var expectedMediaTypes = GetMediaTypes(new string[]
-            {
-                "application/json;odata.metadata=minimal;odata.streaming=true",
-                "application/json;odata.metadata=minimal;odata.streaming=false",
-                "application/json;odata.metadata=minimal",
-                "application/json;odata.metadata=full;odata.streaming=true",
-                "application/json;odata.metadata=full;odata.streaming=false",
-                "application/json;odata.metadata=full",
-                "application/json;odata.metadata=none;odata.streaming=true",
-                "application/json;odata.metadata=none;odata.streaming=false",
-                "application/json;odata.metadata=none",
-                "application/json;odata.streaming=true",
-                "application/json;odata.streaming=false",
-                "application/json",
-            });
+            var expectedMediaTypes = GetMediaTypes(expectedSupportedJsonMediaTypes);
 
-            Assert.True(expectedMediaTypes.SequenceEqual(supportedMediaTypes));
+            Assert.True(expectedMediaTypes.SequenceEqual(supportedMediaTypes.ToArray()));
         }
 
         [Fact]
@@ -402,7 +317,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             MediaTypeHeaderValue mediaType = GetDefaultContentType(model, feedType);
 
             // Assert
-            Assert.Equal(MediaTypeHeaderValue.Parse("application/json;odata.metadata=minimal;odata.streaming=true"), mediaType);
+            Assert.Equal(MediaTypeHeaderValue.Parse("application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false"), mediaType);
         }
 
         [Fact]
@@ -416,7 +331,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             MediaTypeHeaderValue mediaType = GetDefaultContentType(model, entryType);
 
             // Assert
-            Assert.Equal(MediaTypeHeaderValue.Parse("application/json;odata.metadata=minimal;odata.streaming=true"), mediaType);
+            Assert.Equal(MediaTypeHeaderValue.Parse("application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false"), mediaType);
         }
 
         [Fact]
@@ -430,7 +345,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             MediaTypeHeaderValue mediaType = GetDefaultContentType(model, propertyType);
 
             // Assert
-            Assert.Equal(MediaTypeHeaderValue.Parse("application/json;odata.metadata=minimal;odata.streaming=true"), mediaType);
+            Assert.Equal(MediaTypeHeaderValue.Parse("application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false"), mediaType);
         }
 
         [Fact]
@@ -444,7 +359,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             MediaTypeHeaderValue mediaType = GetDefaultContentType(model, serviceDocumentType);
 
             // Assert
-            Assert.Equal(MediaTypeHeaderValue.Parse("application/json;odata.metadata=minimal;odata.streaming=true"), mediaType);
+            Assert.Equal(MediaTypeHeaderValue.Parse("application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false"), mediaType);
         }
 
         [Fact]
@@ -476,6 +391,31 @@ namespace Microsoft.AspNet.OData.Test.Formatter
         [InlineData("application%2fjson%3bodata.streaming%3dfalse", "application/json;odata.streaming=false")]
         [InlineData("application%2fjson", "application/json")]
         [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bodata.metadata%3dminimal", "application/json;odata.streaming=true;odata.metadata=minimal")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dtrue", "application/json;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dfalse", "application/json;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse%3bodata.streaming%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=false;odata.streaming=true")]
         public void TestCreate_DollarFormat_Feed(string dollarFormatValue, string expectedMediaType)
         {
             // Arrange
@@ -504,6 +444,31 @@ namespace Microsoft.AspNet.OData.Test.Formatter
         [InlineData("application%2fjson%3bodata.streaming%3dfalse", "application/json;odata.streaming=false")]
         [InlineData("application%2fjson", "application/json")]
         [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bodata.metadata%3dminimal", "application/json;odata.streaming=true;odata.metadata=minimal")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dtrue", "application/json;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dfalse", "application/json;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse%3bodata.streaming%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=false;odata.streaming=true")]
         public void TestCreate_DollarFormat_Entry(string dollarFormatValue, string expectedMediaType)
         {
             // Arrange
@@ -532,6 +497,31 @@ namespace Microsoft.AspNet.OData.Test.Formatter
         [InlineData("application%2fjson%3bodata.streaming%3dfalse", "application/json;odata.streaming=false")]
         [InlineData("application%2fjson", "application/json")]
         [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bodata.metadata%3dminimal", "application/json;odata.streaming=true;odata.metadata=minimal")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dtrue", "application/json;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dfalse", "application/json;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse%3bodata.streaming%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=false;odata.streaming=true")]
         public void TestCreate_DollarFormat_Property(string dollarFormatValue, string expectedMediaType)
         {
             // Arrange
@@ -560,6 +550,31 @@ namespace Microsoft.AspNet.OData.Test.Formatter
         [InlineData("application%2fjson%3bodata.streaming%3dfalse", "application/json;odata.streaming=false")]
         [InlineData("application%2fjson", "application/json")]
         [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bodata.metadata%3dminimal", "application/json;odata.streaming=true;odata.metadata=minimal")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dtrue", "application/json;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dfalse", "application/json;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse%3bodata.streaming%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=false;odata.streaming=true")]
         public void TestCreate_DollarFormat_EntityReferenceLink(string dollarFormatValue, string expectedMediaType)
         {
             // Arrange
@@ -588,6 +603,31 @@ namespace Microsoft.AspNet.OData.Test.Formatter
         [InlineData("application%2fjson%3bodata.streaming%3dfalse", "application/json;odata.streaming=false")]
         [InlineData("application%2fjson", "application/json")]
         [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bodata.metadata%3dminimal", "application/json;odata.streaming=true;odata.metadata=minimal")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dtrue", "application/json;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dfalse", "application/json;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse%3bodata.streaming%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=false;odata.streaming=true")]
         public void TestCreate_DollarFormat_Collection(string dollarFormatValue, string expectedMediaType)
         {
             // Arrange
@@ -616,6 +656,31 @@ namespace Microsoft.AspNet.OData.Test.Formatter
         [InlineData("application%2fjson%3bodata.streaming%3dfalse", "application/json;odata.streaming=false")]
         [InlineData("application%2fjson", "application/json")]
         [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bodata.metadata%3dminimal", "application/json;odata.streaming=true;odata.metadata=minimal")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dtrue", "application/json;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dfalse", "application/json;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse%3bodata.streaming%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=false;odata.streaming=true")]
         public void TestCreate_DollarFormat_ServiceDocument(string dollarFormatValue, string expectedMediaType)
         {
             // Arrange
@@ -660,6 +725,31 @@ namespace Microsoft.AspNet.OData.Test.Formatter
         [InlineData("application%2fjson%3bodata.streaming%3dfalse", "application/json;odata.streaming=false")]
         [InlineData("application%2fjson", "application/json")]
         [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bodata.metadata%3dminimal", "application/json;odata.streaming=true;odata.metadata=minimal")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=minimal;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dminimal%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=minimal;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=full;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dtrue", "application/json;odata.metadata=none;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.metadata%3dnone%3bIEEE754Compatible%3dfalse", "application/json;odata.metadata=none;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=true;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dtrue%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=true;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dtrue", "application/json;odata.streaming=false;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bodata.streaming%3dfalse%3bIEEE754Compatible%3dfalse", "application/json;odata.streaming=false;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dtrue", "application/json;IEEE754Compatible=true")]
+        [InlineData("application%2fjson%3bIEEE754Compatible%3dfalse", "application/json;IEEE754Compatible=false")]
+        [InlineData("application%2fjson%3bodata.metadata%3dfull%3bIEEE754Compatible%3dfalse%3bodata.streaming%3dtrue", "application/json;odata.metadata=full;IEEE754Compatible=false;odata.streaming=true")]
         public void TestCreate_DollarFormat_Error(string dollarFormatValue, string expectedMediaType)
         {
             // Arrange

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataMediaTypesTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataMediaTypesTest.cs
@@ -14,89 +14,233 @@ namespace Microsoft.Test.OData.WebApi.AspNet.Formatter
         [Fact]
         public void ApplicationJson_Value()
         {
-            Assert.Equal("application/json", ODataMediaTypes.ApplicationJson.ToString());
+            Assert.Equal("application/json", ODataMediaTypes.ApplicationJson);
         }
 
         [Fact]
         public void ApplicationJsonODataFullMetadata_Value()
         {
             Assert.Equal("application/json;odata.metadata=full",
-                ODataMediaTypes.ApplicationJsonODataFullMetadata.ToString());
+                ODataMediaTypes.ApplicationJsonODataFullMetadata);
         }
 
         [Fact]
         public void ApplicationJsonODataFullMetadataStreamingFalse_Value()
         {
             Assert.Equal("application/json;odata.metadata=full;odata.streaming=false",
-                ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalse.ToString());
+                ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalse);
         }
 
         [Fact]
         public void ApplicationJsonODataFullMetadataStreamingTrue_Value()
         {
             Assert.Equal("application/json;odata.metadata=full;odata.streaming=true",
-                ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrue.ToString());
+                ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrue);
         }
 
         [Fact]
         public void ApplicationJsonODataMinimalMetadata_Value()
         {
             Assert.Equal("application/json;odata.metadata=minimal",
-                ODataMediaTypes.ApplicationJsonODataMinimalMetadata.ToString());
+                ODataMediaTypes.ApplicationJsonODataMinimalMetadata);
         }
 
         [Fact]
         public void ApplicationJsonODataMinimalMetadataStreamingFalse_Value()
         {
             Assert.Equal("application/json;odata.metadata=minimal;odata.streaming=false",
-                ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalse.ToString());
+                ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalse);
         }
 
         [Fact]
         public void ApplicationJsonODataMinimalMetadataStreamingTrue_Value()
         {
             Assert.Equal("application/json;odata.metadata=minimal;odata.streaming=true",
-                ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrue.ToString());
+                ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrue);
         }
 
         [Fact]
         public void ApplicationJsonODataNoMetadata_Value()
         {
             Assert.Equal("application/json;odata.metadata=none",
-                ODataMediaTypes.ApplicationJsonODataNoMetadata.ToString());
+                ODataMediaTypes.ApplicationJsonODataNoMetadata);
         }
 
         [Fact]
         public void ApplicationJsonODataNoMetadataStreamingFalse_Value()
         {
             Assert.Equal("application/json;odata.metadata=none;odata.streaming=false",
-                ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalse.ToString());
+                ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalse);
         }
 
         [Fact]
         public void ApplicationJsonODataNoMetadataStreamingTrue_Value()
         {
             Assert.Equal("application/json;odata.metadata=none;odata.streaming=true",
-                ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrue.ToString());
+                ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrue);
         }
 
         [Fact]
         public void ApplicationJsonStreamingFalse_Value()
         {
             Assert.Equal("application/json;odata.streaming=false",
-                ODataMediaTypes.ApplicationJsonStreamingFalse.ToString());
+                ODataMediaTypes.ApplicationJsonStreamingFalse);
         }
 
         [Fact]
         public void ApplicationJsonStreamingTrue_Value()
         {
-            Assert.Equal("application/json;odata.streaming=true", ODataMediaTypes.ApplicationJsonStreamingTrue.ToString());
+            Assert.Equal("application/json;odata.streaming=true", ODataMediaTypes.ApplicationJsonStreamingTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonIEEE754CompatibleTrue_Value()
+        {
+            Assert.Equal("application/json;IEEE754Compatible=true", ODataMediaTypes.ApplicationJsonIEEE754CompatibleTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonIEEE754CompatibleFalse_Value()
+        {
+            Assert.Equal("application/json;IEEE754Compatible=false", ODataMediaTypes.ApplicationJsonIEEE754CompatibleFalse);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataFullMetadataIEEE754CompatibleTrue_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=full;IEEE754Compatible=true", ODataMediaTypes.ApplicationJsonODataFullMetadataIEEE754CompatibleTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataFullMetadataIEEE754CompatibleFalse_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=full;IEEE754Compatible=false", ODataMediaTypes.ApplicationJsonODataFullMetadataIEEE754CompatibleFalse);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataFullMetadataStreamingFalseIEEE754CompatibleTrue_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=true", ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalseIEEE754CompatibleTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataFullMetadataStreamingFalseIEEE754CompatibleFalse_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=full;odata.streaming=false;IEEE754Compatible=false", ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingFalseIEEE754CompatibleFalse);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataFullMetadataStreamingTrueIEEE754CompatibleTrue_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=true", ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrueIEEE754CompatibleTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataFullMetadataStreamingTrueIEEE754CompatibleFalse_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=full;odata.streaming=true;IEEE754Compatible=false", ODataMediaTypes.ApplicationJsonODataFullMetadataStreamingTrueIEEE754CompatibleFalse);
+        }
+
+         [Fact]
+        public void ApplicationJsonODataMinimalMetadataIEEE754CompatibleTrue_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=minimal;IEEE754Compatible=true", ODataMediaTypes.ApplicationJsonODataMinimalMetadataIEEE754CompatibleTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataMinimalMetadataIEEE754CompatibleFalse_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=minimal;IEEE754Compatible=false", ODataMediaTypes.ApplicationJsonODataMinimalMetadataIEEE754CompatibleFalse);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataMinimalMetadataStreamingFalseIEEE754CompatibleTrue_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=true", ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalseIEEE754CompatibleTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataMinimalMetadataStreamingFalseIEEE754CompatibleFalse_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=minimal;odata.streaming=false;IEEE754Compatible=false", ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingFalseIEEE754CompatibleFalse);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataMinimalMetadataStreamingTrueIEEE754CompatibleTrue_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=true", ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrueIEEE754CompatibleTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataMinimalMetadataStreamingTrueIEEE754CompatibleFalse_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false", ODataMediaTypes.ApplicationJsonODataMinimalMetadataStreamingTrueIEEE754CompatibleFalse);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataNoMetadataIEEE754CompatibleTrue_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=none;IEEE754Compatible=true", ODataMediaTypes.ApplicationJsonODataNoMetadataIEEE754CompatibleTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataNoMetadataIEEE754CompatibleFalse_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=none;IEEE754Compatible=false", ODataMediaTypes.ApplicationJsonODataNoMetadataIEEE754CompatibleFalse);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataNoMetadataStreamingFalseIEEE754CompatibleTrue_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=true", ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalseIEEE754CompatibleTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataNoMetadataStreamingFalseIEEE754CompatibleFalse_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=none;odata.streaming=false;IEEE754Compatible=false", ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingFalseIEEE754CompatibleFalse);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataNoMetadataStreamingTrueIEEE754CompatibleTrue_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=true", ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrueIEEE754CompatibleTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonODataNoMetadataStreamingTrueIEEE754CompatibleFalse_Value()
+        {
+            Assert.Equal("application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false", ODataMediaTypes.ApplicationJsonODataNoMetadataStreamingTrueIEEE754CompatibleFalse);
+        }
+
+        [Fact]
+        public void ApplicationJsonStreamingFalseIEEE754CompatibleTrue_Value()
+        {
+            Assert.Equal("application/json;odata.streaming=false;IEEE754Compatible=true", ODataMediaTypes.ApplicationJsonStreamingFalseIEEE754CompatibleTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonStreamingFalseIEEE754CompatibleFalse_Value()
+        {
+            Assert.Equal("application/json;odata.streaming=false;IEEE754Compatible=false", ODataMediaTypes.ApplicationJsonStreamingFalseIEEE754CompatibleFalse);
+        }
+
+        [Fact]
+        public void ApplicationJsonStreamingTrueIEEE754CompatibleTrue_Value()
+        {
+            Assert.Equal("application/json;odata.streaming=true;IEEE754Compatible=true", ODataMediaTypes.ApplicationJsonStreamingTrueIEEE754CompatibleTrue);
+        }
+
+        [Fact]
+        public void ApplicationJsonStreamingTrueIEEE754CompatibleFalse_Value()
+        {
+            Assert.Equal("application/json;odata.streaming=true;IEEE754Compatible=false", ODataMediaTypes.ApplicationJsonStreamingTrueIEEE754CompatibleFalse);
         }
 
         [Fact]
         public void ApplicationXml_Value()
         {
-            Assert.Equal("application/xml", ODataMediaTypes.ApplicationXml.ToString());
+            Assert.Equal("application/xml", ODataMediaTypes.ApplicationXml);
         }
 
         [Theory]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1460.*

### Description

*Made IEEE754Compatable parameter available to input/output ODataFormattere's supported Json media types. Default value is false, i.e. Int64 and Decimal numbers are not represented as strings.*
Added to both AspNet.OData and AspNetCore.OData.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
