### PR TITLE
Return Task<> from method of controller doesn't pick up odata output formatter

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/TypeHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/TypeHelper.cs
@@ -456,6 +456,16 @@ namespace Microsoft.AspNet.OData
             return result;
         }
 
+        internal static Type GetTaskInnerTypeOrSelf(Type type)
+        {
+            if (IsGenericType(type) && type.GetGenericTypeDefinition() == typeof(Task<>))
+            {
+                return type.GetGenericArguments().First();
+            }
+
+            return type;
+        }
+
         private static Type GetInnerGenericType(Type interfaceType)
         {
             // Getting the type T definition if the returning type implements IEnumerable<T>

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
@@ -112,6 +112,7 @@ namespace Microsoft.AspNet.OData.Formatter
             {
                 return false;
             }
+            type = TypeHelper.GetTaskInnerTypeOrSelf(type);
 
             ODataSerializerProvider serializerProvider = request.GetRequestContainer().GetRequiredService<ODataSerializerProvider>();
 
@@ -145,6 +146,7 @@ namespace Microsoft.AspNet.OData.Formatter
             {
                 throw Error.ArgumentNull("type");
             }
+            type = TypeHelper.GetTaskInnerTypeOrSelf(type);
 
             HttpRequest request = context.HttpContext.Request;
             if (request == null)
@@ -192,6 +194,7 @@ namespace Microsoft.AspNet.OData.Formatter
             {
                 throw Error.ArgumentNull("type");
             }
+            type = TypeHelper.GetTaskInnerTypeOrSelf(type);
 
             HttpRequest request = context.HttpContext.Request;
             if (request == null)

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DateAndTimeOfDay/DateAndTimeOfDayController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DateAndTimeOfDay/DateAndTimeOfDayController.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNet.OData;
 using Microsoft.AspNet.OData.Routing;
 using Microsoft.OData.Edm;
@@ -213,6 +214,12 @@ namespace Microsoft.Test.E2E.AspNet.OData.DateAndTimeOfDay
         public ITestActionResult Get()
         {
             return Ok(_db.People);
+        }
+
+        [EnableQuery]
+        public async Task<TestSingleResult<EfPerson>> Get(int key)
+        {
+            return await Task.FromResult(TestSingleResult.Create(_db.People.Where(c => c.Id == key)));
         }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DateAndTimeOfDay/DateWithEfTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DateAndTimeOfDay/DateWithEfTest.cs
@@ -58,6 +58,20 @@ namespace Microsoft.Test.E2E.AspNet.OData.DateAndTimeOfDay
 
             Assert.Equal(expect, String.Join(",", content["value"].Select(e => e["Id"].ToString())));
         }
+
+        [Fact]
+        public async Task CanQuerySingleEntityFromTaskReturnTypeInControllerOnEf()
+        {
+            string requestUri = string.Format("{0}/odata/EfPeople(1)", BaseAddress);
+
+            HttpResponseMessage response = await Client.GetAsync(requestUri);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            JObject content = await response.Content.ReadAsObject<JObject>();
+
+            Assert.Equal("1", (string)content["Id"]);
+        }
     }
 
     public class MyConverter : ODataPayloadValueConverter


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1498.*

### Description

* In ASP.NET Core version, the type in `CanWriteResult` is the `Task<T>`, it can't pass the `ODataOutputFormatter` 's verification.

* While, in Classic version, the `type` in `CanWriteType(Type)` of `ODataMediaTypeFormatter` is the T of Take<T>.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
