### PR TITLE
issue #1434: add the OData-Version into the No-Content response

### DIFF
--- a/src/Microsoft.AspNet.OData/Results/CreatedODataResult.cs
+++ b/src/Microsoft.AspNet.OData/Results/CreatedODataResult.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNet.OData.Results
             HttpResponseMessage response = await result.ExecuteAsync(cancellationToken);
             response.Headers.Location = LocationHeader;
             ResultHelpers.AddEntityId(response, () => GenerateEntityId(Request));
-
+            ResultHelpers.AddServiceVersion(response, () => ResultHelpers.GetVersionString(Request));
             return response;
         }
 

--- a/src/Microsoft.AspNet.OData/Results/ResultHelpers.cs
+++ b/src/Microsoft.AspNet.OData/Results/ResultHelpers.cs
@@ -9,6 +9,8 @@ using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Formatter;
 using Microsoft.AspNet.OData.Formatter.Serialization;
+using Microsoft.AspNet.OData.Routing;
+using Microsoft.OData;
 using Microsoft.OData.Edm;
 using ODataPath = Microsoft.AspNet.OData.Routing.ODataPath;
 
@@ -60,6 +62,20 @@ namespace Microsoft.AspNet.OData.Results
             {
                 response.Headers.TryAddWithoutValidation(EntityIdHeaderName, entityId().ToString());
             }
+        }
+
+        public static void AddServiceVersion(HttpResponseMessage response, Func<string> version)
+        {
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                response.Headers.TryAddWithoutValidation(ODataVersionConstraint.ODataServiceVersionHeader, version());
+            }
+        }
+
+        internal static string GetVersionString(HttpRequestMessage request)
+        {
+            ODataVersion? serviceVersion = request.ODataProperties().ODataServiceVersion;
+            return ODataUtils.ODataVersionToString(serviceVersion ?? ODataVersionConstraint.DefaultODataVersion);
         }
     }
 }

--- a/src/Microsoft.AspNet.OData/Results/UpdatedODataResult.cs
+++ b/src/Microsoft.AspNet.OData/Results/UpdatedODataResult.cs
@@ -100,7 +100,9 @@ namespace Microsoft.AspNet.OData.Results
         public virtual async Task<HttpResponseMessage> ExecuteAsync(CancellationToken cancellationToken)
         {
             IHttpActionResult result = GetInnerActionResult();
-            return await result.ExecuteAsync(cancellationToken);
+            var response = await result.ExecuteAsync(cancellationToken);
+            ResultHelpers.AddServiceVersion(response, () => ResultHelpers.GetVersionString(Request));
+            return response;
         }
 
         internal IHttpActionResult GetInnerActionResult()

--- a/src/Microsoft.AspNetCore.OData/Results/CreatedODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/CreatedODataResult.cs
@@ -48,6 +48,7 @@ namespace Microsoft.AspNet.OData.Results
             // before calling AddEntityId() to ensure the response code is set correctly.
             await result.ExecuteResultAsync(context);
             ResultHelpers.AddEntityId(response, () => GenerateEntityId(request));
+            ResultHelpers.AddServiceVersion(response, () => ResultHelpers.GetVersionString(request));
         }
 
         // internal just for unit test.

--- a/src/Microsoft.AspNetCore.OData/Results/ResultHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/ResultHelpers.cs
@@ -7,7 +7,9 @@ using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Formatter;
 using Microsoft.AspNet.OData.Formatter.Serialization;
+using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNetCore.Http;
+using Microsoft.OData;
 using Microsoft.OData.Edm;
 using ODataPath = Microsoft.AspNet.OData.Routing.ODataPath;
 
@@ -58,6 +60,19 @@ namespace Microsoft.AspNet.OData.Results
             {
                 response.Headers.Add(EntityIdHeaderName, entityId().ToString());
             }
+        }
+
+        public static void AddServiceVersion(HttpResponse response, Func<string> version)
+        {
+            if (response.StatusCode == (int)HttpStatusCode.NoContent)
+            {
+                response.Headers[ODataVersionConstraint.ODataServiceVersionHeader] = version();
+            }
+        }
+
+        internal static string GetVersionString(HttpRequest request)
+        {
+            return ODataUtils.ODataVersionToString(request.ODataServiceVersion() ?? ODataVersionConstraint.DefaultODataVersion);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Results/UpdatedODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/UpdatedODataResult.cs
@@ -34,11 +34,13 @@ namespace Microsoft.AspNet.OData.Results
         }
 
         /// <inheritdoc/>
-        public virtual Task ExecuteResultAsync(ActionContext context)
+        public async virtual Task ExecuteResultAsync(ActionContext context)
         {
+            HttpResponse response = context.HttpContext.Response;
             HttpRequest request = context.HttpContext.Request;
             IActionResult result = GetInnerActionResult(request);
-            return result.ExecuteResultAsync(context);
+            await result.ExecuteResultAsync(context);
+            ResultHelpers.AddServiceVersion(response, () => ResultHelpers.GetVersionString(request));
         }
 
         internal IActionResult GetInnerActionResult(HttpRequest request)

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceTests.cs
@@ -112,6 +112,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance
                 response.StatusCode,
                 requestUri,
                 contentOfString));
+
+            Assert.Equal("4.0", response.Headers.GetValues("OData-Version").Single());
             JObject contentOfJObject = await response.Content.ReadAsObject<JObject>();
             string name = (string)contentOfJObject["Name"];
             Assert.True("Name4" == name);

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Enums/EnumsTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Enums/EnumsTest.cs
@@ -500,6 +500,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Enums
                     string.Format("Response code is not right, expected: {0}, actual: {1}", HttpStatusCode.NoContent, response.StatusCode));
                 Assert.True(response.Headers.Contains("OData-EntityId"), "The response should contain Header 'OData-EntityId'");
                 Assert.True(response.Headers.Contains("Location"), "The response should contain Header 'Location'");
+                Assert.True(response.Headers.Contains("OData-Version"), "The response should contain Header 'OData-Version'");
             }
         }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -2799,6 +2799,9 @@ public class Microsoft.AspNet.OData.Results.CreatedODataResult`1 : IActionResult
 public class Microsoft.AspNet.OData.Results.UpdatedODataResult`1 : IActionResult {
 	public UpdatedODataResult`1 (T entity)
 
+	[
+	AsyncStateMachineAttribute(),
+	]
 	public virtual System.Threading.Tasks.Task ExecuteResultAsync (Microsoft.AspNetCore.Mvc.ActionContext context)
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* https://github.com/OData/WebApi/issues/1434

### Description

* Add the `OData-Version` into No-Content response.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
