### PR TITLE
downgrade the newtonsoft.json version to 6.0.4 for classic

### DIFF
--- a/samples/AspNetODataSample.Web/Web.config
+++ b/samples/AspNetODataSample.Web/Web.config
@@ -44,10 +44,6 @@
         <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.3" newVersion="10.0.3" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>

--- a/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
+++ b/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
@@ -37,8 +37,8 @@
       <HintPath>..\..\sln\packages\Microsoft.Spatial.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Microsoft.AspNet.OData/packages.config
+++ b/src/Microsoft.AspNet.OData/packages.config
@@ -7,5 +7,5 @@
   <package id="Microsoft.OData.Core" version="7.5.0" targetFramework="net45" />
   <package id="Microsoft.OData.Edm" version="7.5.0" targetFramework="net45" />
   <package id="Microsoft.Spatial" version="7.5.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/App.config
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/App.config
@@ -53,10 +53,7 @@
         <assemblyIdentity name="NuGet.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.7.41101.299" newVersion="2.7.41101.299" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
-      </dependentAssembly>
+
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -66,8 +66,8 @@
       <HintPath>..\..\..\..\sln\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\sln\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/packages.config
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/packages.config
@@ -20,7 +20,7 @@
   <package id="Microsoft.Spatial" version="7.5.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="System.Collections" version="4.3.0" targetFramework="net45" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/Microsoft.AspNet.OData.Test.csproj
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/Microsoft.AspNet.OData.Test.csproj
@@ -48,8 +48,8 @@
       <HintPath>..\..\..\sln\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/app.config
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/app.config
@@ -2,10 +2,6 @@
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/packages.config
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.Spatial" version="7.5.0" targetFramework="net452" />
   <package id="Moq" version="4.7.137" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />
   <package id="System.Collections" version="4.3.0" targetFramework="net45" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue https://github.com/OData/WebApi/issues/1518.*

### Description

Microsoft.AspNet.OData has a reference to Microsoft.AspNet.WebApi.Client package, which has a reference to newtonsoft.json as version >= 6.0.4

![image](https://user-images.githubusercontent.com/9426627/42349746-8289093c-8062-11e8-8e4b-2d843cedda0b.png)

However, Microsoft.AspNet.OData itself has a reference to newtonsoft.json as version = 10.0.3.

So, there is a conflict. We should downgrade the reference to 6.0.4.


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
