### PR TITLE
Add UseOData() extension methods for IApplicationBuilder

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/ODataApplicationBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ODataApplicationBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNet.OData.Batch;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.OData.Edm;
 
 namespace Microsoft.AspNet.OData.Extensions
 {
@@ -12,8 +13,20 @@ namespace Microsoft.AspNet.OData.Extensions
     /// </summary>
     public static class ODataApplicationBuilderExtensions
     {
+        private static readonly int MaxTop = 100;
+
         /// <summary>
-        /// USe OData batching middleware.
+        /// The default OData route name.
+        /// </summary>
+        public readonly static string DefaultRouteName = "odata";
+
+        /// <summary>
+        /// The default OData route prefix.
+        /// </summary>
+        public readonly static string DefaultRoutePrefix = "odata";
+
+        /// <summary>
+        /// Use OData batching middleware.
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder "/> to use.</param>
         /// <returns>The <see cref="IApplicationBuilder "/>.</returns>
@@ -25,6 +38,51 @@ namespace Microsoft.AspNet.OData.Extensions
             }
 
             return app.UseMiddleware<ODataBatchMiddleware>();
+        }
+
+        /// <summary>
+        /// Use OData route with default route name and route prefix.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder "/> to use.</param>
+        /// <param name="model">The <see cref="IEdmModel"/> to use.</param>
+        /// <returns>The <see cref="IApplicationBuilder "/>.</returns>
+        public static IApplicationBuilder UseOData(this IApplicationBuilder app, IEdmModel model)
+        {
+            return app.UseOData(DefaultRouteName, DefaultRoutePrefix, model);
+        }
+
+        /// <summary>
+        /// Use OData route with given route name and route prefix.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder "/> to use.</param>
+        /// <param name="routeName">The given OData route name.</param>
+        /// <param name="routePrerix">The given OData route prefix.</param>
+        /// <param name="model">The <see cref="IEdmModel"/> to use.</param>
+        /// <returns>The <see cref="IApplicationBuilder "/>.</returns>
+        public static IApplicationBuilder UseOData(this IApplicationBuilder app, string routeName, string routePrerix, IEdmModel model)
+        {
+            if (app == null)
+            {
+                throw Error.ArgumentNull("app");
+            }
+
+            VerifyODataIsRegistered(app);
+
+            return app.UseMvc(b =>
+            {
+                b.Select().Expand().Filter().OrderBy().MaxTop(MaxTop).Count();
+
+                b.MapODataServiceRoute(routeName, routePrerix, model);
+            });
+        }
+
+        private static void VerifyODataIsRegistered(IApplicationBuilder app)
+        {
+            // We use the IPerRouteContainer to verify if AddOData() was called before calling UseOData
+            if (app.ApplicationServices.GetService(typeof(IPerRouteContainer)) == null)
+            {
+                throw Error.InvalidOperation(SRResources.MissingODataServices, nameof(IPerRouteContainer));
+            }
         }
     }
 }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/ODataApplicationBuilderExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/ODataApplicationBuilderExtensionsTest.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.OData.Edm;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.OData.Test.Extensions
+{
+    public class ODataApplicationBuilderExtensionsTest
+    {
+        [Fact]
+        public void UseOData_ThrowsInvalidOperationException_IfODataServiceIsNotRegistered()
+        {
+            // Arrange
+            var applicationBuilderMock = new Mock<IApplicationBuilder>();
+            applicationBuilderMock.Setup(s => s.ApplicationServices).Returns(Mock.Of<IServiceProvider>());
+            var edmModel = new Mock<IEdmModel>().Object;
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => applicationBuilderMock.Object.UseOData(edmModel));
+
+            Assert.Equal(String.Format(SRResources.MissingODataServices, nameof(IPerRouteContainer)), exception.Message);
+        }
+
+        [Fact]
+        public void UseODataWithNameAndPrefix_ThrowsInvalidOperationException_IfODataServiceIsNotRegistered()
+        {
+            // Arrange
+            var applicationBuilderMock = new Mock<IApplicationBuilder>();
+            applicationBuilderMock.Setup(s => s.ApplicationServices).Returns(Mock.Of<IServiceProvider>());
+            var edmModel = new Mock<IEdmModel>().Object;
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => applicationBuilderMock.Object.UseOData("odata", "odata", edmModel));
+
+            Assert.Equal(String.Format(SRResources.MissingODataServices, nameof(IPerRouteContainer)), exception.Message);
+        }
+    }
+}

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -1889,6 +1889,19 @@ public sealed class Microsoft.AspNet.OData.Extensions.HttpResponseExtensions {
 ExtensionAttribute(),
 ]
 public sealed class Microsoft.AspNet.OData.Extensions.ODataApplicationBuilderExtensions {
+	public static readonly string DefaultRouteName = "odata"
+	public static readonly string DefaultRoutePrefix = "odata"
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseOData (Microsoft.AspNetCore.Builder.IApplicationBuilder app, Microsoft.OData.Edm.IEdmModel model)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseOData (Microsoft.AspNetCore.Builder.IApplicationBuilder app, string routeName, string routePrerix, Microsoft.OData.Edm.IEdmModel model)
+
 	[
 	ExtensionAttribute(),
 	]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* Add UseOData() extension methods for IApplicationBuilder. (Only for ASP.NET Core)

### Description

* 
We have `AddOData()` to add the service, but it shows that we should call `UseMvc(..)` and set up an action to register the OData route. This PR to combine it into an extension method `UseOData()` for IApplicationBuilder.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
