### PR TITLE
Fix issue #1529: ETag missing on derived entity set

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
@@ -598,6 +598,10 @@ namespace Microsoft.AspNet.OData.Builder
 
             IEnumerable<StructuralPropertyConfiguration> concurrencyPropertyies =
                 entityTypeConfig.Properties.OfType<StructuralPropertyConfiguration>().Where(property => property.ConcurrencyToken);
+            foreach (var baseType in entityTypeConfig.BaseTypes())
+            {
+                concurrencyPropertyies = concurrencyPropertyies.Concat(baseType.Properties.OfType<StructuralPropertyConfiguration>().Where(property => property.ConcurrencyToken));
+            }
 
             IList<IEdmStructuralProperty> edmProperties = new List<IEdmStructuralProperty>();
 

--- a/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
@@ -600,7 +600,8 @@ namespace Microsoft.AspNet.OData.Builder
                 entityTypeConfig.Properties.OfType<StructuralPropertyConfiguration>().Where(property => property.ConcurrencyToken);
             foreach (var baseType in entityTypeConfig.BaseTypes())
             {
-                concurrencyPropertyies = concurrencyPropertyies.Concat(baseType.Properties.OfType<StructuralPropertyConfiguration>().Where(property => property.ConcurrencyToken));
+                concurrencyPropertyies = concurrencyPropertyies.Concat(
+                    baseType.Properties.OfType<StructuralPropertyConfiguration>().Where(property => property.ConcurrencyToken));
             }
 
             IList<IEdmStructuralProperty> edmProperties = new List<IEdmStructuralProperty>();

--- a/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
@@ -596,17 +596,17 @@ namespace Microsoft.AspNet.OData.Builder
         {
             EntityTypeConfiguration entityTypeConfig = navigationSourceConfiguration.EntityType;
 
-            IEnumerable<StructuralPropertyConfiguration> concurrencyPropertyies =
+            IEnumerable<StructuralPropertyConfiguration> concurrencyProperties =
                 entityTypeConfig.Properties.OfType<StructuralPropertyConfiguration>().Where(property => property.ConcurrencyToken);
             foreach (var baseType in entityTypeConfig.BaseTypes())
             {
-                concurrencyPropertyies = concurrencyPropertyies.Concat(
+                concurrencyProperties = concurrencyProperties.Concat(
                     baseType.Properties.OfType<StructuralPropertyConfiguration>().Where(property => property.ConcurrencyToken));
             }
 
             IList<IEdmStructuralProperty> edmProperties = new List<IEdmStructuralProperty>();
 
-            foreach (StructuralPropertyConfiguration property in concurrencyPropertyies)
+            foreach (StructuralPropertyConfiguration property in concurrencyProperties)
             {
                 IEdmProperty value;
                 if (edmTypeMap.EdmProperties.TryGetValue(property.PropertyInfo, out value))

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ETags/DerivedETagTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ETags/DerivedETagTests.cs
@@ -115,8 +115,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.ETags
             Assert.True(response.IsSuccessStatusCode);
             var jsonResult = await response.Content.ReadAsObject<JObject>();
             var derivedEtags = jsonResult.GetValue("value").Select(e => e["@odata.etag"].ToString());
-
-            Assert.StartsWith("W/\"bnVsbA==", String.Concat(derivedEtags));
+            Assert.Equal(10, derivedEtags.Count());
+            Assert.Equal("W/\"bnVsbA==\"", derivedEtags.First());
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* #1529 .*

### Description

* When customer defined entity set on derived type, while the concurrency property defined on base type, the etag can't present on the payload. See detail in the #1529.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
