### PR TITLE
Fix SelectExpandBinder to take into account constant parameterization when using ModelId as part of a query(#1541)

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -309,6 +309,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             List<MemberAssignment> wrapperTypeMemberAssignments = new List<MemberAssignment>();
 
             PropertyInfo wrapperProperty;
+            Expression wrapperPropertyValueExpression;
             bool isInstancePropertySet = false;
             bool isTypeNamePropertySet = false;
             bool isContainerPropertySet = false;
@@ -316,7 +317,10 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             // Initialize property 'ModelID' on the wrapper class.
             // source = new Wrapper { ModelID = 'some-guid-id' }
             wrapperProperty = wrapperType.GetProperty("ModelID");
-            wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, Expression.Constant(_modelID)));
+            wrapperPropertyValueExpression = _settings.EnableConstantParameterization ?
+                LinqParameterContainer.Parameterize(typeof(string), _modelID) :
+                Expression.Constant(_modelID);
+            wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, wrapperPropertyValueExpression));
 
             if (IsSelectAll(selectExpandClause))
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1541.

### Description

When ModelId is used as part of a query in the SelectExpandBinder, it should respect the ODataQuerySettings.EnableConstantParameterization property. Otherwise, there is no way to force a generation of a SQL parameter in the resulting query. Which can result in polluting the SQL Server query plan cache with unwanted query plans (containing constants).

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
