### PR TITLE
AspNetCore JsonBatch: skip serialization for empty content

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchResponseItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchResponseItem.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.OData.Batch
                 batchResponse.SetHeader(header.Key, String.Join(",", header.Value.ToArray()));
             }
 
-            if (context.Response.Body != null)
+            if (context.Response.Body != null && context.Response.Body.Length != 0)
             {
                 using (Stream stream = batchResponse.GetStream())
                 {

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Batch/Tests/DataServicesClient/DefaultODataBatchHandlerTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Batch/Tests/DataServicesClient/DefaultODataBatchHandlerTests.cs
@@ -254,6 +254,19 @@ Content-Type: application/json;odata.metadata=minimal
             HttpContent content = new StringContent(@"
 {
     ""requests"": [{
+            ""id"": ""0"",
+            ""atomicityGroup"": ""f7de7314-2f3d-4422-b840-ada6d6de0f18"",
+            ""method"": ""PATCH"",
+            ""url"": """ + absoluteUri + "(6)" + @""",
+            ""headers"": {
+                ""OData-Version"": ""4.0"",
+                ""Content-Type"": ""application/json;odata.metadata=minimal"",
+                ""Accept"": ""application/json;odata.metadata=minimal""
+            },
+            ""body"": {
+                ""Name"":""PatchedByJsonBatch_0""
+            }
+        }, {
             ""id"": ""1"",
             ""atomicityGroup"": ""f7de7314-2f3d-4422-b840-ada6d6de0f18"",
             ""method"": ""POST"",
@@ -311,6 +324,7 @@ Content-Type: application/json;odata.metadata=minimal
             using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), GetEdmModel(new ODataConventionModelBuilder())))
             {
                 var batchReader = messageReader.CreateODataBatchReader();
+
                 while (batchReader.Read())
                 {
                     switch (batchReader.State)
@@ -318,12 +332,22 @@ Content-Type: application/json;odata.metadata=minimal
                         case ODataBatchReaderState.Operation:
                             var operationMessage = batchReader.CreateOperationResponseMessage();
                             subResponseCount++;
-                            Assert.Equal(201, operationMessage.StatusCode);
+
+                            if (operationMessage.ContentId.Equals("0"))
+                            {
+                                // No-Content response for PATCH
+                                Assert.Equal(204, operationMessage.StatusCode);
+                            }
+                            else
+                            {
+                                Assert.Equal(201, operationMessage.StatusCode);
+                            }
+
                             break;
                     }
                 }
             }
-            Assert.Equal(3, subResponseCount);
+            Assert.Equal(4, subResponseCount);
         }
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1543 .*

### Description

*For AspNetCore implementation, skip serializing the payload content if it is empty. Not an issue for AspNet classic which already has the correct logic.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
