### PR TITLE
Fix the issue #850, (de)serialize using the Edm Enum member string

### DIFF
--- a/samples/AspNetCoreODataSample.Web/Controllers/PeopleController.cs
+++ b/samples/AspNetCoreODataSample.Web/Controllers/PeopleController.cs
@@ -26,5 +26,11 @@ namespace AspNetCoreODataSample.Web.Controllers
 
             return Ok(m);
         }
+
+        [EnableQuery]
+        public IActionResult Post([FromBody]Person person)
+        {
+            return Created(person);
+        }
     }
 }

--- a/samples/AspNetCoreODataSample.Web/Controllers/PeopleController.cs
+++ b/samples/AspNetCoreODataSample.Web/Controllers/PeopleController.cs
@@ -21,6 +21,7 @@ namespace AspNetCoreODataSample.Web.Controllers
                 {
                     { "abc", "abcValue" }
                 }
+                MyLevel = Level.High
             };
 
             return Ok(m);

--- a/samples/AspNetCoreODataSample.Web/Models/Level.cs
+++ b/samples/AspNetCoreODataSample.Web/Models/Level.cs
@@ -14,7 +14,7 @@ namespace AspNetCoreODataSample.Web.Models
         [EnumMember(Value = "medium")]
         Medium,
 
-        [EnumMember(Value = "high")]
+        [EnumMember(Value = "veryhigh")]
         High
     }
 }

--- a/samples/AspNetCoreODataSample.Web/Models/Level.cs
+++ b/samples/AspNetCoreODataSample.Web/Models/Level.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Runtime.Serialization;
+
+namespace AspNetCoreODataSample.Web.Models
+{
+    [DataContract(Name = "level")]
+    public enum Level
+    {
+        [EnumMember(Value = "low")]
+        Low,
+
+        [EnumMember(Value = "medium")]
+        Medium,
+
+        [EnumMember(Value = "high")]
+        High
+    }
+}

--- a/samples/AspNetCoreODataSample.Web/Models/Person.cs
+++ b/samples/AspNetCoreODataSample.Web/Models/Person.cs
@@ -8,8 +8,11 @@ namespace AspNetCoreODataSample.Web.Models
     public class Person
     {
         public string FirstName { get; set; }
+
         public string LastName { get; set; }
 
         public IDictionary<string, object> DynamicProperties { get; set; }
+
+        public Level MyLevel { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
@@ -440,13 +440,7 @@ namespace Microsoft.AspNet.OData.Builder
             // add annotation for properties
             Dictionary<PropertyInfo, IEdmProperty> edmProperties = edmTypeMap.EdmProperties;
             model.AddClrPropertyInfoAnnotations(edmProperties);
-
-            // add Enum mapping annotation
-            if (edmTypeMap.EnumMembers != null && edmTypeMap.EnumMembers.Any())
-            {
-                model.SetAnnotationValue(model, new ClrEnumMemberAnnotation(edmTypeMap.EnumMembers));
-            }
-
+            model.AddClrEnumMemberInfoAnnotations(edmTypeMap);
             model.AddPropertyRestrictionsAnnotations(edmTypeMap.EdmPropertiesRestrictions);
             model.AddPropertiesQuerySettings(edmTypeMap.EdmPropertiesQuerySettings);
             model.AddStructuredTypeQuerySettings(edmTypeMap.EdmStructuredTypeQuerySettings);
@@ -519,6 +513,21 @@ namespace Microsoft.AspNet.OData.Builder
                 {
                     model.SetAnnotationValue(edmProperty, new ClrPropertyInfoAnnotation(clrProperty));
                 }
+            }
+        }
+
+        private static void AddClrEnumMemberInfoAnnotations(this EdmModel model, EdmTypeMap edmTypeMap)
+        {
+            if (edmTypeMap.EnumMembers == null || !edmTypeMap.EnumMembers.Any())
+            {
+                return;
+            }
+
+            var enumGroupBy = edmTypeMap.EnumMembers.GroupBy(e => e.Key.GetType(), e => e);
+            foreach (var enumGroup in enumGroupBy)
+            {
+                IEdmType edmType = edmTypeMap.EdmTypes[enumGroup.Key];
+                model.SetAnnotationValue(edmType, new ClrEnumMemberAnnotation(enumGroup.ToDictionary(e => e.Key, e => e.Value)));
             }
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
@@ -440,6 +440,13 @@ namespace Microsoft.AspNet.OData.Builder
             // add annotation for properties
             Dictionary<PropertyInfo, IEdmProperty> edmProperties = edmTypeMap.EdmProperties;
             model.AddClrPropertyInfoAnnotations(edmProperties);
+
+            // add Enum mapping annotation
+            if (edmTypeMap.EnumMembers != null && edmTypeMap.EnumMembers.Any())
+            {
+                model.SetAnnotationValue(model, new ClrEnumMemberAnnotation(edmTypeMap.EnumMembers));
+            }
+
             model.AddPropertyRestrictionsAnnotations(edmTypeMap.EdmPropertiesRestrictions);
             model.AddPropertiesQuerySettings(edmTypeMap.EdmPropertiesQuerySettings);
             model.AddStructuredTypeQuerySettings(edmTypeMap.EdmStructuredTypeQuerySettings);

--- a/src/Microsoft.AspNet.OData.Shared/ClrEnumMemberAnnotation.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ClrEnumMemberAnnotation.cs
@@ -9,12 +9,12 @@ using Microsoft.OData.Edm;
 namespace Microsoft.AspNet.OData
 {
     /// <summary>
-    /// Represents a mapping from an <see cref="IEdmEnumMember"/> to a CLR Enum member.
+    /// Represents a mapping betwwen an <see cref="IEdmEnumMember"/> and a CLR Enum member.
     /// </summary>
     public class ClrEnumMemberAnnotation
     {
-        private IDictionary<Enum, IEdmEnumMember> _maps;
-        private IDictionary<IEdmEnumMember, Enum> _reverseMaps;
+        private IDictionary<Enum, IEdmEnumMember> _map;
+        private IDictionary<IEdmEnumMember, Enum> _reverseMap;
 
         /// <summary>
         /// Initializes a new instance of <see cref="ClrEnumMemberAnnotation"/> class.
@@ -27,11 +27,11 @@ namespace Microsoft.AspNet.OData
                 throw Error.ArgumentNull("map");
             }
 
-            _maps = map;
-            _reverseMaps = new Dictionary<IEdmEnumMember, Enum>();
+            _map = map;
+            _reverseMap = new Dictionary<IEdmEnumMember, Enum>();
             foreach (var item in map)
             {
-                _reverseMaps.Add(item.Value, item.Key);
+                _reverseMap.Add(item.Value, item.Key);
             }
         }
 
@@ -43,12 +43,8 @@ namespace Microsoft.AspNet.OData
         public IEdmEnumMember GetEdmEnumMember(Enum clrEnumMemberInfo)
         {
             IEdmEnumMember value;
-            if (_maps.TryGetValue(clrEnumMemberInfo, out value))
-            {
-                return value;
-            }
-
-            return null;
+            _map.TryGetValue(clrEnumMemberInfo, out value);
+            return value;
         }
 
         /// <summary>
@@ -59,12 +55,8 @@ namespace Microsoft.AspNet.OData
         public Enum GetClrEnumMember(IEdmEnumMember edmEnumMember)
         {
             Enum value;
-            if (_reverseMaps.TryGetValue(edmEnumMember, out value))
-            {
-                return value;
-            }
-
-            return null;
+            _reverseMap.TryGetValue(edmEnumMember, out value);
+            return value;
         }
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/ClrEnumMemberAnnotation.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ClrEnumMemberAnnotation.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNet.OData
+{
+    /// <summary>
+    /// Represents a mapping from an <see cref="IEdmEnumMember"/> to a CLR Enum member.
+    /// </summary>
+    public class ClrEnumMemberAnnotation
+    {
+        private IDictionary<Enum, IEdmEnumMember> _maps;
+        private IDictionary<IEdmEnumMember, Enum> _reverseMaps;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ClrEnumMemberAnnotation"/> class.
+        /// </summary>
+        /// <param name="map">The mapping between CLR Enum member and the EDM <see cref="IEdmEnumMember"/>.</param>
+        public ClrEnumMemberAnnotation(IDictionary<Enum, IEdmEnumMember> map)
+        {
+            if (map == null)
+            {
+                throw Error.ArgumentNull("map");
+            }
+
+            _maps = map;
+            _reverseMaps = new Dictionary<IEdmEnumMember, Enum>();
+            foreach (var item in map)
+            {
+                _reverseMaps.Add(item.Value, item.Key);
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IEdmEnumMember"/> for the CLR Enum member.
+        /// </summary>
+        /// <param name="clrEnumMemberInfo">The backing CLR Enum member info.</param>
+        /// <returns>The Edm <see cref="IEdmEnumMember"/>.</returns>
+        public IEdmEnumMember GetEdmEnumMember(Enum clrEnumMemberInfo)
+        {
+            IEdmEnumMember value;
+            if (_maps.TryGetValue(clrEnumMemberInfo, out value))
+            {
+                return value;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the CLR Enum member for <see cref="IEdmEnumMember"/>.
+        /// </summary>
+        /// <param name="edmEnumMember">The Edm <see cref="IEdmEnumMember"/>.</param>
+        /// <returns>The backing CLR Enum member info.</returns>
+        public Enum GetClrEnumMember(IEdmEnumMember edmEnumMember)
+        {
+            Enum value;
+            if (_reverseMaps.TryGetValue(edmEnumMember, out value))
+            {
+                return value;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataEnumDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataEnumDeserializer.cs
@@ -61,6 +61,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             }
 
             IEdmEnumTypeReference enumTypeReference = (IEdmEnumTypeReference)edmType;
+            IEdmEnumType enumType = enumTypeReference.EnumDefinition();
             ODataEnumValue enumValue = item as ODataEnumValue;
             if (readContext.IsUntyped)
             {
@@ -69,11 +70,9 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             }
 
             // Enum member supports model alias case. So, try to use the Edm member name to retrieve the Enum value.
-            var memberMapAnnotation = readContext.Model.GetClrEnumMemberAnnotation();
+            var memberMapAnnotation = readContext.Model.GetClrEnumMemberAnnotation(enumType);
             if (memberMapAnnotation != null)
             {
-                IEdmEnumType enumType = enumTypeReference.EnumDefinition();
-
                 if (enumValue != null)
                 {
                     IEdmEnumMember enumMember = enumType.Members.FirstOrDefault(m => m.Name == enumValue.Value);

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
@@ -704,6 +704,22 @@ namespace Microsoft.AspNet.OData.Formatter
             return propertyName;
         }
 
+        public static ClrEnumMemberAnnotation GetClrEnumMemberAnnotation(this IEdmModel edmModel)
+        {
+            if (edmModel == null)
+            {
+                throw Error.ArgumentNull("edmModel");
+            }
+
+            ClrEnumMemberAnnotation annotation = edmModel.GetAnnotationValue<ClrEnumMemberAnnotation>(edmModel);
+            if (annotation != null)
+            {
+                return annotation;
+            }
+
+            return null;
+        }
+
         public static PropertyInfo GetDynamicPropertyDictionary(IEdmStructuredType edmType, IEdmModel edmModel)
         {
             if (edmType == null)

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
@@ -704,14 +704,14 @@ namespace Microsoft.AspNet.OData.Formatter
             return propertyName;
         }
 
-        public static ClrEnumMemberAnnotation GetClrEnumMemberAnnotation(this IEdmModel edmModel)
+        public static ClrEnumMemberAnnotation GetClrEnumMemberAnnotation(this IEdmModel edmModel, IEdmEnumType enumType)
         {
             if (edmModel == null)
             {
                 throw Error.ArgumentNull("edmModel");
             }
 
-            ClrEnumMemberAnnotation annotation = edmModel.GetAnnotationValue<ClrEnumMemberAnnotation>(edmModel);
+            ClrEnumMemberAnnotation annotation = edmModel.GetAnnotationValue<ClrEnumMemberAnnotation>(enumType);
             if (annotation != null)
             {
                 return annotation;

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataEnumSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataEnumSerializer.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             }
 
             // Enum member supports model alias case. So, try to use the Edm member name to create Enum value.
-            var memberMapAnnotation = writeContext.Model.GetClrEnumMemberAnnotation();
+            var memberMapAnnotation = writeContext.Model.GetClrEnumMemberAnnotation(enumType.EnumDefinition());
             if (memberMapAnnotation != null)
             {
                 var edmEnumMember = memberMapAnnotation.GetEdmEnumMember((Enum)graph);

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataEnumSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataEnumSerializer.cs
@@ -90,7 +90,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 }
             }
 
-            // Enum member maybe support camel case. So, try to use the Edm member name to create Enum value.
+            // Enum member supports model alias case. So, try to use the Edm member name to create Enum value.
             var member = enumType.EnumDefinition().Members
                 .FirstOrDefault(m => String.Equals(m.Name, value, StringComparison.OrdinalIgnoreCase));
             if (member != null)

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataEnumSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataEnumSerializer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
@@ -87,6 +88,14 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 {
                     value = ((EdmEnumObject)graph).Value;
                 }
+            }
+
+            // Enum member maybe support camel case. So, try to use the Edm member name to create Enum value.
+            var member = enumType.EnumDefinition().Members
+                .FirstOrDefault(m => String.Equals(m.Name, value, StringComparison.OrdinalIgnoreCase));
+            if (member != null)
+            {
+                value = member.Name;
             }
 
             ODataEnumValue enumValue = new ODataEnumValue(value, enumType.FullName());

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataEnumSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataEnumSerializer.cs
@@ -91,11 +91,14 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             }
 
             // Enum member supports model alias case. So, try to use the Edm member name to create Enum value.
-            var member = enumType.EnumDefinition().Members
-                .FirstOrDefault(m => String.Equals(m.Name, value, StringComparison.OrdinalIgnoreCase));
-            if (member != null)
+            var memberMapAnnotation = writeContext.Model.GetClrEnumMemberAnnotation();
+            if (memberMapAnnotation != null)
             {
-                value = member.Name;
+                var edmEnumMember = memberMapAnnotation.GetEdmEnumMember((Enum)graph);
+                if (edmEnumMember != null)
+                {
+                    value = edmEnumMember.Name;
+                }
             }
 
             ODataEnumValue enumValue = new ODataEnumValue(value, enumType.FullName());

--- a/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
+++ b/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Builder\DecimalPropertyConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\LengthPropertyConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\PrecisionPropertyConfiguration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ClrEnumMemberAnnotation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\CollectionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\ListWrapperCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\PropertyHelper.cs" />

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/EnumTypeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/EnumTypeTest.cs
@@ -1084,12 +1084,20 @@ namespace Microsoft.AspNet.OData.Test.Builder
             // Assert
             IEdmEnumType enumType = model.SchemaElements.OfType<IEdmEnumType>().Single();
             Assert.NotNull(enumType);
-            Assert.Equal(3, enumType.Members.Count());
+            Assert.Equal(4, enumType.Members.Count());
             Assert.Equal("Feelings", enumType.Name);
             Assert.Equal("Test", enumType.Namespace);
             Assert.Contains(enumType.Members, (m) => m.Name.Equals("happy"));
             Assert.Contains(enumType.Members, (m) => m.Name.Equals("sad"));
             Assert.Contains(enumType.Members, (m) => m.Name.Equals("KeepDefaultName"));
+            Assert.Contains(enumType.Members, (m) => m.Name.Equals("soso"));
+
+            var annotation = model.GetClrEnumMemberAnnotation(enumType);
+            Assert.NotNull(annotation);
+
+            IEdmEnumMember enumMember = enumType.Members.Single(m => m.Name.Equals("soso"));
+            Assert.Same(enumMember, annotation.GetEdmEnumMember(Life.NotTooBad));
+            Assert.Equal(Life.NotTooBad, annotation.GetClrEnumMember(enumMember));
         }
 
         [Fact]
@@ -1118,13 +1126,14 @@ namespace Microsoft.AspNet.OData.Test.Builder
             // Assert
             IEdmEnumType enumType = model.SchemaElements.OfType<IEdmEnumType>().Single();
             Assert.NotNull(enumType);
-            Assert.Equal(4, enumType.Members.Count());
+            Assert.Equal(5, enumType.Members.Count());
             Assert.Equal("Feelings", enumType.Name);
             Assert.Equal("Test", enumType.Namespace);
             Assert.Contains(enumType.Members, (m) => m.Name.Equals("happy"));
             Assert.Contains(enumType.Members, (m) => m.Name.Equals("sad"));
             Assert.Contains(enumType.Members, (m) => m.Name.Equals("JustSoSo"));
             Assert.Contains(enumType.Members, (m) => m.Name.Equals("KeepDefaultName"));
+            Assert.Contains(enumType.Members, (m) => m.Name.Equals("soso"));
         }
 
         private IEdmStructuredType AddComplexTypeWithODataConventionModelBuilder()
@@ -1192,10 +1201,16 @@ namespace Microsoft.AspNet.OData.Test.Builder
     {
         [EnumMember(Value = "happy")]
         Happy = 1,
+
         [EnumMember(Value = "sad")]
         Sad = 2,
+
         JustSoSo = 3,
+
         [EnumMember]
-        KeepDefaultName
+        KeepDefaultName = 4,
+
+        [EnumMember(Value = "soso")]
+        NotTooBad
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/ODataEnumTypeSerializerTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/ODataEnumTypeSerializerTests.cs
@@ -3,8 +3,11 @@
 
 using Microsoft.AspNet.OData.Formatter;
 using Microsoft.AspNet.OData.Formatter.Serialization;
+using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
+using System.Linq;
+using System.Runtime.Serialization;
 using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
@@ -60,5 +63,39 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             Assert.NotNull(annotation);
             Assert.Null(annotation.TypeName);
         }
+
+        [Fact]
+        public void CreateODataEnumValue_ReturnsCorrectEnumMember()
+        {
+            // Arrange
+            var builder = ODataConventionModelBuilderFactory.Create();
+            builder.EnumType<BookCategory>().Namespace = "NS";
+            IEdmModel model = builder.GetEdmModel();
+            IEdmEnumType enumType = model.SchemaElements.OfType<IEdmEnumType>().Single();
+
+            var provider = new DefaultODataSerializerProvider(new MockContainer());
+            ODataEnumSerializer serializer = new ODataEnumSerializer(provider);
+            ODataSerializerContext writeContext = new ODataSerializerContext
+            {
+                Model = model
+            };
+
+            // Act
+            ODataEnumValue value = serializer.CreateODataEnumValue(BookCategory.Newspaper,
+                new EdmEnumTypeReference(enumType, false), writeContext);
+
+            // Assert
+            Assert.NotNull(value);
+            Assert.Equal("news", value.Value);
+        }
+    }
+
+    [DataContract(Name = "category")]
+    public enum BookCategory
+    {
+        [EnumMember(Value = "cartoon")]
+        Cartoon,
+        [EnumMember(Value = "news")]
+        Newspaper
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -196,6 +196,13 @@ public sealed class Microsoft.AspNet.OData.ODataUriFunctions {
 	public static bool RemoveCustomUriFunction (string functionName, Microsoft.OData.UriParser.FunctionSignatureWithReturnType functionSignature, System.Reflection.MethodInfo methodInfo)
 }
 
+public class Microsoft.AspNet.OData.ClrEnumMemberAnnotation {
+	public ClrEnumMemberAnnotation (System.Collections.Generic.IDictionary`2[[System.Enum],[Microsoft.OData.Edm.IEdmEnumMember]] map)
+
+	public System.Enum GetClrEnumMember (Microsoft.OData.Edm.IEdmEnumMember edmEnumMember)
+	public Microsoft.OData.Edm.IEdmEnumMember GetEdmEnumMember (System.Enum clrEnumMemberInfo)
+}
+
 public class Microsoft.AspNet.OData.ClrPropertyInfoAnnotation {
 	public ClrPropertyInfoAnnotation (System.Reflection.PropertyInfo clrPropertyInfo)
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -203,6 +203,13 @@ public sealed class Microsoft.AspNet.OData.ODataUriFunctions {
 	public static bool RemoveCustomUriFunction (string functionName, Microsoft.OData.UriParser.FunctionSignatureWithReturnType functionSignature, System.Reflection.MethodInfo methodInfo)
 }
 
+public class Microsoft.AspNet.OData.ClrEnumMemberAnnotation {
+	public ClrEnumMemberAnnotation (System.Collections.Generic.IDictionary`2[[System.Enum],[Microsoft.OData.Edm.IEdmEnumMember]] map)
+
+	public System.Enum GetClrEnumMember (Microsoft.OData.Edm.IEdmEnumMember edmEnumMember)
+	public Microsoft.OData.Edm.IEdmEnumMember GetEdmEnumMember (System.Enum clrEnumMemberInfo)
+}
+
 public class Microsoft.AspNet.OData.ClrPropertyInfoAnnotation {
 	public ClrPropertyInfoAnnotation (System.Reflection.PropertyInfo clrPropertyInfo)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue ##850.*

### Description

* Enum supports camel case, however when serialize the enum member, it's using the old case, doesn't support the camel case. This fix is a quick fix for this.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
