### PR TITLE
Don't assume port 80 when generating nextLink in ASP.NET Core #1559

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -272,7 +272,14 @@ namespace Microsoft.AspNet.OData.Extensions
                 throw Error.ArgumentNull("request");
             }
 
-            UriBuilder uriBuilder = new UriBuilder(request.Scheme, request.Host.Host, request.Host.Port.HasValue ? request.Host.Port.Value : 80, (request.PathBase + request.Path).ToUriComponent());
+            UriBuilder uriBuilder = new UriBuilder(request.Scheme, request.Host.Host) 
+            { 
+                Path = (request.PathBase + request.Path).ToUriComponent() 
+            };
+            if (request.Host.Port.HasValue)
+            {
+                uriBuilder.Port = request.Host.Port.Value;
+            }
             IEnumerable<KeyValuePair<string, string>> queryParameters = request.Query.SelectMany(kvp => kvp.Value, (kvp, value) => new KeyValuePair<string, string>(kvp.Key, value));
 
             return GetNextPageHelper.GetNextPageLink(uriBuilder.Uri, queryParameters, pageSize);

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/HttpRequestExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/HttpRequestExtensionsTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNetCore.Http;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/HttpRequestExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/HttpRequestExtensionsTest.cs
@@ -1,0 +1,83 @@
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Test.Abstraction;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Net.Http;
+using Xunit;
+
+namespace Microsoft.AspNet.OData.Test
+{
+    public class HttpRequestMessageExtensionsTest
+    {
+        [Theory]
+        [InlineData("http://localhost/Customers", 10, "http://localhost/Customers?$skip=10")]
+        [InlineData("http://localhost/Customers?$filter=Age ge 18", 10, "http://localhost/Customers?$filter=Age%20ge%2018&$skip=10")]
+        [InlineData("http://localhost/Customers?$top=20", 10, "http://localhost/Customers?$top=10&$skip=10")]
+        [InlineData("http://localhost/Customers?$skip=5&$top=10", 2, "http://localhost/Customers?$top=8&$skip=7")]
+        [InlineData("http://localhost/Customers?$filter=Age ge 18&$orderby=Name&$top=11&$skip=6", 10, "http://localhost/Customers?$filter=Age%20ge%2018&$orderby=Name&$top=1&$skip=16")]
+        [InlineData("http://localhost/Customers?testkey%23%2B%3D%3F%26=testvalue%23%2B%3D%3F%26", 10, "http://localhost/Customers?testkey%23%2B%3D%3F%26=testvalue%23%2B%3D%3F%26&$skip=10")]
+        public void GetNextPageLink_GetsNextPageLink(string requestUri, int pageSize, string nextPageUri)
+        {
+            // Arrange
+            HttpRequest request = RequestFactory.Create(HttpMethod.Get, requestUri);
+
+            // Act
+            Uri nextPageLink = request.GetNextPageLink(pageSize);
+
+            // Assert
+            Assert.Equal(nextPageUri, nextPageLink.AbsoluteUri);
+        }
+    
+        [Theory]
+        [InlineData("http://localhost/Customers", 10, "http://localhost/Customers?$skip=10")]
+        [InlineData("https://localhost/Customers", 10, "https://localhost/Customers?$skip=10")]
+        [InlineData("http://example.com/Customers", 10, "http://example.com/Customers?$skip=10")]
+        [InlineData("https://example.com/Customers", 10, "https://example.com/Customers?$skip=10")]
+        public void GetNextPageLink_UsesNoPortWhenNotSpecified(string requestUri, int pageSize, string nextPageUri)
+        {
+            // Arrange
+            HttpRequest request = RequestFactory.Create(HttpMethod.Get, requestUri);
+
+            // Act
+            Uri nextPageLink = request.GetNextPageLink(pageSize);
+
+            // Assert
+            Assert.Equal(nextPageUri, nextPageLink.AbsoluteUri);
+        }
+
+        [Theory]
+        [InlineData("http://example.com:80/Customers", 10, "http://example.com/Customers?$skip=10")]
+        [InlineData("https://example.com:443/Customers", 10, "https://example.com/Customers?$skip=10")]
+        public void GetNextPageLink_UsesPortWhenDefaultPortIsProvided(string requestUri, int pageSize, string nextPageUri)
+        {
+            // Arrange
+            // The RequestFactory removes the default port, so we explicitly add it
+            HttpRequest request = RequestFactory.Create(HttpMethod.Get, requestUri);
+            Uri uri = new Uri(requestUri);
+            var port = request.Scheme == "http" ? 80 : 443;
+            request.Host = new HostString(uri.Host, port);
+
+            // Act
+            Uri nextPageLink = request.GetNextPageLink(pageSize);
+
+            // Assert
+            Assert.Equal(nextPageUri, nextPageLink.AbsoluteUri);
+        }
+
+        [Theory]
+        [InlineData("http://localhost:808/Customers", 10, "http://localhost:808/Customers?$skip=10")]
+        [InlineData("https://localhost:4443/Customers", 10, "https://localhost:4443/Customers?$skip=10")]
+        [InlineData("http://localhost:5000/Customers", 10, "http://localhost:5000/Customers?$skip=10")]
+        public void GetNextPageLink_UsesCorrectPortWhenSpecified(string requestUri, int pageSize, string nextPageUri)
+        {
+            // Arrange
+            HttpRequest request = RequestFactory.Create(HttpMethod.Get, requestUri);
+
+            // Act
+            Uri nextPageLink = request.GetNextPageLink(pageSize);
+
+            // Assert
+            Assert.Equal(nextPageUri, nextPageLink.AbsoluteUri);
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1559*

### Description

Don't explicitly set a port when generating the nextLink

If the port isn't set on `request.Host`, port 80 was assumed previously. If the app is running behind a reverse proxy, and the port was not forwarded, this can result in invalid URLs - for example an HTTPS URL using port 80. Instead, we just omit the port completely if it's not explicitly set.


### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

Unfortunately, I couldn't build the repo after cloning (`Could not load file or assembly 'Microsoft.Build, Version=14.0.0.0`), and there are no existing tests for `HttpRequestExtensions` as far as I can see, so I haven't tried to add any.