### PR TITLE
Fix issue #1555: ETagMessageHandler on controller will throw exception

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/ETagMessageHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ETagMessageHandler.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNet.OData
             IEdmEntityTypeReference typeReference = GetTypeReference(model, edmType, value);
             if (typeReference != null)
             {
-                ResourceContext context = CreateInstanceContext(typeReference, value);
+                ResourceContext context = CreateInstanceContext(model, typeReference, value);
                 context.EdmModel = model;
                 context.NavigationSource = path.NavigationSource;
                 return CreateETag(context, etagHandler);
@@ -116,12 +116,15 @@ namespace Microsoft.AspNet.OData
             return handler.CreateETag(properties);
         }
 
-        private static ResourceContext CreateInstanceContext(IEdmEntityTypeReference reference, object value)
+        private static ResourceContext CreateInstanceContext(IEdmModel model, IEdmEntityTypeReference reference, object value)
         {
             Contract.Assert(reference != null);
             Contract.Assert(value != null);
 
-            ODataSerializerContext serializerCtx = new ODataSerializerContext();
+            ODataSerializerContext serializerCtx = new ODataSerializerContext
+            {
+                Model = model
+            };
             return new ResourceContext(serializerCtx, reference, value);
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1555.*

### Description

* If we put [ETagMessageHandler] on the method of controller, it will throw exception for ETag creating.
  The reason is that the serialize context will set the model.
  This PR is trying to fix that.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
