### PR TITLE
Null check on ODataQueryParameterBindingAttribute for Net Core

### DIFF
--- a/src/Microsoft.AspNetCore.OData/ODataQueryParameterBindingAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataQueryParameterBindingAttribute.cs
@@ -110,6 +110,10 @@ namespace Microsoft.AspNet.OData
 
             public static bool IsODataQueryOptions(Type parameterType)
             {
+                if (parameterType == null)
+                {
+                    return false;
+                }
                 return ((parameterType == typeof(ODataQueryOptions)) ||
                         (parameterType.IsGenericType &&
                          parameterType.GetGenericTypeDefinition() == typeof(ODataQueryOptions<>)));


### PR DESCRIPTION
### Issues

The ODataQueryParameterBindingAttribute fails if a class contains ODataQueryOptions as a property

### Description
I`m using a class ODataQueryOptionsWrapper that has a property of type public ODataQueryOptions<T> QueryOptions { get;  set; }
When using ODataQueryOptionsWrapper and ODataQueryOptions,as I cannot map directly from the api, I set on ODataQueryOptionsWrapper the QueryOptions property manually and because of the null check missing I get an error

Also this attribute does ignores [JsonIgnore], so even if the ODataQueryOptions  is marked as ignored, the attribute is triggered, but here I think is better if you guys decide how.
