### PR TITLE
Fix #1591 -  Honor namespace value when registering Types using Builder

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/EnumTypeConfiguration.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EnumTypeConfiguration.cs
@@ -46,7 +46,8 @@ namespace Microsoft.AspNet.OData.Builder
             ModelBuilder = builder;
             _name = clrType.EdmName();
 
-            // Use the namespace is uder specified one, otherwise use CLR Namespace. If CLR Namespace is null we fallback to "Default"
+            // Use the namespace if one was provided in builder by the user, otherwise fallback to CLR Namespace.
+            // If CLR Namespace is null we fallback to "Default"
             // This can still be overriden by using DataContract attribute.
             _namespace = builder.HasAssignedNamespace ? builder.Namespace : clrType.Namespace ?? builder.Namespace;
 

--- a/src/Microsoft.AspNet.OData.Shared/Builder/EnumTypeConfiguration.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EnumTypeConfiguration.cs
@@ -17,7 +17,6 @@ namespace Microsoft.AspNet.OData.Builder
     /// </summary>
     public class EnumTypeConfiguration : IEdmTypeConfiguration
     {
-        private const string DefaultNamespace = "Default";
         private string _namespace;
         private string _name;
         private NullableEnumTypeConfiguration nullableEnumTypeConfiguration = null;
@@ -46,7 +45,11 @@ namespace Microsoft.AspNet.OData.Builder
             UnderlyingType = Enum.GetUnderlyingType(clrType);
             ModelBuilder = builder;
             _name = clrType.EdmName();
-            _namespace = clrType.Namespace ?? DefaultNamespace;
+
+            // Use the namespace is uder specified one, otherwise use CLR Namespace. If CLR Namespace is null we fallback to "Default"
+            // This can still be overriden by using DataContract attribute.
+            _namespace = builder.HasAssignedNamespace ? builder.Namespace : clrType.Namespace ?? builder.Namespace;
+
             ExplicitMembers = new Dictionary<Enum, EnumMemberConfiguration>();
             RemovedMembers = new List<Enum>();
         }

--- a/src/Microsoft.AspNet.OData.Shared/Builder/ODataModelBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/ODataModelBuilder.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNet.OData.Builder
             }
             set
             {
-                if (string.IsNullOrEmpty(value))
+                if (String.IsNullOrEmpty(value))
                 {
                     throw Error.PropertyNull();
                 }

--- a/src/Microsoft.AspNet.OData.Shared/Builder/ODataModelBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/ODataModelBuilder.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.OData.Builder
         /// </summary>
         public ODataModelBuilder()
         {
-            Namespace = "Default";
+            _namespace = "Default";
             ContainerName = "Container";
             DataServiceVersion = _defaultDataServiceVersion;
             MaxDataServiceVersion = _defaultMaxDataServiceVersion;

--- a/src/Microsoft.AspNet.OData.Shared/Builder/ODataModelBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/ODataModelBuilder.cs
@@ -16,6 +16,8 @@ namespace Microsoft.AspNet.OData.Builder
     /// </summary>
     public class ODataModelBuilder
     {
+        private const string DefaultNamespace = "Default";
+
         private static readonly Version _defaultDataServiceVersion = EdmConstants.EdmVersion4;
         private static readonly Version _defaultMaxDataServiceVersion = EdmConstants.EdmVersion4;
 
@@ -35,11 +37,12 @@ namespace Microsoft.AspNet.OData.Builder
         /// </summary>
         public ODataModelBuilder()
         {
-            _namespace = "Default";
+            _namespace = DefaultNamespace;
             ContainerName = "Container";
             DataServiceVersion = _defaultDataServiceVersion;
             MaxDataServiceVersion = _defaultMaxDataServiceVersion;
             BindingOptions = NavigationPropertyBindingOption.None;
+            HasAssignedNamespace = false;
         }
 
         /// <summary>
@@ -53,13 +56,17 @@ namespace Microsoft.AspNet.OData.Builder
             }
             set
             {
+                // If user chooses to set the namespace to null, we revert back to 'Default' namespace.
                 if (String.IsNullOrEmpty(value))
                 {
-                    throw Error.PropertyNull();
+                    this.HasAssignedNamespace = false;
+                    _namespace = DefaultNamespace;
                 }
-
-                this.HasAssignedNamespace = true;
-                _namespace = value;
+                else
+                {
+                    this.HasAssignedNamespace = true;
+                    _namespace = value;
+                }
             }
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Builder/ODataModelBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/ODataModelBuilder.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNet.OData.Builder
 
         private Version _dataServiceVersion;
         private Version _maxDataServiceVersion;
+        private string _namespace;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataModelBuilder"/> class.
@@ -44,7 +45,23 @@ namespace Microsoft.AspNet.OData.Builder
         /// <summary>
         /// Gets or sets the namespace that will be used for the resulting model
         /// </summary>
-        public string Namespace { get; set; }
+        public string Namespace
+        {
+            get
+            {
+                return _namespace;
+            }
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw Error.PropertyNull();
+                }
+
+                this.HasAssignedNamespace = true;
+                _namespace = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the name of the container that will hold all the navigation sources, actions and functions
@@ -141,6 +158,14 @@ namespace Microsoft.AspNet.OData.Builder
         /// Gets or sets the navigation property binding options.
         /// </summary>
         public NavigationPropertyBindingOption BindingOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="Namespace"/> was auto assigned or is using a value assigned by user.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the <see cref="Namespace"/> is using user assigned value; otherwise, <c>false</c>.
+        /// </value>
+        internal bool HasAssignedNamespace { get; private set; }
 
         /// <summary>
         /// Registers an entity type as part of the model and returns an object that can be used to configure the entity type.

--- a/src/Microsoft.AspNet.OData.Shared/Builder/StructuralTypeConfiguration.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/StructuralTypeConfiguration.cs
@@ -58,7 +58,9 @@ namespace Microsoft.AspNet.OData.Builder
             ModelBuilder = modelBuilder;
             _name = clrType.EdmName();
 
-            // Use the namespace is uder specified one, otherwise use CLR Namespace. If CLR Namespace is null we fallback to "Default"
+            // Use the namespace if one was provided in builder by the user, otherwise fallback to CLR Namespace.
+            // If CLR Namespace is null we fallback to "Default"
+            // This can still be overriden by using DataContract attribute.
             _namespace = modelBuilder.HasAssignedNamespace ? modelBuilder.Namespace : clrType.Namespace ?? modelBuilder.Namespace;
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Builder/StructuralTypeConfiguration.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/StructuralTypeConfiguration.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNet.OData.Builder
     /// </summary>
     public abstract class StructuralTypeConfiguration : IEdmTypeConfiguration
     {
-        private const string DefaultNamespace = "Default";
         private string _namespace;
         private string _name;
         private PropertyInfo _dynamicPropertyDictionary;
@@ -58,7 +57,9 @@ namespace Microsoft.AspNet.OData.Builder
             ClrType = clrType;
             ModelBuilder = modelBuilder;
             _name = clrType.EdmName();
-            _namespace = clrType.Namespace ?? DefaultNamespace;
+
+            // Use the namespace is uder specified one, otherwise use CLR Namespace. If CLR Namespace is null we fallback to "Default"
+            _namespace = modelBuilder.HasAssignedNamespace ? modelBuilder.Namespace : clrType.Namespace ?? modelBuilder.Namespace;
         }
 
         /// <summary>

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/EnumTypeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/EnumTypeTest.cs
@@ -1127,6 +1127,38 @@ namespace Microsoft.AspNet.OData.Test.Builder
             Assert.Contains(enumType.Members, (m) => m.Name.Equals("KeepDefaultName"));
         }
 
+        /// <summary>
+        /// Tests the namespace assignment logic to ensure that user assigned namespaces are honored during registration.
+        /// </summary>
+        [Fact]
+        public void NamespaceAssignment_AutoAssignsNamespaceToEnumType_AssignedNamespace()
+        {
+            // Act.
+            string expectedNamespace = "TestingNamespace";
+            ODataConventionModelBuilder modelBuilder = new ODataConventionModelBuilder()
+            {
+                Namespace = expectedNamespace
+            };
+
+            // Assert
+            Assert.Equal(expectedNamespace, modelBuilder.EnumType<ValueOutOfRangeEnum>().Namespace);
+            Assert.Equal("Test", modelBuilder.EnumType<Life>().Namespace);
+        }
+
+        /// <summary>
+        /// Tests the namespace assignment logic to ensure that user assigned namespaces are honored during registration.
+        /// </summary>
+        [Fact]
+        public void NamespaceAssignment_AutoAssignsNamespaceToEnumType_DefaultNamespace()
+        {
+            // Act.
+            ODataConventionModelBuilder modelBuilder = new ODataConventionModelBuilder();
+
+            // Assert
+            Assert.Equal(typeof(Life).Namespace, modelBuilder.EnumType<ValueOutOfRangeEnum>().Namespace);
+            Assert.Equal("Test", modelBuilder.EnumType<Life>().Namespace);
+        }
+
         private IEdmStructuredType AddComplexTypeWithODataConventionModelBuilder()
         {
             var builder = ODataConventionModelBuilderFactory.Create();

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/EnumTypeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/EnumTypeTest.cs
@@ -1133,7 +1133,7 @@ namespace Microsoft.AspNet.OData.Test.Builder
         [Fact]
         public void NamespaceAssignment_AutoAssignsNamespaceToEnumType_AssignedNamespace()
         {
-            // Act.
+            // Arrange and Act.
             string expectedNamespace = "TestingNamespace";
             ODataConventionModelBuilder modelBuilder = new ODataConventionModelBuilder()
             {
@@ -1151,7 +1151,7 @@ namespace Microsoft.AspNet.OData.Test.Builder
         [Fact]
         public void NamespaceAssignment_AutoAssignsNamespaceToEnumType_DefaultNamespace()
         {
-            // Act.
+            // Arrange and Act.
             ODataConventionModelBuilder modelBuilder = new ODataConventionModelBuilder();
 
             // Assert

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/StructuralTypeConfigurationTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/StructuralTypeConfigurationTest.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.AspNet.OData.Builder;
 using Microsoft.AspNet.OData.Test.Builder.TestModels;
-using Microsoft.AspNet.OData.Test.Builder.TestModelss;
 using Microsoft.AspNet.OData.Test.Common;
 using Moq;
 using Xunit;
@@ -63,7 +62,7 @@ namespace Microsoft.AspNet.OData.Test.Builder
         [Fact]
         public void NamespaceAssignment_AutoAssignsNamespaceToStructuralType_AssignedNamespace()
         {
-            // Act.
+            // Arrange & Act.
             string expectedNamespace = "TestingNamespace";
             ODataConventionModelBuilder modelBuilder = new ODataConventionModelBuilder()
             {
@@ -82,12 +81,38 @@ namespace Microsoft.AspNet.OData.Test.Builder
         }
 
         /// <summary>
+        /// Tests the namespace assignment logic to ensure that user assigned namespaces are honored during registration
+        /// but individual types can have namespaces assigned to them as well.
+        /// </summary>
+        [Fact]
+        public void NamespaceAssignment_AutoAssignsNamespaceToStructuralType_AssignedNamespaceAndClassNamespace()
+        {
+            // Arrange & Act.
+            string expectedNamespace = "TestingNamespace";
+            ODataConventionModelBuilder modelBuilder = new ODataConventionModelBuilder()
+            {
+                Namespace = expectedNamespace
+            };
+
+            modelBuilder.EntitySet<Client>("clients");
+            modelBuilder.EntitySet<MyOrder>("orders").EntityType.Namespace = "DifferentNamespace";
+            modelBuilder.ComplexType<ZipCode>();
+
+            // Assert
+            Assert.Equal(expectedNamespace, modelBuilder.EntityType<Client>().Namespace);
+            Assert.Equal("DifferentNamespace", modelBuilder.EntityType<MyOrder>().Namespace);
+            Assert.Equal(expectedNamespace, modelBuilder.EntityType<OrderLine>().Namespace);
+            Assert.Equal(expectedNamespace, modelBuilder.EntityType<OrderHeader>().Namespace);
+            Assert.Equal(expectedNamespace, modelBuilder.ComplexType<ZipCode>().Namespace);
+        }
+
+        /// <summary>
         /// Tests the namespace assignment logic to ensure that default CLR namespace is used if user does not assign one.
         /// </summary>
         [Fact]
         public void NamespaceAssignment_AutoAssignsNamespaceToStructuralType_DefaultNamespace()
         {
-            // Act.
+            // Arrange & Act.
             ODataConventionModelBuilder modelBuilder = new ODataConventionModelBuilder();
 
             modelBuilder.EntitySet<Client>("clients");
@@ -107,7 +132,7 @@ namespace Microsoft.AspNet.OData.Test.Builder
         [Fact]
         public void NamespaceAssignment_AutoAssignsNamespaceToStructuralType_NamespaceAssignedAfterAddingEntities()
         {
-            // Act.
+            // Arrange & Act.
             string expectedNamespace = "TestingNamespace";
             ODataConventionModelBuilder modelBuilder = new ODataConventionModelBuilder();
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/StructuralTypeConfigurationTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/StructuralTypeConfigurationTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.OData.Test.Builder
         /// Tests the namespace assignment logic to ensure that user assigned namespaces are honored during registration.
         /// </summary>
         [Fact]
-        public void NamespaceAssignment_AutoAssignsNamespaceToEntity_AssignedNamespace()
+        public void NamespaceAssignment_AutoAssignsNamespaceToStructuralType_AssignedNamespace()
         {
             // Act.
             string expectedNamespace = "TestingNamespace";
@@ -85,7 +85,7 @@ namespace Microsoft.AspNet.OData.Test.Builder
         /// Tests the namespace assignment logic to ensure that default CLR namespace is used if user does not assign one.
         /// </summary>
         [Fact]
-        public void NamespaceAssignment_AutoAssignsNamespaceToEntity_DefaultNamespace()
+        public void NamespaceAssignment_AutoAssignsNamespaceToStructuralType_DefaultNamespace()
         {
             // Act.
             ODataConventionModelBuilder modelBuilder = new ODataConventionModelBuilder();
@@ -99,6 +99,30 @@ namespace Microsoft.AspNet.OData.Test.Builder
             Assert.Equal(typeof(OrderLine).Namespace, modelBuilder.EntityType<OrderLine>().Namespace);
             Assert.Equal(typeof(OrderHeader).Namespace, modelBuilder.EntityType<OrderHeader>().Namespace);
             Assert.Equal(typeof(ZipCode).Namespace, modelBuilder.ComplexType<ZipCode>().Namespace);
+        }
+
+        /// <summary>
+        /// Tests the namespace assignment logic to check the order in which namespace is assigned matters.
+        /// </summary>
+        [Fact]
+        public void NamespaceAssignment_AutoAssignsNamespaceToStructuralType_NamespaceAssignedAfterAddingEntities()
+        {
+            // Act.
+            string expectedNamespace = "TestingNamespace";
+            ODataConventionModelBuilder modelBuilder = new ODataConventionModelBuilder();
+
+            modelBuilder.EntitySet<Client>("clients");
+
+            modelBuilder.Namespace = expectedNamespace;
+            modelBuilder.ComplexType<ZipCode>();
+
+            // Assert
+            // Client was registered explicitly so picks up the namespace. Auto discovery is done at model generation hence uses the assigned namespace
+            Assert.Equal(typeof(Client).Namespace, modelBuilder.EntityType<Client>().Namespace);
+            Assert.Equal(expectedNamespace, modelBuilder.EntityType<MyOrder>().Namespace);
+            Assert.Equal(expectedNamespace, modelBuilder.EntityType<OrderLine>().Namespace);
+            Assert.Equal(expectedNamespace, modelBuilder.EntityType<OrderHeader>().Namespace);
+            Assert.Equal(expectedNamespace, modelBuilder.ComplexType<ZipCode>().Namespace);
         }
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/StructuralTypeConfigurationTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/StructuralTypeConfigurationTest.cs
@@ -81,6 +81,31 @@ namespace Microsoft.AspNet.OData.Test.Builder
         }
 
         /// <summary>
+        /// Tests the namespace assignment logic to ensure that user assigned namespaces are honored during registration.
+        /// </summary>
+        [Fact]
+        public void NamespaceAssignment_SettingNamespaceToNullOrEmptyRevertsItToDefault()
+        {
+            // Arrange & Act.
+            ODataConventionModelBuilder modelBuilderWithNullNamespace = new ODataConventionModelBuilder()
+            {
+                Namespace = null
+            };
+
+            // Assert
+            Assert.Equal("Default", modelBuilderWithNullNamespace.Namespace);
+
+
+            ODataConventionModelBuilder modelBuilderWithEmptyNamespace = new ODataConventionModelBuilder()
+            {
+                Namespace = string.Empty
+            };
+
+            // Assert
+            Assert.Equal("Default", modelBuilderWithEmptyNamespace.Namespace);
+        }
+
+        /// <summary>
         /// Tests the namespace assignment logic to ensure that user assigned namespaces are honored during registration
         /// but individual types can have namespaces assigned to them as well.
         /// </summary>

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/StructuralTypeConfigurationTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/StructuralTypeConfigurationTest.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Test.Builder.TestModels;
+using Microsoft.AspNet.OData.Test.Builder.TestModelss;
 using Microsoft.AspNet.OData.Test.Common;
 using Moq;
 using Xunit;
@@ -53,6 +55,50 @@ namespace Microsoft.AspNet.OData.Test.Builder
             ExceptionAssert.ThrowsArgument(() => configuration.AddDynamicPropertyDictionary(property),
                 "propertyInfo",
                 string.Format("The argument must be of type '{0}'.", "IDictionary<string, object>"));
+        }
+
+        /// <summary>
+        /// Tests the namespace assignment logic to ensure that user assigned namespaces are honored during registration.
+        /// </summary>
+        [Fact]
+        public void NamespaceAssignment_AutoAssignsNamespaceToEntity_AssignedNamespace()
+        {
+            // Act.
+            string expectedNamespace = "TestingNamespace";
+            ODataConventionModelBuilder modelBuilder = new ODataConventionModelBuilder()
+            {
+                Namespace = expectedNamespace
+            };
+
+            modelBuilder.EntitySet<Client>("clients");
+            modelBuilder.ComplexType<ZipCode>();
+
+            // Assert
+            Assert.Equal(expectedNamespace, modelBuilder.EntityType<Client>().Namespace);
+            Assert.Equal(expectedNamespace, modelBuilder.EntityType<MyOrder>().Namespace);
+            Assert.Equal(expectedNamespace, modelBuilder.EntityType<OrderLine>().Namespace);
+            Assert.Equal(expectedNamespace, modelBuilder.EntityType<OrderHeader>().Namespace);
+            Assert.Equal(expectedNamespace, modelBuilder.ComplexType<ZipCode>().Namespace);
+        }
+
+        /// <summary>
+        /// Tests the namespace assignment logic to ensure that default CLR namespace is used if user does not assign one.
+        /// </summary>
+        [Fact]
+        public void NamespaceAssignment_AutoAssignsNamespaceToEntity_DefaultNamespace()
+        {
+            // Act.
+            ODataConventionModelBuilder modelBuilder = new ODataConventionModelBuilder();
+
+            modelBuilder.EntitySet<Client>("clients");
+            modelBuilder.ComplexType<ZipCode>();
+
+            // Assert
+            Assert.Equal(typeof(Client).Namespace, modelBuilder.EntityType<Client>().Namespace);
+            Assert.Equal(typeof(MyOrder).Namespace, modelBuilder.EntityType<MyOrder>().Namespace);
+            Assert.Equal(typeof(OrderLine).Namespace, modelBuilder.EntityType<OrderLine>().Namespace);
+            Assert.Equal(typeof(OrderHeader).Namespace, modelBuilder.EntityType<OrderHeader>().Namespace);
+            Assert.Equal(typeof(ZipCode).Namespace, modelBuilder.ComplexType<ZipCode>().Namespace);
         }
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/TestModels/Client.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/TestModels/Client.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using Microsoft.AspNet.OData.Test.Builder.TestModels;
 
-namespace Microsoft.AspNet.OData.Test.Builder.TestModelss
+namespace Microsoft.AspNet.OData.Test.Builder.TestModels
 {
     public class Client
     {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/ODataActionPayloadDeserializerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/ODataActionPayloadDeserializerTest.cs
@@ -499,7 +499,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
         private const string EntityPayload =
             "{" +
                 "\"Id\": 1, " +
-                "\"Customer\": {\"@odata.type\":\"#Microsoft.AspNet.OData.Test.Common.Models.Customer\", \"Id\":109,\"Name\":\"Avatar\" } " +
+                "\"Customer\": {\"@odata.type\":\"#A.B.Customer\", \"Id\":109,\"Name\":\"Avatar\" } " +
                 // null can't work here, see: https://github.com/OData/odata.net/issues/99
                 // ",\"NullableCustomer\" : null " +  //
             "}";
@@ -567,10 +567,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
             "{" +
                 "\"Id\": 1, " +
                 "\"Customers\": [" +
-                    "{\"@odata.type\":\"#Microsoft.AspNet.OData.Test.Common.Models.Customer\", \"Id\":109,\"Name\":\"Avatar\" }, " +
+                    "{\"@odata.type\":\"#A.B.Customer\", \"Id\":109,\"Name\":\"Avatar\" }, " +
                     // null can't work. see: https://github.com/OData/odata.net/issues/100
                     // "null," +
-                    "{\"@odata.type\":\"#Microsoft.AspNet.OData.Test.Common.Models.Customer\", \"Id\":901,\"Name\":\"Robot\" } " +
+                    "{\"@odata.type\":\"#A.B.Customer\", \"Id\":901,\"Name\":\"Robot\" } " +
                  "]" +
             "}";
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataActionTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataActionTests.cs
@@ -74,10 +74,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter
         }
 
         private const string EntityPayload = @"{ 
-                ""Customer"": {""@odata.type"":""#Microsoft.AspNet.OData.Test.Formatter.Customer"", ""ID"":101,""Name"":""Avatar"" } , 
+                ""Customer"": {""@odata.type"":""#org.odata.Customer"", ""ID"":101,""Name"":""Avatar"" } , 
                 ""Customers"": [
-                    {""@odata.type"":""#Microsoft.AspNet.OData.Test.Formatter.Customer"", ""ID"":901,""Name"":""John"" } , 
-                    {""@odata.type"":""#Microsoft.AspNet.OData.Test.Formatter.SubCustomer"", ""ID"":902,""Name"":""Mike"", ""Price"": 9.9 } 
+                    {""@odata.type"":""#org.odata.Customer"", ""ID"":901,""Name"":""John"" } , 
+                    {""@odata.type"":""#org.odata.SubCustomer"", ""ID"":902,""Name"":""Mike"", ""Price"": 9.9 } 
                 ]
             }";
 
@@ -229,12 +229,12 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             var model = new EdmModel();
 
             // entity type customer
-            EdmEntityType customer = new EdmEntityType("Microsoft.AspNet.OData.Test.Formatter", "Customer");
+            EdmEntityType customer = new EdmEntityType("org.odata", "Customer");
             customer.AddKeys(customer.AddStructuralProperty("ID", EdmPrimitiveTypeKind.Int32));
             customer.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
             model.AddElement(customer);
 
-            EdmEntityType subCustomer = new EdmEntityType("Microsoft.AspNet.OData.Test.Formatter", "SubCustomer", customer);
+            EdmEntityType subCustomer = new EdmEntityType("org.odata", "SubCustomer", customer);
             customer.AddKeys(subCustomer.AddStructuralProperty("Price", EdmPrimitiveTypeKind.Double));
             model.AddElement(subCustomer);
 
@@ -402,7 +402,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             Assert.Equal(2, customers.Count());
             EdmEntityObject entity = customers.First() as EdmEntityObject;
             IEdmTypeReference typeReference = entity.GetEdmType();
-            Assert.Equal("Microsoft.AspNet.OData.Test.Formatter.Customer", typeReference.FullName());
+            Assert.Equal("org.odata.Customer", typeReference.FullName());
 
             customer = customers.First();
             Assert.NotNull(customer);
@@ -411,7 +411,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
 
             entity = customers.Last() as EdmEntityObject;
             typeReference = entity.GetEdmType();
-            Assert.Equal("Microsoft.AspNet.OData.Test.Formatter.SubCustomer", typeReference.FullName());
+            Assert.Equal("org.odata.SubCustomer", typeReference.FullName());
             customer = customers.Last();
             Assert.NotNull(customer);
             Assert.Equal(902, customer.ID);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/ODataActionParametersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/ODataActionParametersTest.cs
@@ -23,9 +23,9 @@ namespace Microsoft.AspNet.OData.Test
 
         [Theory]
         [InlineData("Drive", "Vehicles(Model=6,Name='6')/org.odata.Drive")]
-        [InlineData("Drive", "Vehicles(Model=6,Name='6')/Microsoft.AspNet.OData.Test.Builder.TestModels.Car/org.odata.Drive")]
+        [InlineData("Drive", "Vehicles(Model=6,Name='6')/org.odata.Car/org.odata.Drive")]
         [InlineData("Drive", "MyVehicle/org.odata.Drive")]
-        [InlineData("Drive", "MyVehicle/Microsoft.AspNet.OData.Test.Builder.TestModels.Car/org.odata.Drive")]
+        [InlineData("Drive", "MyVehicle/org.odata.Car/org.odata.Drive")]
         public void Can_Find_Action_QualifiedActionName(string actionName, string url)
         {
             // Arrange
@@ -44,9 +44,9 @@ namespace Microsoft.AspNet.OData.Test
 
         [Theory]
         [InlineData("Vehicles(Model=6,Name='6')/Drive")]
-        [InlineData("Vehicles(Model=6,Name='6')/Microsoft.AspNet.OData.Test.Builder.TestModels.Car/Drive")]
+        [InlineData("Vehicles(Model=6,Name='6')/org.odata.Car/Drive")]
         [InlineData("MyVehicle/Drive")]
-        [InlineData("MyVehicle/Microsoft.AspNet.OData.Test.Builder.TestModels.Car/Drive")]
+        [InlineData("MyVehicle/org.odata.Car/Drive")]
         public void CanParse_UnqualifiedBoundAction(string url)
         {
             // Arrange
@@ -61,8 +61,8 @@ namespace Microsoft.AspNet.OData.Test
 
 
         [Theory]
-        [InlineData("Vehicles(Model=8,Name='8')/Microsoft.AspNet.OData.Test.Builder.TestModels.Car/org.odata.Wash")]
-        [InlineData("MyVehicle/Microsoft.AspNet.OData.Test.Builder.TestModels.Car/org.odata.Wash")]
+        [InlineData("Vehicles(Model=8,Name='8')/org.odata.Car/org.odata.Wash")]
+        [InlineData("MyVehicle/org.odata.Car/org.odata.Wash")]
         public void Can_find_action_overload_using_bindingparameter_type(string url)
         {
             // Arrange
@@ -80,8 +80,8 @@ namespace Microsoft.AspNet.OData.Test
         }
 
         [Theory]
-        [InlineData("Vehicles(Model=8,Name='8')/Microsoft.AspNet.OData.Test.Builder.TestModels.Car/customize.NSAction")]
-        [InlineData("MyVehicle/Microsoft.AspNet.OData.Test.Builder.TestModels.Car/customize.NSAction")]
+        [InlineData("Vehicles(Model=8,Name='8')/org.odata.Car/customize.NSAction")]
+        [InlineData("MyVehicle/org.odata.Car/customize.NSAction")]
         public void Can_Find_Customized_Namespace_Action(string url)
         {
             // Arrange
@@ -119,7 +119,7 @@ namespace Microsoft.AspNet.OData.Test
 
             // Act & Assert
             ExceptionAssert.Throws<ODataException>(() =>
-                new DefaultODataPathHandler().Parse(model, _serviceRoot, "Vehicles/Microsoft.AspNet.OData.Test.Builder.TestModels.Car(Model=8,Name='8')/org.odata.Park"),
+                new DefaultODataPathHandler().Parse(model, _serviceRoot, "Vehicles/org.odata.Car(Model=8,Name='8')/org.odata.Park"),
                 "Multiple action overloads were found with the same binding parameter for 'org.odata.Park'.");
         }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/ODataContainmentTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/ODataContainmentTest.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Builder.TestModels;
-using Microsoft.AspNet.OData.Test.Builder.TestModelss;
 using Microsoft.AspNet.OData.Test.Common;
 using Microsoft.OData.Edm;
 using Newtonsoft.Json.Linq;

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/ODataContainmentTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/ODataContainmentTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.OData.Test
         public async Task GetSpecialOrderLines_Containment()
         {
             // Arrange
-            var requestUri = BaseAddress + "/odata/MyOrders(1)/OrderLines/Microsoft.AspNet.OData.Test.Builder.TestModels.SpecialOrderLine";
+            var requestUri = BaseAddress + "/odata/MyOrders(1)/OrderLines/ns.SpecialOrderLine";
 
             // Act
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
@@ -71,12 +71,12 @@ namespace Microsoft.AspNet.OData.Test
             // Assert
             Assert.True(response.IsSuccessStatusCode);
             Assert.Contains(
-                "http://localhost/odata/$metadata#MyOrders(1)/OrderLines/Microsoft.AspNet.OData.Test.Builder.TestModels.SpecialOrderLine",
+                "http://localhost/odata/$metadata#MyOrders(1)/OrderLines/ns.SpecialOrderLine",
                 (string)result["@odata.context"]);
         }
 
         [Theory]
-        [InlineData("/odata/MyOrders(2)/Microsoft.AspNet.OData.Test.Builder.TestModels.MySpecialOrder")]
+        [InlineData("/odata/MyOrders(2)/ns.MySpecialOrder")]
         [InlineData("/odata/MyOrders(2)")]
         public async Task GetMyOrder_WithOrWithoutCastType_Containment(string url)
         {
@@ -91,7 +91,7 @@ namespace Microsoft.AspNet.OData.Test
             // Assert
             Assert.True(response.IsSuccessStatusCode);
             Assert.Contains(
-                "http://localhost/odata/$metadata#MyOrders/Microsoft.AspNet.OData.Test.Builder.TestModels.MySpecialOrder/$entity",
+                "http://localhost/odata/$metadata#MyOrders/ns.MySpecialOrder/$entity",
                 (string)result["@odata.context"]);
         }
 
@@ -201,9 +201,9 @@ namespace Microsoft.AspNet.OData.Test
             Assert.Equal("http://localhost/odata/MyOrders(1)/OrderLines/$ref", myOrder["OrderLines@odata.associationLink"]);
             var mySpecialOrder = array[1];
             Assert.Equal("http://localhost/odata/MyOrders(2)", mySpecialOrder["@odata.id"]);
-            Assert.Equal("http://localhost/odata/MyOrders(2)/Microsoft.AspNet.OData.Test.Builder.TestModels.MySpecialOrder", mySpecialOrder["@odata.editLink"]);
-            Assert.Equal("http://localhost/odata/MyOrders(2)/Microsoft.AspNet.OData.Test.Builder.TestModels.MySpecialOrder/OrderLines", mySpecialOrder["OrderLines@odata.navigationLink"]);
-            Assert.Equal("http://localhost/odata/MyOrders(2)/Microsoft.AspNet.OData.Test.Builder.TestModels.MySpecialOrder/OrderLines/$ref", mySpecialOrder["OrderLines@odata.associationLink"]);
+            Assert.Equal("http://localhost/odata/MyOrders(2)/ns.MySpecialOrder", mySpecialOrder["@odata.editLink"]);
+            Assert.Equal("http://localhost/odata/MyOrders(2)/ns.MySpecialOrder/OrderLines", mySpecialOrder["OrderLines@odata.navigationLink"]);
+            Assert.Equal("http://localhost/odata/MyOrders(2)/ns.MySpecialOrder/OrderLines/$ref", mySpecialOrder["OrderLines@odata.associationLink"]);
         }
 
         [Fact]
@@ -253,15 +253,15 @@ namespace Microsoft.AspNet.OData.Test
             Assert.Equal("ns.Tag", tag["title"]);
             Assert.Equal("http://localhost/odata/MyOrders(1)/OrderLines(2)/ns.Tag", tag["target"]);
             orderLine = orderLines[1];
-            Assert.Equal("#Microsoft.AspNet.OData.Test.Builder.TestModels.SpecialOrderLine", orderLine["@odata.type"]);
+            Assert.Equal("#ns.SpecialOrderLine", orderLine["@odata.type"]);
             Assert.Equal("MyOrders(1)/OrderLines(22)", orderLine["@odata.id"]);
             Assert.Equal(
-                "MyOrders(1)/OrderLines(22)/Microsoft.AspNet.OData.Test.Builder.TestModels.SpecialOrderLine",
+                "MyOrders(1)/OrderLines(22)/ns.SpecialOrderLine",
                 orderLine["@odata.editLink"]);
             tag = orderLine["#ns.Tag"];
             Assert.Equal("ns.Tag", tag["title"]);
             Assert.Equal(
-                "http://localhost/odata/MyOrders(1)/OrderLines(22)/Microsoft.AspNet.OData.Test.Builder.TestModels.OrderLine/ns.Tag",
+                "http://localhost/odata/MyOrders(1)/OrderLines(22)/ns.OrderLine/ns.Tag",
                 tag["target"]);
         }
 
@@ -504,7 +504,7 @@ namespace Microsoft.AspNet.OData.Test
             }
 
             [EnableQuery]
-            [ODataRoute("MyOrders({orderId})/Microsoft.AspNet.OData.Test.Builder.TestModels.MySpecialOrder")]
+            [ODataRoute("MyOrders({orderId})/ns.MySpecialOrder")]
             public SingleResult<MySpecialOrder> GetMySpecialOrder(int orderId)
             {
                 var result = _myOrders.AsQueryable().Where(mo => mo.ID == orderId).OfType<MySpecialOrder>();
@@ -517,7 +517,7 @@ namespace Microsoft.AspNet.OData.Test
                 return _orderLines.AsQueryable().Where(orderLine => orderLine.OrderId == orderId);
             }
 
-            [ODataRoute("MyOrders({orderId})/OrderLines/Microsoft.AspNet.OData.Test.Builder.TestModels.SpecialOrderLine")]
+            [ODataRoute("MyOrders({orderId})/OrderLines/ns.SpecialOrderLine")]
             public IQueryable<SpecialOrderLine> GetSpecialOrderLines(int orderId)
             {
                 return _orderLines.AsQueryable().Where(orderLine => orderLine.OrderId == orderId).OfType<SpecialOrderLine>();


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1591*

### Description
- Honoring Namespace value passed to ModelBuilder for all classes registered. If user passed a value that value is used as the namespace for the registered types by default. If no value is specified by the user fallback to CLR namespace. If CLR namespace is null, we use 'Default' as the namespace.
This PR also brings a parity between the namespace value used on Actions\Functions and the actual namespace of the entity.
- Fixed the build to run on machines which are running just VS2017, also fixed for machines running Preview version of VS2017.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary
This might be regarded as a breaking change (it was an acting bug imo tho.) So based on that a Doc change might be required. Since users are expected to use namespace in front of action\function name and that behavior has not changed maybe no documentation will be needed. However $metadata document generation will change with this PR.

