### PR TITLE
CSDL returned from $metadata endpoint has incorrect "Unicode" attributes

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EdmModelHelperMethods.cs
@@ -872,8 +872,9 @@ namespace Microsoft.AspNet.OData.Builder
                 }
                 else if (configuration.Kind == EdmTypeKind.Primitive)
                 {
-                    PrimitiveTypeConfiguration primitiveTypeConfiguration = configuration as PrimitiveTypeConfiguration;
-                    return new EdmPrimitiveTypeReference(primitiveTypeConfiguration.EdmPrimitiveType, nullable);
+                    PrimitiveTypeConfiguration primitiveTypeConfiguration = (PrimitiveTypeConfiguration)configuration;
+                    EdmPrimitiveTypeKind typeKind = EdmTypeBuilder.GetTypeKind(primitiveTypeConfiguration.ClrType);
+                    return EdmCoreModel.Instance.GetPrimitive(typeKind, nullable);
                 }
                 else
                 {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/MetadataControllerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/MetadataControllerTest.cs
@@ -560,12 +560,12 @@ namespace Microsoft.AspNet.OData.Test
             "<Schema Namespace=\"Default\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
                 "<Action Name=\"NullableAction\" IsBound=\"true\">" +
                     "<Parameter Name=\"bindingParameter\" Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterPerson\" />" +
-                    "<Parameter Name=\"param\" Type=\"Edm.String\" Unicode=\"false\" />" +
+                    "<Parameter Name=\"param\" Type=\"Edm.String\" />" +
                     "<ReturnType Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterAddress\" />" +
                 "</Action>" +
                 "<Action Name=\"NonNullableAction\" IsBound=\"true\">" +
                     "<Parameter Name=\"bindingParameter\" Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterPerson\" />" +
-                    "<Parameter Name=\"param\" Type=\"Edm.String\" Nullable=\"false\" Unicode=\"false\" />" +
+                    "<Parameter Name=\"param\" Type=\"Edm.String\" Nullable=\"false\" />" +
                     "<ReturnType Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterAddress\" Nullable=\"false\" />" +
                 "</Action>" +
                 "<EntityContainer Name=\"Container\" /></Schema>" +
@@ -602,12 +602,12 @@ namespace Microsoft.AspNet.OData.Test
             "<Schema Namespace=\"Default\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
                 "<Function Name=\"NullableFunction\" IsBound=\"true\">" +
                     "<Parameter Name=\"bindingParameter\" Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterPerson\" />" +
-                    "<Parameter Name=\"param\" Type=\"Edm.String\" Unicode=\"false\" />" +
+                    "<Parameter Name=\"param\" Type=\"Edm.String\" />" +
                     "<ReturnType Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterAddress\" />" +
                 "</Function>" +
                 "<Function Name=\"NonNullableFunction\" IsBound=\"true\">" +
                     "<Parameter Name=\"bindingParameter\" Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterPerson\" />" +
-                    "<Parameter Name=\"param\" Type=\"Edm.String\" Nullable=\"false\" Unicode=\"false\" />" +
+                    "<Parameter Name=\"param\" Type=\"Edm.String\" Nullable=\"false\" />" +
                     "<ReturnType Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterAddress\" Nullable=\"false\" />" +
                 "</Function>" +
                 "<EntityContainer Name=\"Container\" />" +
@@ -644,14 +644,14 @@ namespace Microsoft.AspNet.OData.Test
             "<Schema Namespace=\"Default\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
                 "<Action Name=\"ActionWithOptional\" IsBound=\"true\">" +
                     "<Parameter Name=\"bindingParameter\" Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterPerson\" />" +
-                    "<Parameter Name=\"param1\" Type=\"Edm.String\" Unicode=\"false\">" +
+                    "<Parameter Name=\"param1\" Type=\"Edm.String\">" +
                       "<Annotation Term=\"Org.OData.Core.V1.OptionalParameter\">" +
                         "<Record>" +
                           "<PropertyValue Property=\"DefaultValue\" String=\"A default value\" />" +
                         "</Record>" +
                       "</Annotation>" +
                     "</Parameter>" +
-                    "<Parameter Name=\"param2\" Type=\"Edm.String\" Unicode=\"false\">" +
+                    "<Parameter Name=\"param2\" Type=\"Edm.String\">" +
                       "<Annotation Term=\"Org.OData.Core.V1.OptionalParameter\" />" +
                     "</Parameter>" +
                 "</Action>" +
@@ -686,19 +686,19 @@ namespace Microsoft.AspNet.OData.Test
             "<Schema Namespace=\"Default\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
                 "<Function Name=\"FunctionWithoutOptional\" IsBound=\"true\">" +
                     "<Parameter Name=\"bindingParameter\" Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterPerson\" />" +
-                    "<Parameter Name=\"param\" Type=\"Edm.String\" Unicode=\"false\" />" +
+                    "<Parameter Name=\"param\" Type=\"Edm.String\" />" +
                     "<ReturnType Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterAddress\" />" +
                 "</Function>" +
                 "<Function Name=\"FunctionWithOptional\" IsBound=\"true\">" +
                     "<Parameter Name=\"bindingParameter\" Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterPerson\" />" +
-                    "<Parameter Name=\"param1\" Type=\"Edm.String\" Unicode=\"false\">" +
+                    "<Parameter Name=\"param1\" Type=\"Edm.String\">" +
                       "<Annotation Term=\"Org.OData.Core.V1.OptionalParameter\">" +
                         "<Record>" +
                           "<PropertyValue Property=\"DefaultValue\" String=\"A default value\" />" +
                         "</Record>" +
                       "</Annotation>" +
                     "</Parameter>" +
-                    "<Parameter Name=\"param2\" Type=\"Edm.String\" Unicode=\"false\">" +
+                    "<Parameter Name=\"param2\" Type=\"Edm.String\">" +
                       "<Annotation Term=\"Org.OData.Core.V1.OptionalParameter\" />" +
                     "</Parameter>" +
                     "<ReturnType Type=\"Microsoft.AspNet.OData.Test.Formatter.FormatterAddress\" />" +


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #736 for Web API OData 6.x and later (it was already fixed for 5.9.1-5.11).

### Description

This fixes a logic error that was resulting in spurious `Unicode=false` attributes being emitted by the `CsdlWriter`.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

None
