### PR TITLE
Fixes #1600 - ActionDescriptorExtensions is not thread safe

### DIFF
--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/ActionDescriptorExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/ActionDescriptorExtensionsTest.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Moq;
+using Xunit;
+using ActionDescriptorExtensions = Microsoft.AspNet.OData.Extensions.ActionDescriptorExtensions;
+
+namespace Microsoft.AspNet.OData.Test.Extensions
+{
+
+    public class ActionDescriptorExtensionsTest
+    {
+        [Fact]
+        public void GetEdmModel_WillNotFail_With_Parallel_Calls()
+        {
+            var services = new Mock<IServiceProvider>();
+            services.Setup(s => s.GetService(typeof(ApplicationPartManager))).Returns(new ApplicationPartManager());
+            var request = new DefaultHttpRequest(new DefaultHttpContext { RequestServices = services.Object });
+            var ad = new ActionDescriptor();
+            Parallel.For(0, 10, i => { ActionDescriptorExtensions.GetEdmModel(ad, request, typeof(string)); });
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1600.*

### Description

Adds a sync lock to avoid multiple instances adding the same key to the actionDescriptor.Properties dictionary

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X ] *Build and test with one-click build and test script passed*

### Additional work necessary

Note that the tests pass if I correct a syntax error in PeopleController.cs, (missing comma) but that is outside the scope of this PR and should be fixed separately
