### PR TITLE
Add the iconUrl to the nuget spec

### DIFF
--- a/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.Nightly.Release.nuspec
+++ b/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.Nightly.Release.nuspec
@@ -13,6 +13,7 @@
     <licenseUrl>https://raw.githubusercontent.com/OData/WebApi/master/License.txt</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft AspNet WebApi AspNetWebApi OData</tags>
+    <iconUrl>http://static.tumblr.com/hgchgxz/9ualgdf98/icon.png</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AspNet.WebApi.Client" version="$AspNetPackageDependency$" />
       <dependency id="Microsoft.AspNet.WebApi.Core" version="$AspNetPackageDependency$" />

--- a/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.Release.nuspec
+++ b/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.Release.nuspec
@@ -13,6 +13,7 @@
     <licenseUrl>https://raw.githubusercontent.com/OData/WebApi/master/License.txt</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft AspNet WebApi AspNetWebApi OData</tags>
+    <iconUrl>http://static.tumblr.com/hgchgxz/9ualgdf98/icon.png</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AspNet.WebApi.Client" version="$AspNetPackageDependency$" />
       <dependency id="Microsoft.AspNet.WebApi.Core" version="$AspNetPackageDependency$" />

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.Nightly.Release.nuspec
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.Nightly.Release.nuspec
@@ -13,6 +13,7 @@
     <licenseUrl>https://raw.githubusercontent.com/OData/WebApi/master/License.txt</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft AspNetCore WebApi OData</tags>
+    <iconUrl>http://static.tumblr.com/hgchgxz/9ualgdf98/icon.png</iconUrl>
     <dependencies>
         <group targetFramework=".NETStandard2.0">
           <dependency id="Microsoft.AspNetCore.Mvc.Core" version="$AspNetCorePackageDependency$" />

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.Release.nuspec
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.Release.nuspec
@@ -13,6 +13,7 @@
     <licenseUrl>https://raw.githubusercontent.com/OData/WebApi/master/License.txt</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft AspNetCore WebApi OData</tags>
+    <iconUrl>http://static.tumblr.com/hgchgxz/9ualgdf98/icon.png</iconUrl>
     <dependencies>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.AspNetCore.Mvc.Core" version="$AspNetCorePackageDependency$" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* The [Page](https://www.nuget.org/packages/Microsoft.AspNetCore.OData/7.0.0-beta4) shows the default Icon for the Web API OData package.

However, it should use the OData default icon as below.

![image](https://user-images.githubusercontent.com/9426627/45327347-03a24000-b50c-11e8-820c-968d2eead13d.png)


### Description

*The PR is to fix that.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
