### PR TITLE
Improving the error message for when an unknown property is deserialized

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
@@ -263,6 +263,15 @@ namespace Microsoft.AspNet.OData.Common
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The property &apos;{0}&apos; does not exist on type &apos;{1}&apos;. Make sure to only use property names that are defined by the type..
+        /// </summary>
+        internal static string CannotDeserializeUnknownProperty {
+            get {
+                return ResourceManager.GetString("CannotDeserializeUnknownProperty", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Cannot define keys on type &apos;{0}&apos; deriving from &apos;{1}&apos;. The base type in the entity inheritance hierarchy already contains keys..
         /// </summary>
         internal static string CannotDefineKeysOnDerivedTypes {

--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CannotDeserializeUnknownProperty" xml:space="preserve">
+    <value>The property '{0}' does not exist on type '{1}'. Make sure to only use property names that are defined by the type.</value>
+  </data>
   <data name="CannotSerializerNull" xml:space="preserve">
     <value>Cannot serialize a null '{0}'.</value>
   </data>
@@ -885,5 +888,5 @@
   </data>
   <data name="AggregateKindNotSupported" xml:space="preserve">
     <value>{0} type of aggregation is not supported.</value>
-  </data>  
+  </data>
 </root>

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/DeserializationHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/DeserializationHelpers.cs
@@ -35,7 +35,8 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
 
             if (!isDynamicProperty && edmProperty == null)
             {
-                throw new ODataException("Does not support untyped value in non-open type.");
+                throw new ODataException(
+                    Error.Format(SRResources.CannotDeserializeUnknownProperty, property.Name, resourceType.Definition));
             }
 
             // dynamic properties have null values

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/DeserializationHelpersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/DeserializationHelpersTest.cs
@@ -291,6 +291,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
         public void ApplyProperty_FailsWithUsefulErrorMessageOnUnknownProperty()
         {
             // Arrange
+            const string HelpfulErrorMessage =
+                "The property 'Unknown' does not exist on type 'namespace.name'. Make sure to only use property names " +
+                "that are defined by the type.";
+
             var property = new ODataProperty { Name = "Unknown", Value = "Value" };
             var entityType = new EdmComplexType("namespace", "name");
             entityType.AddStructuralProperty("Known", EdmLibHelpers.GetEdmPrimitiveTypeReferenceOrNull(typeof(string)));
@@ -307,10 +311,6 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
                     readContext: null));
 
             // Assert
-            const string HelpfulErrorMessage =
-                "The property 'Unknown' does not exist on type 'namespace.name'. Make sure to only use property names " +
-                "that are defined by the type.";
-
             Assert.Equal(HelpfulErrorMessage, exception.Message);
         }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/DeserializationHelpersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/DeserializationHelpersTest.cs
@@ -287,6 +287,33 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
             resource.Verify();
         }
 
+        [Fact]
+        public void ApplyProperty_FailsWithUsefulErrorMessageOnUnknownProperty()
+        {
+            // Arrange
+            var property = new ODataProperty { Name = "Unknown", Value = "Value" };
+            var entityType = new EdmComplexType("namespace", "name");
+            entityType.AddStructuralProperty("Known", EdmLibHelpers.GetEdmPrimitiveTypeReferenceOrNull(typeof(string)));
+
+            var entityTypeReference = new EdmComplexTypeReference(entityType, isNullable: false);
+
+            // Act
+            var exception = Assert.Throws<ODataException>(() =>
+                DeserializationHelpers.ApplyProperty(
+                    property,
+                    entityTypeReference,
+                    resource: null,
+                    deserializerProvider: null,
+                    readContext: null));
+
+            // Assert
+            const string HelpfulErrorMessage =
+                "The property 'Unknown' does not exist on type 'namespace.name'. Make sure to only use property names " +
+                "that are defined by the type.";
+
+            Assert.Equal(HelpfulErrorMessage, exception.Message);
+        }
+
         private static IEdmProperty GetMockEdmProperty(string name, EdmPrimitiveTypeKind elementType)
         {
             Mock<IEdmProperty> property = new Mock<IEdmProperty>();


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This is addresses the unhelpful error message described in this GitHub issue:

https://github.com/OData/WebApi/issues/1421

### Description

This changes a single error message in `DeserializationHelpers.cs`.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

None
