### PR TITLE
User definable CLR type mapping system

### DIFF
--- a/samples/AspNetCoreODataSample.DynamicModels.Web/AspNetCoreODataSample.DynamicModels.Web.csproj
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/AspNetCoreODataSample.DynamicModels.Web.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.OData\Microsoft.AspNetCore.OData.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/HousesController.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/HousesController.cs
@@ -33,5 +33,13 @@ namespace AspNetCoreODataSample.DynamicModels.Web.Controllers
             }
             return Ok(item);
         }
+
+        // GET /House(1)/Rooms
+        [EnableQuery]
+        public IQueryable<Room> GetRooms([FromODataUri] int key)
+        {
+            return _context.Houses.Where(i => i.ID == key).SelectMany(i => i.Rooms);
+        }
+
     }
 }

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/HousesController.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/HousesController.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AspNetCoreODataSample.DynamicModels.Web.Models;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Controllers
+{
+    public class HousesController : ODataController
+    {
+        private readonly HouseContext _context;
+
+        public HousesController(HouseContext context)
+        {
+            _context = context;
+        }
+
+        [EnableQuery]
+        public IActionResult Get()
+        {
+            return Ok(_context.Houses);
+        }
+
+        [EnableQuery]
+        public ActionResult Get(int key)
+        {
+            var item = _context.Houses.SingleOrDefault(p => p.ID == key);
+            if (item == null)
+            {
+                return NotFound();
+            }
+            return Ok(item);
+        }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/InteriorController.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/InteriorController.cs
@@ -40,7 +40,7 @@ namespace AspNetCoreODataSample.DynamicModels.Web.Controllers
             return SingleResult.Create(GetInterior().Where(i => i.ID == key).Select(i => i.Room));
         }
 
-        public IActionResult Post(Interior entity)
+        public IActionResult Post([FromBody] Interior entity)
         {
             if (!ModelState.IsValid)
             {
@@ -59,7 +59,7 @@ namespace AspNetCoreODataSample.DynamicModels.Web.Controllers
             return Created(entity);
         }
 
-        public IActionResult Patch([FromODataUri] int key, Delta<Interior> entity)
+        public IActionResult Patch([FromODataUri] int key, [FromBody] Delta<Interior> entity)
         {
             if (!ModelState.IsValid)
             {
@@ -76,7 +76,7 @@ namespace AspNetCoreODataSample.DynamicModels.Web.Controllers
             return Updated(entity);
         }
 
-        public IActionResult Put([FromODataUri] int key, Interior entity)
+        public IActionResult Put([FromODataUri] int key, [FromBody] Interior entity)
         {
             if (!ModelState.IsValid)
             {
@@ -87,6 +87,11 @@ namespace AspNetCoreODataSample.DynamicModels.Web.Controllers
             {
                 ModelState.AddModelError<Interior>(e => e.Definition, "Could not determine type of interior, please specify the type.");
                 return BadRequest(ModelState);
+            }
+
+            if (entity.ID == 0)
+            {
+                entity.ID = key;
             }
 
             if (key != entity.ID)

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/InteriorController.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/InteriorController.cs
@@ -1,0 +1,68 @@
+﻿using System.Diagnostics;
+using System.Linq;
+using AspNetCoreODataSample.DynamicModels.Web.Edm;
+using AspNetCoreODataSample.DynamicModels.Web.Models;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Controllers
+{
+    public class InteriorController : ODataController
+    {
+        private readonly HouseContext _context;
+
+        public InteriorController(HouseContext context)
+        {
+            _context = context;
+        }
+
+        [EnableQuery]
+        public IActionResult Get()
+        {
+            return Ok(GetInterior());
+        }
+
+        [EnableQuery]
+        public ActionResult Get(int key)
+        {
+            var item = GetInterior().SingleOrDefault(p => p.ID == key);
+            if (item == null)
+            {
+                return NotFound();
+            }
+            return Ok(item);
+        }
+
+        private IQueryable<Interior> GetInterior()
+        {
+            var odataPath = HttpContext.ODataFeature().Path;
+            if (!(odataPath.Segments.FirstOrDefault() is EntitySetSegment entitySetSegment))
+            {
+                Debug.Fail("We should only come into this controller with a proper entity segment");
+                return null;
+            }
+
+            // unwrap which entity was requested
+            var model = Request.GetModel();
+            var collectionType = ((IEdmCollectionType)entitySetSegment.EntitySet.Type);
+            var elementType = (IEdmSchemaElement)collectionType.ElementType.Definition;
+
+            IQueryable<Interior> interiorQuery = _context.Interior
+                .Include(i => i.Definition);
+
+            // filter for specific interior type if needed
+            var interiorDefinition = model.GetAnnotationValue<InteriorDefinitionAnnotation>(elementType);
+            if (interiorDefinition != null)
+            {
+                interiorQuery = interiorQuery.Where(e => e.Definition.ID == interiorDefinition.DefinitionID);
+            }
+
+            // wrap to correct collection type
+            return interiorQuery.WithEdmCollectionType(collectionType);
+        }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/InteriorDefinitionsController.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/InteriorDefinitionsController.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AspNetCoreODataSample.DynamicModels.Web.Models;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Controllers
+{
+    public class InteriorDefinitionsController : ODataController
+    {
+        private readonly HouseContext _context;
+
+        public InteriorDefinitionsController(HouseContext context)
+        {
+            _context = context;
+        }
+
+        [EnableQuery]
+        public IActionResult Get()
+        {
+            return Ok(_context.InteriorDefinitions);
+        }
+
+        [EnableQuery]
+        public ActionResult Get(int key)
+        {
+            var item = _context.InteriorDefinitions
+                .Include(d => d.Properties)
+                .SingleOrDefault(p => p.ID == key);
+
+            if (item == null)
+            {
+                return NotFound();
+            }
+            return Ok(item);
+        }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/RoomsController.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/RoomsController.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+using AspNetCoreODataSample.DynamicModels.Web.Models;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Controllers
+{
+    public class RoomsController : ODataController
+    {
+        private readonly HouseContext _context;
+
+        public RoomsController(HouseContext context)
+        {
+            _context = context;
+        }
+
+        [EnableQuery]
+        public IActionResult Get()
+        {
+            return Ok(_context.Rooms);
+        }
+
+        [EnableQuery]
+        public ActionResult Get(int key)
+        {
+            var item = _context.Rooms.SingleOrDefault(p => p.ID == key);
+            if (item == null)
+            {
+                return NotFound();
+            }
+            return Ok(item);
+        }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/RoomsController.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Controllers/RoomsController.cs
@@ -30,5 +30,12 @@ namespace AspNetCoreODataSample.DynamicModels.Web.Controllers
             }
             return Ok(item);
         }
+
+        // GET /Rooms(1)/Interior
+        [EnableQuery]
+        public IQueryable<Interior> GetInterior([FromODataUri] int key)
+        {
+            return _context.Rooms.Where(i => i.ID == key).SelectMany(i => i.Interior);
+        }
     }
 }

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/EdmModelBuilder.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/EdmModelBuilder.cs
@@ -60,6 +60,8 @@ namespace AspNetCoreODataSample.DynamicModels.Web.Edm
             // Register base type of interiors and ignore user-defined properties 
             // they are defined below according to the current DB confiuration
             var interiorTypeConfiguration = builder.EntityType<Interior>();
+            interiorTypeConfiguration.Ignore(i => i.DefinitionID);
+            interiorTypeConfiguration.Ignore(i => i.Definition);
             interiorTypeConfiguration.Ignore(i => i.StringProperty1);
             interiorTypeConfiguration.Ignore(i => i.StringProperty2);
             interiorTypeConfiguration.Ignore(i => i.StringProperty3);

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/EdmModelBuilder.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/EdmModelBuilder.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using AspNetCoreODataSample.DynamicModels.Web.Models;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Validation;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Edm
+{
+    public class EdmModelBuilder
+    {
+        private readonly HouseContext _houseContext;
+        private readonly IPluralizer _pluralizer;
+        private IEdmModel _edmModel;
+
+        public EdmModelBuilder(HouseContext houseContext, IPluralizer pluralizer)
+        {
+            _houseContext = houseContext;
+            _pluralizer = pluralizer;
+        }
+
+        public IEdmModel GetEdmModel()
+        {
+            // here you would use some caching system which ensures
+            // the EDM model is only rebuilt when it was updated in the DB
+            if (_edmModel == null)
+            {
+                _edmModel = BuildEdmModel();
+            }
+
+            return _edmModel;
+        }
+
+        private IEdmModel BuildEdmModel()
+        {
+            var builder = new ODataConventionModelBuilder();
+
+            // General Entities
+            builder.EntityType<House>();
+            builder.EntitySet<House>("Houses");
+            builder.EntityType<Room>();
+            builder.EntitySet<House>("Rooms");
+
+            // Interior definition (user-defined properties)
+            builder.EntityType<InteriorDefinition>()
+                .HasMany(d => d.Properties).AutomaticallyExpand(true);
+            builder.EntitySet<House>("InteriorDefinitions");
+
+            builder.EntityType<InteriorPropertyDefinition>();
+            builder.EnumType<InteriorPropertyType>();
+
+            // Register base type of interiors and ignore user-defined properties 
+            // they are defined below according to the current DB confiuration
+            var interiorTypeConfiguration = builder.EntityType<Interior>();
+            interiorTypeConfiguration.Ignore(i => i.StringProperty1);
+            interiorTypeConfiguration.Ignore(i => i.StringProperty2);
+            interiorTypeConfiguration.Ignore(i => i.StringProperty3);
+            interiorTypeConfiguration.Ignore(i => i.IntProperty1);
+            interiorTypeConfiguration.Ignore(i => i.IntProperty2);
+            interiorTypeConfiguration.Ignore(i => i.IntProperty3);
+            interiorTypeConfiguration.Ignore(i => i.DoubleProperty1);
+            interiorTypeConfiguration.Ignore(i => i.DoubleProperty2);
+            interiorTypeConfiguration.Ignore(i => i.DoubleProperty3);
+            builder.EntitySet<Interior>("Interior");
+
+            // Build the intermediate model and register all dynamic interior definitions
+            var model = (EdmModel)builder.GetEdmModel();
+            var entityType = (IEdmEntityType)model.FindDeclaredType(interiorTypeConfiguration.FullName);
+            var container = (EdmEntityContainer)model.EntityContainer;
+            var ns = model.SchemaElements.First().Namespace;
+            var propertyLookup = BuildPropertyLookup(typeof(IUserDefinedPropertyBag));
+
+            var definitions = _houseContext.InteriorDefinitions.Include(d => d.Properties).ToArray();
+            foreach (var definition in definitions)
+            {
+                // register type by name using the Interior as base type. 
+                var type = new EdmEntityType(ns, definition.Name, entityType, false, false);
+                // define the correct CLR type as backstore
+                model.SetAnnotationValue(type, new ClrTypeAnnotation(typeof(Interior)));
+                // remember which interior definition represents this EDM type. 
+                model.SetAnnotationValue(type, new InteriorDefinitionAnnotation(definition.ID));
+                // register user defined properties
+                foreach (var property in definition.Properties)
+                {
+                    var edmProperty = type.AddStructuralProperty(property.Name, MapToEdmType(property.PropertyType));
+                    model.SetAnnotationValue(edmProperty, new ClrPropertyInfoAnnotation(propertyLookup[property.PropertyName].Single()));
+                }
+
+                // add to model and register entity set
+                model.AddElement(type);
+                container.AddEntitySet(_pluralizer.Pluralize(definition.Name), type);
+            }
+
+            // Register type mapping handler which translates Interiors correctly.
+            model.SetAnnotationValue<IEdmModelClrTypeMappingHandler>(model, new InteriorDefinitionAwareClrTypeMappingHandler());
+
+            // validate the model again newly added entities
+            if (!model.Validate(out var errors))
+            {
+                Debug.Fail("EDM is not valid", string.Join(Environment.NewLine, errors.Select(e => e.ToString())));
+            }
+
+            return model;
+        }
+
+        private EdmPrimitiveTypeKind MapToEdmType(InteriorPropertyType propertyType)
+        {
+            switch (propertyType)
+            {
+                case InteriorPropertyType.String:
+                    return EdmPrimitiveTypeKind.String;
+                case InteriorPropertyType.Int:
+                    return EdmPrimitiveTypeKind.Int32;
+                case InteriorPropertyType.Double:
+                    return EdmPrimitiveTypeKind.Double;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyType), propertyType, null);
+            }
+        }
+
+        private ILookup<string, PropertyInfo> BuildPropertyLookup(Type type)
+            => type.GetProperties(BindingFlags.Public | BindingFlags.Instance).ToLookup(prop => prop.Name);
+
+        public bool IsInterior(IEdmModel model, IEdmType type)
+        {
+            return model.GetAnnotationValue<InteriorDefinitionAnnotation>(type) != null;
+        }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/EdmModelBuilder.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/EdmModelBuilder.cs
@@ -47,12 +47,12 @@ namespace AspNetCoreODataSample.DynamicModels.Web.Edm
             builder.EntityType<House>();
             builder.EntitySet<House>("Houses");
             builder.EntityType<Room>();
-            builder.EntitySet<House>("Rooms");
+            builder.EntitySet<Room>("Rooms");
 
             // Interior definition (user-defined properties)
             builder.EntityType<InteriorDefinition>()
                 .HasMany(d => d.Properties).AutomaticallyExpand(true);
-            builder.EntitySet<House>("InteriorDefinitions");
+            builder.EntitySet<InteriorDefinition>("InteriorDefinitions");
 
             builder.EntityType<InteriorPropertyDefinition>();
             builder.EnumType<InteriorPropertyType>();

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/EdmTypedIQueryableWrapper.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/EdmTypedIQueryableWrapper.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.OData.Edm;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Edm
+{
+    /// <summary>
+    /// A set of extension methods to easily wrap IQueryable objects with their expected EDM types. 
+    /// </summary>
+    public static class EdmTypedIQueryableWrapperExtensions
+    {
+        public static IQueryable<T> WithEdmCollectionType<T>(this IQueryable<T> queryable, IEdmCollectionType collectionType)
+        {
+            return new EdmTypedIQueryableWrapper<T>(queryable, collectionType);
+        }
+        public static IQueryable<T> WithEdmElementType<T>(this IQueryable<T> queryable, IEdmEntityType entityType)
+        {
+            return new EdmTypedIQueryableWrapper<T>(queryable, new EdmCollectionType(new EdmEntityTypeReference(entityType, true)));
+        }
+        public static IQueryable<T> WithEdmElementType<T>(this IQueryable<T> queryable, IEdmComplexType complexType)
+        {
+            return new EdmTypedIQueryableWrapper<T>(queryable, new EdmCollectionType(new EdmComplexTypeReference(complexType, true)));
+        }
+    }
+
+    /// <summary>
+    /// This base interface allows non-generic access to the <see cref="IEdmCollectionType"/>. 
+    /// </summary>
+    public interface IEdmTypedIQueryableWrapper
+    {
+        IEdmCollectionType EdmCollectionType { get; }
+    }
+
+    /// <summary>
+    /// This IQueryable wrapper allows specifying for an IQueryable which <see cref="IEdmCollectionType"/> is contained. 
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class EdmTypedIQueryableWrapper<T> : IOrderedQueryable<T>, IEdmTypedIQueryableWrapper
+    {
+        public IEdmCollectionType EdmCollectionType { get; }
+        private readonly IQueryable _queryable;
+
+        public EdmTypedIQueryableWrapper(IQueryable queryable, IEdmCollectionType edmCollectionType)
+        {
+            EdmCollectionType = edmCollectionType;
+            _queryable = queryable;
+            Provider = new EdmTypedIQueryableWrapperQueryProvider(this);
+        }
+
+
+        private class EdmTypedIQueryableWrapperQueryProvider : IQueryProvider
+        {
+            private readonly EdmTypedIQueryableWrapper<T> _edmTypedIQueryableWrapper;
+
+            public EdmTypedIQueryableWrapperQueryProvider(EdmTypedIQueryableWrapper<T> edmTypedIQueryableWrapper)
+            {
+                _edmTypedIQueryableWrapper = edmTypedIQueryableWrapper;
+            }
+
+            public IQueryable CreateQuery(Expression expression)
+            {
+                return new EdmTypedIQueryableWrapper<T>(_edmTypedIQueryableWrapper._queryable.Provider.CreateQuery(expression), _edmTypedIQueryableWrapper.EdmCollectionType);
+            }
+
+            public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+            {
+                return new EdmTypedIQueryableWrapper<TElement>(_edmTypedIQueryableWrapper._queryable.Provider.CreateQuery<TElement>(expression), _edmTypedIQueryableWrapper.EdmCollectionType);
+            }
+
+            public object Execute(Expression expression)
+            {
+                return _edmTypedIQueryableWrapper._queryable.Provider.Execute(expression);
+            }
+
+            public TResult Execute<TResult>(Expression expression)
+            {
+                return _edmTypedIQueryableWrapper._queryable.Provider.Execute<TResult>(expression);
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return Provider.Execute<IEnumerable<T>>(Expression).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public Expression Expression => _queryable.Expression;
+
+        public Type ElementType => _queryable.ElementType;
+
+        public IQueryProvider Provider { get; }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/InteriorDefinitionAnnotation.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/InteriorDefinitionAnnotation.cs
@@ -1,0 +1,12 @@
+﻿namespace AspNetCoreODataSample.DynamicModels.Web.Models
+{
+    public class InteriorDefinitionAnnotation
+    {
+        public int DefinitionID { get; }
+
+        public InteriorDefinitionAnnotation(int definitionId)
+        {
+            DefinitionID = definitionId;
+        }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/InteriorDefinitionAwareClrTypeMappingHandler.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/InteriorDefinitionAwareClrTypeMappingHandler.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Linq;
+using AspNetCoreODataSample.DynamicModels.Web.Models;
+using Microsoft.AspNet.OData;
+using Microsoft.OData.Edm;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Edm
+{
+    public class InteriorDefinitionAwareClrTypeMappingHandler : IEdmModelClrTypeMappingHandler
+    {
+        private static readonly Type InteriorType = typeof(Interior);
+
+        public IEdmType MapClrTypeToEdmType(IEdmModel edmModel, Type clrType)
+        {
+            // when the base type is requested, provide the base EDM type
+            if (clrType == InteriorType)
+            {
+                return edmModel.FindDeclaredType(InteriorType.FullName);
+            }
+            return null;
+        }
+
+        public IEdmCollectionType MapClrEnumerableToEdmCollection(IEdmModel edmModel, Type clrType, Type elementClrType)
+        {
+            // when the base type is requested, provide the base EDM type
+            if (elementClrType == InteriorType)
+            {
+                return new EdmCollectionType(new EdmEntityTypeReference((IEdmEntityType)edmModel.FindDeclaredType(InteriorType.FullName), true));
+            }
+            return null;
+        }
+
+        public IEdmType MapClrInstanceToEdmType(IEdmModel edmModel, object clrInstance)
+        {
+            // simply unwrap the type reference (Dont-Repeat-Yourself)
+            return MapClrInstanceToEdmTypeReference(edmModel, clrInstance)?.Definition;
+        }
+
+        public IEdmTypeReference MapClrInstanceToEdmTypeReference(IEdmModel edmModel, object clrInstance)
+        {
+            // handle IQueryable wrappers
+            if (clrInstance is IEdmTypedIQueryableWrapper wrapper)
+            {
+                return new EdmCollectionTypeReference(wrapper.EdmCollectionType);
+            }
+
+            // handle Interior instances
+            if (clrInstance is Interior interior)
+            {
+                // lookup IEdmEntityType with matching definition (via annotation)
+                var type = edmModel.SchemaElements
+                    .OfType<IEdmEntityType>()
+                    .Select(edmType => new { EdmType = edmType, Annotation = edmModel.GetAnnotationValue<InteriorDefinitionAnnotation>(edmType) })
+                    .Where(tuple => tuple.Annotation != null && tuple.Annotation.DefinitionID == interior.DefinitionID)
+                    .Select(tuple => tuple.EdmType)
+                    .SingleOrDefault();
+                if (type != null)
+                {
+                    return new EdmEntityTypeReference(type, true);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/InteriorDefinitionAwareClrTypeMappingHandler.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Edm/InteriorDefinitionAwareClrTypeMappingHandler.cs
@@ -44,6 +44,12 @@ namespace AspNetCoreODataSample.DynamicModels.Web.Edm
                 return new EdmCollectionTypeReference(wrapper.EdmCollectionType);
             }
 
+            // handle IQueryable wrappers in SingleResult
+            if (clrInstance is SingleResult<Interior> single && single.Queryable is IEdmTypedIQueryableWrapper singleWrapper)
+            {
+                return new EdmCollectionTypeReference(singleWrapper.EdmCollectionType);
+            }
+
             // handle Interior instances
             if (clrInstance is Interior interior)
             {

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Models/House.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Models/House.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Models
+{
+    public class House
+    {
+        [Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int ID { get; set; }
+        public string Name { get; set; }
+        public string Address { get; set; }
+        public List<Room> Rooms { get; set; }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Models/HouseContext.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Models/HouseContext.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Models
+{
+    public class HouseContext : DbContext
+    {
+        public HouseContext(DbContextOptions<HouseContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<House> Houses { get; set; }
+        public DbSet<Room> Rooms { get; set; }
+        public DbSet<Interior> Interior { get; set; }
+        public DbSet<InteriorDefinition> InteriorDefinitions { get; set; }
+        public DbSet<InteriorPropertyDefinition> InteriorPropertyDefinitions { get; set; }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Models/IUserDefinedPropertyBag.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Models/IUserDefinedPropertyBag.cs
@@ -1,0 +1,16 @@
+﻿namespace AspNetCoreODataSample.DynamicModels.Web.Models
+{
+    public interface IUserDefinedPropertyBag
+    {
+        string StringProperty1 { get; set; }
+        string StringProperty2 { get; set; }
+        string StringProperty3 { get; set; }
+        int IntProperty1 { get; set; }
+        int IntProperty2 { get; set; }
+        int IntProperty3 { get; set; }
+        double DoubleProperty1 { get; set; }
+        double DoubleProperty2 { get; set; }
+        double DoubleProperty3 { get; set; }
+
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Models/Interior.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Models/Interior.cs
@@ -12,6 +12,9 @@ namespace AspNetCoreODataSample.DynamicModels.Web.Models
         public int DefinitionID { get; set; }
         public InteriorDefinition Definition { get; set; }
 
+        [ForeignKey(nameof(Room))]
+        public int RoomId { get; set; }
+        public Room Room { get; set; }
 
         public string StringProperty1 { get; set; }
         public string StringProperty2 { get; set; }

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Models/Interior.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Models/Interior.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Models
+{
+    public class Interior : IUserDefinedPropertyBag
+    {
+        [Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int ID { get; set; }
+
+        [ForeignKey(nameof(Definition))]
+        public int DefinitionID { get; set; }
+        public InteriorDefinition Definition { get; set; }
+
+
+        public string StringProperty1 { get; set; }
+        public string StringProperty2 { get; set; }
+        public string StringProperty3 { get; set; }
+        public int IntProperty1 { get; set; }
+        public int IntProperty2 { get; set; }
+        public int IntProperty3 { get; set; }
+        public double DoubleProperty1 { get; set; }
+        public double DoubleProperty2 { get; set; }
+        public double DoubleProperty3 { get; set; }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Models/InteriorDefinition.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Models/InteriorDefinition.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Models
+{
+    public class InteriorDefinition
+    {
+        [Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int ID { get; set; }
+        public string Name { get; set; }
+        public List<InteriorPropertyDefinition> Properties { get; set; }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Models/InteriorPropertyDefinition.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Models/InteriorPropertyDefinition.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Models
+{
+    public class InteriorPropertyDefinition
+    {
+        [Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int ID { get; set; }
+
+        [ForeignKey(nameof(Definition))]
+        public int DefinitionID { get; set; }
+        public InteriorDefinition Definition { get; set; }
+
+        public string Name { get; set; }
+        public InteriorPropertyType PropertyType { get; set; }
+        public string PropertyName { get; set; }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Models/InteriorPropertyType.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Models/InteriorPropertyType.cs
@@ -1,0 +1,9 @@
+﻿namespace AspNetCoreODataSample.DynamicModels.Web.Models
+{
+    public enum InteriorPropertyType
+    {
+        String,
+        Int,
+        Double
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Models/Room.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Models/Room.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Models
+{
+    public class Room
+    {
+        [Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int ID { get; set; }
+        [ForeignKey(nameof(House))]
+        public int HouseID { get; set; }
+        public House House { get; set; }
+        public string Name { get; set; }
+
+        public List<Interior> Interior { get; set; }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Program.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Program.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace AspNetCoreODataSample.DynamicModels.Web
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Properties/launchSettings.json
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:5912/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "api",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "AspNetCoreODataSample.Web": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "efcore/Movies",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:5913/"
+    }
+  }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Startup.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Startup.cs
@@ -251,6 +251,8 @@ namespace AspNetCoreODataSample.DynamicModels.Web
                         {
                             Definition = tableDefinition,
                             DefinitionID = tableDefinition.ID,
+                            Room = room,
+                            RoomId = room.ID,
 
                             StringProperty1 = deskManufacturers[random.Next(deskManufacturers.Length)],
                             StringProperty2 = deskModels[random.Next(deskModels.Length)],
@@ -270,6 +272,8 @@ namespace AspNetCoreODataSample.DynamicModels.Web
                         {
                             Definition = chairDefinition,
                             DefinitionID = chairDefinition.ID,
+                            Room = room,
+                            RoomId = room.ID,
 
                             StringProperty1 = chairManufacturers[random.Next(deskManufacturers.Length)],
                             StringProperty2 = chairModels[random.Next(deskModels.Length)],

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Startup.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Startup.cs
@@ -1,0 +1,286 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AspNetCoreODataSample.DynamicModels.Web.Edm;
+using AspNetCoreODataSample.DynamicModels.Web.Models;
+using AspNetCoreODataSample.DynamicModels.Web.Utils;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Routing.Conventions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData;
+
+namespace AspNetCoreODataSample.DynamicModels.Web
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddDbContext<HouseContext>(opt => opt.UseInMemoryDatabase("HouseList"));
+            services.AddSingleton<IPluralizer, SimplePluralizer>();
+
+            // Register model builder as scoped to let it use the per-request DbContext
+            services.AddScoped<EdmModelBuilder>();
+
+            services.AddOData();
+            services.AddMvc();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            using (var serviceScope = app.ApplicationServices.CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<HouseContext>();
+                AddTestData(context);
+            }
+
+
+            app.UseMvc(builder =>
+            {
+                builder.Select().Expand().Filter().OrderBy().MaxTop(100).Count();
+
+                builder.MapODataServiceRoute("odata", "api", odataBuilder =>
+                {
+                    // add the IEdmModel as scoped service always have up-to-date models provided and used. 
+                    // the EdmModelBuilder internally should to a caching. 
+                    odataBuilder.AddService(Microsoft.OData.ServiceLifetime.Scoped, sp =>
+                        // EdmModelBuilder is registered in the asp.net core application, not in the odata specific DI
+                        // therefore we need to dig down to the correct service provider 
+                        sp.GetService<HttpRequestScope>().HttpRequest.HttpContext.RequestServices.GetService<EdmModelBuilder>().GetEdmModel());
+
+                    // The routing conventions which will redirect to the generic InteriorController for accessing entity sets
+                    odataBuilder.AddService(Microsoft.OData.ServiceLifetime.Singleton, sp =>
+                    {
+                        IList<IODataRoutingConvention> routingConventions = ODataRoutingConventions.CreateDefaultWithAttributeRouting("odata", builder);
+                        routingConventions.Add(new InteriorRoutingConvention());
+                        return routingConventions.ToList().AsEnumerable();
+                    });
+                });
+            });
+        }
+
+        private void AddTestData(HouseContext context)
+        {
+            // NOTE: save changes inbetween ensure we have IDs for our entities
+
+            // Add interior definitions for chairs and tables:
+
+            // class Chair
+            // {
+            //     public string Manufacturer {get;set;}
+            //     public string Model {get;set;}
+            //     public int Year {get;set;}
+            //     public double Weight {get;set;}
+            // }
+
+            var chairDefinition = new InteriorDefinition
+            {
+                Name = "Chair",
+            };
+            context.Add(chairDefinition);
+            context.SaveChanges();
+
+            context.Add(new InteriorPropertyDefinition
+            {
+                Name = "Manufacturer",
+                PropertyType = InteriorPropertyType.String,
+                PropertyName = nameof(IUserDefinedPropertyBag.StringProperty1),
+                DefinitionID = chairDefinition.ID,
+                Definition = chairDefinition,
+            });
+            context.Add(new InteriorPropertyDefinition
+            {
+                Name = "Model",
+                PropertyType = InteriorPropertyType.String,
+                PropertyName = nameof(IUserDefinedPropertyBag.StringProperty2),
+                DefinitionID = chairDefinition.ID,
+                Definition = chairDefinition,
+            });
+            context.Add(new InteriorPropertyDefinition
+            {
+                Name = "Year",
+                PropertyType = InteriorPropertyType.Int,
+                PropertyName = nameof(IUserDefinedPropertyBag.IntProperty1),
+                DefinitionID = chairDefinition.ID,
+                Definition = chairDefinition,
+            });
+
+            context.Add(new InteriorPropertyDefinition
+            {
+                Name = "Weight",
+                PropertyType = InteriorPropertyType.Double,
+                PropertyName = nameof(IUserDefinedPropertyBag.DoubleProperty1),
+                DefinitionID = chairDefinition.ID,
+                Definition = chairDefinition,
+            });
+            context.SaveChanges();
+
+
+            // class Table
+            // {
+            //     public string Manufacturer {get;set;}
+            //     public string Model {get;set;}
+            //     public int ExpansionPanels {get;set;}
+            //     public int SuitablePersonCount {get;set;}
+            //     public double Width {get;set;}
+            //     public double Height {get;set;}
+            //     public double Depth {get;set;}
+            // }
+
+            var tableDefinition = new InteriorDefinition
+            {
+                Name = "Table",
+            };
+            context.Add(tableDefinition);
+            context.SaveChanges();
+
+            context.Add(new InteriorPropertyDefinition
+            {
+                Name = "Manufacturer",
+                PropertyType = InteriorPropertyType.String,
+                PropertyName = nameof(IUserDefinedPropertyBag.StringProperty1),
+                DefinitionID = tableDefinition.ID,
+                Definition = tableDefinition,
+            });
+            context.Add(new InteriorPropertyDefinition
+            {
+                Name = "Model",
+                PropertyType = InteriorPropertyType.String,
+                PropertyName = nameof(IUserDefinedPropertyBag.StringProperty2),
+                DefinitionID = tableDefinition.ID,
+                Definition = tableDefinition,
+            });
+            context.Add(new InteriorPropertyDefinition
+            {
+                Name = "ExpansionPanels",
+                PropertyType = InteriorPropertyType.Int,
+                PropertyName = nameof(IUserDefinedPropertyBag.IntProperty1),
+                DefinitionID = tableDefinition.ID,
+                Definition = tableDefinition,
+            });
+            context.Add(new InteriorPropertyDefinition
+            {
+                Name = "SuitablePersonCount",
+                PropertyType = InteriorPropertyType.Int,
+                PropertyName = nameof(IUserDefinedPropertyBag.IntProperty2),
+                DefinitionID = tableDefinition.ID,
+                Definition = tableDefinition,
+            });
+            context.Add(new InteriorPropertyDefinition
+            {
+                Name = "Width",
+                PropertyType = InteriorPropertyType.Double,
+                PropertyName = nameof(IUserDefinedPropertyBag.DoubleProperty1),
+                DefinitionID = tableDefinition.ID,
+                Definition = tableDefinition,
+            });
+            context.Add(new InteriorPropertyDefinition
+            {
+                Name = "Height",
+                PropertyType = InteriorPropertyType.Double,
+                PropertyName = nameof(IUserDefinedPropertyBag.DoubleProperty2),
+                DefinitionID = tableDefinition.ID,
+                Definition = tableDefinition,
+            });
+            context.Add(new InteriorPropertyDefinition
+            {
+                Name = "Depth",
+                PropertyType = InteriorPropertyType.Double,
+                PropertyName = nameof(IUserDefinedPropertyBag.DoubleProperty3),
+                DefinitionID = tableDefinition.ID,
+                Definition = tableDefinition,
+            });
+            context.SaveChanges();
+
+            // Add some test houses and rooms (random data)
+
+            var deskManufacturers = new[] { "Desk Inc.", "Desktopia", "Desk4You", "WeLoveDesks" };
+            var deskModels = new[] { "Dining Table", "Couch Table", "Pool Table", "Table Football Table", "Poker Table" };
+
+            var chairManufacturers = new[] { "Chair Inc.", "Chairtopia", "Chair4You", "WeLoveChairs" };
+            var chairModels = new[] { "Armchair", "Rocking Chair", "Stool", "Wheelchair", "Deckchair" };
+
+            var random = new Random();
+            for (int houseIndex = 0; houseIndex < random.Next(1, 5); houseIndex++)
+            {
+                var house = new House
+                {
+                    Name = "House " + houseIndex,
+                    Address = "Main Street " + random.Next(1, 100)
+                };
+                context.Add(house);
+                context.SaveChanges();
+
+                for (int roomIndex = 0; roomIndex < random.Next(1, 10); roomIndex++)
+                {
+                    var room = new Room
+                    {
+                        Name = house.Name + " - Room " + roomIndex,
+                        House = house,
+                        HouseID = house.ID
+                    };
+                    context.Add(room);
+                    context.SaveChanges();
+
+                    for (int tableIndex = 0; tableIndex < random.Next(1, 5); tableIndex++)
+                    {
+                        var table = new Interior
+                        {
+                            Definition = tableDefinition,
+                            DefinitionID = tableDefinition.ID,
+
+                            StringProperty1 = deskManufacturers[random.Next(deskManufacturers.Length)],
+                            StringProperty2 = deskModels[random.Next(deskModels.Length)],
+                            IntProperty1 = random.Next(0, 2), // ExpansionPanels
+                            IntProperty2 = random.Next(4, 10), // SuitablePersonCount
+                            DoubleProperty1 = random.NextDouble() * 300, // Width (0-300cm)
+                            DoubleProperty2 = random.NextDouble() * 120, // Height (0-120cm)
+                            DoubleProperty3 = random.NextDouble() * 800, // Depth (0-800cm)
+                        };
+                        context.Add(table);
+                    }
+                    context.SaveChanges();
+
+                    for (int chairIndex = 0; chairIndex < random.Next(1, 10); chairIndex++)
+                    {
+                        var chair = new Interior
+                        {
+                            Definition = chairDefinition,
+                            DefinitionID = chairDefinition.ID,
+
+                            StringProperty1 = chairManufacturers[random.Next(deskManufacturers.Length)],
+                            StringProperty2 = chairModels[random.Next(deskModels.Length)],
+                            IntProperty1 = random.Next(2000, DateTime.Now.Year + 1), // Year
+                            DoubleProperty1 = 500 + random.NextDouble() * 500, // Weight (500-1000g)
+                        };
+                        context.Add(chair);
+                    }
+                    context.SaveChanges();
+                }
+            }
+        }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Utils/InteriorRoutingConvention.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Utils/InteriorRoutingConvention.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using AspNetCoreODataSample.DynamicModels.Web.Edm;
+using AspNetCoreODataSample.DynamicModels.Web.Models;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Routing;
+using Microsoft.AspNet.OData.Routing.Conventions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Utils
+{
+    public class InteriorRoutingConvention : IODataRoutingConvention
+    {
+        private readonly string ControllerName = "Interior";
+
+        public IEnumerable<ControllerActionDescriptor> SelectAction(RouteContext routeContext)
+        {
+            var odataPath = routeContext.HttpContext.ODataFeature().Path;
+
+            // check whether an entity set was requested
+            if (!(odataPath.Segments.FirstOrDefault() is EntitySetSegment entitySetSegment) || !(entitySetSegment.EntitySet.Type is IEdmCollectionType edmCollectionType))
+            {
+                return null;
+            }
+
+            // ask model provider whether requested entity set is a Interior
+            var edmModel = routeContext.HttpContext.Request.GetModel();
+            var edmModelProvider = routeContext.HttpContext.RequestServices.GetRequiredService<EdmModelBuilder>();
+            if (edmModelProvider.IsInterior(edmModel, edmCollectionType.ElementType.Definition))
+            {
+                IActionDescriptorCollectionProvider actionCollectionProvider =
+                    routeContext.HttpContext.RequestServices.GetRequiredService<IActionDescriptorCollectionProvider>();
+
+                IEnumerable<ControllerActionDescriptor> actionDescriptors = actionCollectionProvider
+                    .ActionDescriptors.Items.OfType<ControllerActionDescriptor>()
+                    .Where(c => c.ControllerName == ControllerName);
+
+                if (odataPath.PathTemplate == "~/entityset/key/navigation")
+                {
+                    if (routeContext.HttpContext.Request.Method.ToUpperInvariant() == "GET")
+                    {
+                        NavigationPropertySegment navigationPathSegment = (NavigationPropertySegment)odataPath.Segments.Last();
+
+                        routeContext.RouteData.Values["navigation"] = navigationPathSegment.NavigationProperty.Name;
+
+                        KeySegment keyValueSegment = (KeySegment)odataPath.Segments[1];
+                        routeContext.RouteData.Values[ODataRouteConstants.Key] = keyValueSegment.Keys.First().Value;
+
+                        return actionDescriptors.Where(c => c.ActionName == "GetNavigation");
+                    }
+                }
+
+                SelectControllerResult controllerResult = new SelectControllerResult(ControllerName, null);
+                IList<IODataRoutingConvention> routingConventions = ODataRoutingConventions.CreateDefault();
+                foreach (NavigationSourceRoutingConvention nsRouting in routingConventions.OfType<NavigationSourceRoutingConvention>())
+                {
+                    string actionName = nsRouting.SelectAction(routeContext, controllerResult, actionDescriptors);
+                    if (!String.IsNullOrEmpty(actionName))
+                    {
+                        return actionDescriptors.Where(
+                            c => String.Equals(c.ActionName, actionName, StringComparison.OrdinalIgnoreCase));
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Utils/InteriorRoutingConvention.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Utils/InteriorRoutingConvention.cs
@@ -41,21 +41,6 @@ namespace AspNetCoreODataSample.DynamicModels.Web.Utils
                     .ActionDescriptors.Items.OfType<ControllerActionDescriptor>()
                     .Where(c => c.ControllerName == ControllerName);
 
-                if (odataPath.PathTemplate == "~/entityset/key/navigation")
-                {
-                    if (routeContext.HttpContext.Request.Method.ToUpperInvariant() == "GET")
-                    {
-                        NavigationPropertySegment navigationPathSegment = (NavigationPropertySegment)odataPath.Segments.Last();
-
-                        routeContext.RouteData.Values["navigation"] = navigationPathSegment.NavigationProperty.Name;
-
-                        KeySegment keyValueSegment = (KeySegment)odataPath.Segments[1];
-                        routeContext.RouteData.Values[ODataRouteConstants.Key] = keyValueSegment.Keys.First().Value;
-
-                        return actionDescriptors.Where(c => c.ActionName == "GetNavigation");
-                    }
-                }
-
                 SelectControllerResult controllerResult = new SelectControllerResult(ControllerName, null);
                 IList<IODataRoutingConvention> routingConventions = ODataRoutingConventions.CreateDefault();
                 foreach (NavigationSourceRoutingConvention nsRouting in routingConventions.OfType<NavigationSourceRoutingConvention>())

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/Utils/SimplePluralizer.cs
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/Utils/SimplePluralizer.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Design;
+
+namespace AspNetCoreODataSample.DynamicModels.Web.Utils
+{
+    /// <summary>
+    /// A simple pluralizer which adds an "s" at the end to pluralize the terms
+    /// </summary>
+    public class SimplePluralizer : IPluralizer
+    {
+        public string Pluralize(string identifier)
+        {
+            if (identifier == null) return null;
+            return identifier + "s";
+        }
+
+        public string Singularize(string identifier)
+        {
+            if (identifier == null) return null;
+            return identifier.EndsWith("s") ? identifier.Substring(0, identifier.Length - 1) : identifier;
+        }
+    }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/appsettings.Development.json
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/appsettings.Development.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/samples/AspNetCoreODataSample.DynamicModels.Web/appsettings.json
+++ b/samples/AspNetCoreODataSample.DynamicModels.Web/appsettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "Debug": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  }
+}

--- a/sln/WebApiOData.AspNetCore.sln
+++ b/sln/WebApiOData.AspNetCore.sln
@@ -19,6 +19,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.AspNet.OData.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.OData.Test", "..\test\UnitTest\Microsoft.AspNetCore.OData.Test\Microsoft.AspNetCore.OData.Test.csproj", "{2B8085F7-3625-489E-A963-E29C2BD1AA76}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreODataSample.DynamicModels.Web", "..\samples\AspNetCoreODataSample.DynamicModels.Web\AspNetCoreODataSample.DynamicModels.Web.csproj", "{DC9202F7-ED44-4E40-A509-4C4BE01548B3}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\src\Microsoft.AspNet.OData.Shared\Microsoft.AspNet.OData.Shared.projitems*{b6b951b6-c3f0-4b8e-8955-e039145e7dec}*SharedItemsImports = 13
@@ -48,6 +50,12 @@ Global
 		{2B8085F7-3625-489E-A963-E29C2BD1AA76}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B8085F7-3625-489E-A963-E29C2BD1AA76}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2B8085F7-3625-489E-A963-E29C2BD1AA76}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC9202F7-ED44-4E40-A509-4C4BE01548B3}.CodeAnalysis|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC9202F7-ED44-4E40-A509-4C4BE01548B3}.CodeAnalysis|Any CPU.Build.0 = Debug|Any CPU
+		{DC9202F7-ED44-4E40-A509-4C4BE01548B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC9202F7-ED44-4E40-A509-4C4BE01548B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC9202F7-ED44-4E40-A509-4C4BE01548B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC9202F7-ED44-4E40-A509-4C4BE01548B3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -58,6 +66,7 @@ Global
 		{0D53FCCE-2173-4FDB-A552-C3BBB71DDC49} = {3789AD84-4A87-45C1-BD5C-3B4BE39157C8}
 		{D909E7AB-3281-46EA-929B-F35FE7E94B0F} = {2F6228EC-37EE-4FCB-A38A-B94EE472E70E}
 		{2B8085F7-3625-489E-A963-E29C2BD1AA76} = {2F6228EC-37EE-4FCB-A38A-B94EE472E70E}
+		{DC9202F7-ED44-4E40-A509-4C4BE01548B3} = {3789AD84-4A87-45C1-BD5C-3B4BE39157C8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {731B144D-90AE-4567-B337-7CFE9965AACC}

--- a/src/Microsoft.AspNet.OData.Shared/ETagMessageHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ETagMessageHandler.cs
@@ -76,14 +76,7 @@ namespace Microsoft.AspNet.OData
                 return null;
             }
 
-            IEdmObject edmObject = value as IEdmEntityObject;
-            if (edmObject != null)
-            {
-                IEdmTypeReference edmTypeReference = edmObject.GetEdmType();
-                return edmTypeReference.AsEntity();
-            }
-
-            IEdmTypeReference reference = EdmLibHelpers.GetEdmTypeReference(model, value.GetType());
+            IEdmTypeReference reference = model.GetEdmTypeReference(value);
             if (reference != null && reference.Definition.IsOrInheritsFrom(edmType))
             {
                 return (IEdmEntityTypeReference)reference;

--- a/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
@@ -509,15 +509,12 @@ namespace Microsoft.AspNet.OData
                 throw Error.InvalidOperation(SRResources.QueryGetModelMustNotReturnNull);
             }
 
-            var typeMappingHandler = model.GetAnnotationValue<IEdmModelClrTypeMappingHandler>(model);
             IEdmType elementType = null;
+            IEdmModelClrTypeMappingHandler typeMappingHandler = model.GetAnnotationValue<IEdmModelClrTypeMappingHandler>(model);
             if (typeMappingHandler != null)
             {
                 elementType = typeMappingHandler.MapClrInstanceToEdmType(model, responseValue);
-                if (elementType is IEdmCollectionType collection)
-                {
-                    elementType = collection.ElementType.Definition;
-                }
+                elementType = EdmLibHelpers.UnwrapCollectionType(elementType);
             }
 
             if (elementType == null)
@@ -748,15 +745,12 @@ namespace Microsoft.AspNet.OData
                 throw Error.InvalidOperation(SRResources.QueryGetModelMustNotReturnNull);
             }
 
-            var typeMappingHandler = model.GetAnnotationValue<IEdmModelClrTypeMappingHandler>(model);
             IEdmType type = null;
+            IEdmModelClrTypeMappingHandler typeMappingHandler = model.GetAnnotationValue<IEdmModelClrTypeMappingHandler>(model);
             if (typeMappingHandler != null)
             {
                 type = typeMappingHandler.MapClrInstanceToEdmType(model, responseValue);
-                if (type is IEdmCollectionType collection)
-                {
-                    type = collection.ElementType.Definition;
-                }
+                type = EdmLibHelpers.UnwrapCollectionType(type);
             }
 
             if (type == null)

--- a/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
@@ -509,7 +509,23 @@ namespace Microsoft.AspNet.OData
                 throw Error.InvalidOperation(SRResources.QueryGetModelMustNotReturnNull);
             }
 
-            return new ODataQueryContext(model, elementClrType, path);
+            var typeMappingHandler = model.GetAnnotationValue<IEdmModelClrTypeMappingHandler>(model);
+            IEdmType elementType = null;
+            if (typeMappingHandler != null)
+            {
+                elementType = typeMappingHandler.MapClrInstanceToEdmType(model, responseValue);
+                if (elementType is IEdmCollectionType collection)
+                {
+                    elementType = collection.ElementType.Definition;
+                }
+            }
+
+            if (elementType == null)
+            {
+                elementType = model.GetEdmType(elementClrType);
+            }
+
+            return new ODataQueryContext(model, elementType, elementClrType, path);
         }
 
         /// <summary>
@@ -732,8 +748,24 @@ namespace Microsoft.AspNet.OData
                 throw Error.InvalidOperation(SRResources.QueryGetModelMustNotReturnNull);
             }
 
-            IEdmEntityType baseEntityType = model.GetEdmType(elementClrType) as IEdmEntityType;
-            IEdmStructuredType structuredType = model.GetEdmType(elementClrType) as IEdmStructuredType;
+            var typeMappingHandler = model.GetAnnotationValue<IEdmModelClrTypeMappingHandler>(model);
+            IEdmType type = null;
+            if (typeMappingHandler != null)
+            {
+                type = typeMappingHandler.MapClrInstanceToEdmType(model, responseValue);
+                if (type is IEdmCollectionType collection)
+                {
+                    type = collection.ElementType.Definition;
+                }
+            }
+
+            if (type == null)
+            {
+                type = model.GetEdmType(elementClrType);
+            }
+
+            IEdmEntityType baseEntityType = type as IEdmEntityType;
+            IEdmStructuredType structuredType = type as IEdmStructuredType;
             IEdmProperty property = null;
             if (path != null)
             {

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -410,6 +410,12 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         private void ApplyResourceProperties(object resource, ODataResourceWrapper resourceWrapper,
             IEdmStructuredTypeReference structuredType, ODataDeserializerContext readContext)
         {
+            var typeMappingHandler = readContext.Model.GetAnnotationValue<IEdmModelClrTypeMappingHandler>(readContext.Model);
+            if (typeMappingHandler != null)
+            {
+                typeMappingHandler.InitializeClrInstanceForDeserialization(readContext.Model, structuredType, resource);
+            }
+
             ApplyStructuralProperties(resource, resourceWrapper, structuredType, readContext);
             ApplyNestedProperties(resource, resourceWrapper, structuredType, readContext);
         }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
@@ -1125,5 +1125,12 @@ namespace Microsoft.AspNet.OData.Formatter
                     String.Join("_", type.GetGenericArguments().Select(t => MangleClrTypeName(t))));
             }
         }
+
+        public static IEdmType UnwrapCollectionType(IEdmType type)
+        {
+            return type is IEdmCollectionType collection 
+                ? collection.ElementType.Definition 
+                : type;
+        }
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
@@ -1128,9 +1128,8 @@ namespace Microsoft.AspNet.OData.Formatter
 
         public static IEdmType UnwrapCollectionType(IEdmType type)
         {
-            return type is IEdmCollectionType collection 
-                ? collection.ElementType.Definition 
-                : type;
+            IEdmCollectionType collection = type as IEdmCollectionType;
+            return collection == null ? type : collection.ElementType.Definition;
         }
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
@@ -179,7 +179,7 @@ namespace Microsoft.AspNet.OData.Formatter
                     returnType = edmModel
                         .SchemaElements
                         .OfType<IEdmType>()
-                        .Select(edmType => new {EdmType = edmType, Annotation = edmModel.GetAnnotationValue<ClrTypeAnnotation>(edmType)})
+                        .Select(edmType => new { EdmType = edmType, Annotation = edmModel.GetAnnotationValue<ClrTypeAnnotation>(edmType) })
                         .Where(tuple => tuple.Annotation != null && tuple.Annotation.ClrType == clrType)
                         .Select(tuple => tuple.EdmType)
                         .SingleOrDefault();
@@ -191,7 +191,6 @@ namespace Microsoft.AspNet.OData.Formatter
                     returnType = edmModel.FindType(clrType.EdmFullName());
                 }
                 
-
                 if (TypeHelper.GetBaseType(clrType) != null)
                 {
                     // go up the inheritance tree to see if we have a mapping defined for the base type.
@@ -224,7 +223,6 @@ namespace Microsoft.AspNet.OData.Formatter
                     typeReference = typeMappingHandler.MapClrInstanceToEdmTypeReference(edmModel, clrInstance);
                 }
             }
-
 
             if (typeReference == null)
             {

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
@@ -951,7 +951,17 @@ namespace Microsoft.AspNet.OData.Formatter
             else
             {
                 TryGetInnerTypeForDelta(ref type);
-                expectedPayloadType = model.GetEdmTypeReference(type);
+
+                var typeMappingHandler = model.GetAnnotationValue<IEdmModelClrTypeMappingHandler>(model);
+                if (typeMappingHandler != null)
+                {
+                    expectedPayloadType = typeMappingHandler.MapClrTypeToTypeReference(model, type, path);
+                }
+
+                if (expectedPayloadType == null)
+                {
+                    expectedPayloadType = model.GetEdmTypeReference(type);
+                }
             }
 
             return expectedPayloadType;

--- a/src/Microsoft.AspNet.OData.Shared/IEdmModelClrTypeMappingHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/IEdmModelClrTypeMappingHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNet.OData.Routing;
 using Microsoft.OData.Edm;
 
 namespace Microsoft.AspNet.OData
@@ -20,6 +21,15 @@ namespace Microsoft.AspNet.OData
         /// <returns>The <see cref="IEdmType"/> that corresponds for the given CLR type or <code>null</code> if default mapping should be performed.</returns>
         IEdmType MapClrTypeToEdmType(IEdmModel edmModel, Type clrType);
 
+        /// <summary>
+        /// Maps a given CLR type to its corresponding <see cref="IEdmTypeReference"/>. 
+        /// </summary>
+        /// <param name="edmModel">The EDM model for which the conversion should be performed.</param>
+        /// <param name="clrType">The CLR type that should be mapped.</param>
+        /// <param name="path">The OData path that can be used to obtain further information about the requested type.</param>
+        /// <returns></returns>
+        IEdmTypeReference MapClrTypeToTypeReference(IEdmModel edmModel, Type clrType, ODataPath path);
+        
         /// <summary>
         /// Maps a given CLR collection to its corresponding <see cref="IEdmCollectionType"/>
         /// </summary>
@@ -48,5 +58,13 @@ namespace Microsoft.AspNet.OData
         /// <param name="clrInstance">The CLR object for which the mapping should be performed.</param>
         /// <returns>The <see cref="IEdmTypeReference"/> that corresponds for the given CLR instance or <code>null</code> if default mapping should be performed.</returns>
         IEdmTypeReference MapClrInstanceToEdmTypeReference(IEdmModel edmModel, object clrInstance);
+
+        /// <summary>
+        /// Initializes a newly created CLR object before the deserialization starts. 
+        /// </summary>
+        /// <param name="edmModel">The EDM model defining the <paramref name="typeReference" />.</param>
+        /// <param name="typeReference">The EDM type being deserialized. </param>
+        /// <param name="clrInstance">The CLR object into which the properties will be filled</param>
+        void InitializeClrInstanceForDeserialization(IEdmModel edmModel, IEdmStructuredTypeReference typeReference, object clrInstance);
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/IEdmModelClrTypeMappingHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/IEdmModelClrTypeMappingHandler.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNet.OData
+{
+    /// <summary>
+    /// Exposes the ability to change the behavior on how CLR types and instances are mapped to their corresponding <see cref="IEdmType"/>. 
+    /// </summary>
+    public interface IEdmModelClrTypeMappingHandler
+    {
+        /// <summary>
+        /// Maps a given CLR type to its corresponding <see cref="IEdmType"/>
+        /// </summary>
+        /// <param name="edmModel">The EDM model for which the conversion should be performed.</param>
+        /// <param name="clrType">The CLR type that should be mapped.</param>
+        /// <returns>The <see cref="IEdmType"/> that corresponds for the given CLR type or <code>null</code> if default mapping should be performed.</returns>
+        IEdmType MapClrTypeToEdmType(IEdmModel edmModel, Type clrType);
+
+        /// <summary>
+        /// Maps a given CLR collection to its corresponding <see cref="IEdmCollectionType"/>
+        /// </summary>
+        /// <param name="edmModel">The EDM model for which the conversion should be performed.</param>
+        /// <param name="clrType">The CLR type of the collection that should be mapped. Typically a type assignable to <see cref="IEnumerable{T}"/>.</param>
+        /// <param name="elementClrType">The CLR type of the items contained in the collection.</param>
+        /// <remarks>
+        /// The element type contained in the <paramref name="clrType"/> parameter might consist of OData specific wrapper objects. The <paramref name="elementClrType"/>
+        /// parameter represents the unwrapped CLR type. 
+        /// </remarks>
+        /// <returns>The <see cref="IEdmCollectionType"/> that corresponds to the given CLR type or <code>null</code> if default mapping should be performed.</returns>
+        IEdmCollectionType MapClrEnumerableToEdmCollection(IEdmModel edmModel, Type clrType, Type elementClrType);
+
+        /// <summary>
+        /// Maps a given CLR object to its corresponding <see cref="IEdmType"/>.
+        /// </summary>
+        /// <param name="edmModel">The EDM model for which the conversion should be performed.</param>
+        /// <param name="clrInstance">The CLR object for which the mapping should be performed.</param>
+        /// <returns>The <see cref="IEdmType"/> that corresponds for the given CLR instance or <code>null</code> if default mapping should be performed.</returns>
+        IEdmType MapClrInstanceToEdmType(IEdmModel edmModel, object clrInstance);
+
+        /// <summary>
+        /// Maps a given CLR object to its corresponding <see cref="IEdmTypeReference"/>.
+        /// </summary>
+        /// <param name="edmModel">The EDM model for which the conversion should be performed.</param>
+        /// <param name="clrInstance">The CLR object for which the mapping should be performed.</param>
+        /// <returns>The <see cref="IEdmTypeReference"/> that corresponds for the given CLR instance or <code>null</code> if default mapping should be performed.</returns>
+        IEdmTypeReference MapClrInstanceToEdmTypeReference(IEdmModel edmModel, object clrInstance);
+    }
+}

--- a/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
+++ b/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
@@ -64,6 +64,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Formatter\QueryStringMediaTypeMapping.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter\Serialization\ODataSerializerProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GetNextPageHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IEdmModelClrTypeMappingHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IPerRouteContainer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ODataNullValueMessageHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PerRouteContainerBase.cs" />

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -172,7 +172,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             Contract.Assert(declaringType != null, "only entity types are projected.");
 
             // derived property using cast
-            if (elementType != declaringType)
+            if (!elementType.IsOrInheritsFrom(declaringType))
             {
                 Type castType = EdmLibHelpers.GetClrType(declaringType, _model);
                 if (castType == null)
@@ -674,7 +674,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             if (derivedTypes.Count == 0)
             {
                 // no inheritance.
-                return null;
+                return Expression.Constant(elementType.FullTypeName());
             }
             else
             {

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             }
 
             Type elementType = GetElementType();
-            return model.GetEdmTypeReference(elementType);
+            return model.GetEdmTypeReference(UntypedInstance, elementType);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNet.OData.Shared/Results/ResultHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Results/ResultHelpers.cs
@@ -108,11 +108,10 @@ namespace Microsoft.AspNet.OData.Results
 
         private static IEdmEntityTypeReference GetEntityType(IEdmModel model, object entity)
         {
-            Type entityType = entity.GetType();
-            IEdmTypeReference edmType = model.GetEdmTypeReference(entityType);
+            IEdmTypeReference edmType = model.GetEdmTypeReference(entity);
             if (edmType == null)
             {
-                throw Error.InvalidOperation(SRResources.ResourceTypeNotInModel, entityType.FullName);
+                throw Error.InvalidOperation(SRResources.ResourceTypeNotInModel, entity.GetType().FullName);
             }
             if (!edmType.IsEntity())
             {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
@@ -815,7 +815,7 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Fact]
-        public void CreateTypeNameExpression_ReturnsNull_IfTypeHasNoDerivedTypes()
+        public void CreateTypeNameExpression_ReturnsFullTypeName_IfTypeHasNoDerivedTypes()
         {
             // Arrange
             IEdmEntityType baseType = new EdmEntityType("NS", "BaseType");
@@ -828,7 +828,8 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             Expression result = SelectExpandBinder.CreateTypeNameExpression(source, baseType, model);
 
             // Assert
-            Assert.Null(result);
+            Assert.Equal(ExpressionType.Constant, result.NodeType);
+            Assert.Equal(baseType.FullTypeName(), (result as ConstantExpression).Value);
         }
 
         //[Fact]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -45,6 +45,15 @@ public interface Microsoft.AspNet.OData.IEdmEntityObject : IEdmObject, IEdmStruc
 public interface Microsoft.AspNet.OData.IEdmEnumObject : IEdmObject {
 }
 
+public interface Microsoft.AspNet.OData.IEdmModelClrTypeMappingHandler {
+	void InitializeClrInstanceForDeserialization (Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmStructuredTypeReference typeReference, object clrInstance)
+	Microsoft.OData.Edm.IEdmCollectionType MapClrEnumerableToEdmCollection (Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType, System.Type elementClrType)
+	Microsoft.OData.Edm.IEdmType MapClrInstanceToEdmType (Microsoft.OData.Edm.IEdmModel edmModel, object clrInstance)
+	Microsoft.OData.Edm.IEdmTypeReference MapClrInstanceToEdmTypeReference (Microsoft.OData.Edm.IEdmModel edmModel, object clrInstance)
+	Microsoft.OData.Edm.IEdmType MapClrTypeToEdmType (Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType)
+	Microsoft.OData.Edm.IEdmTypeReference MapClrTypeToTypeReference (Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType, ODataPath path)
+}
+
 public interface Microsoft.AspNet.OData.IEdmObject {
 	Microsoft.OData.Edm.IEdmTypeReference GetEdmType ()
 }
@@ -482,6 +491,7 @@ public class Microsoft.AspNet.OData.ODataNullValueMessageHandler : System.Net.Ht
 public class Microsoft.AspNet.OData.ODataQueryContext {
 	public ODataQueryContext (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmType elementType, ODataPath path)
 	public ODataQueryContext (Microsoft.OData.Edm.IEdmModel model, System.Type elementClrType, ODataPath path)
+	public ODataQueryContext (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmType elementType, System.Type elementClrType, ODataPath path)
 
 	DefaultQuerySettings DefaultQuerySettings  { public get; }
 	System.Type ElementClrType  { public get; }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -45,6 +45,13 @@ public interface Microsoft.AspNet.OData.IEdmEntityObject : IEdmObject, IEdmStruc
 public interface Microsoft.AspNet.OData.IEdmEnumObject : IEdmObject {
 }
 
+public interface Microsoft.AspNet.OData.IEdmModelClrTypeMappingHandler {
+	Microsoft.OData.Edm.IEdmCollectionType MapClrEnumerableToEdmCollection (Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType, System.Type elementClrType)
+	Microsoft.OData.Edm.IEdmType MapClrInstanceToEdmType (Microsoft.OData.Edm.IEdmModel edmModel, object clrInstance)
+	Microsoft.OData.Edm.IEdmTypeReference MapClrInstanceToEdmTypeReference (Microsoft.OData.Edm.IEdmModel edmModel, object clrInstance)
+	Microsoft.OData.Edm.IEdmType MapClrTypeToEdmType (Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType)
+}
+
 public interface Microsoft.AspNet.OData.IEdmObject {
 	Microsoft.OData.Edm.IEdmTypeReference GetEdmType ()
 }
@@ -529,6 +536,7 @@ public class Microsoft.AspNet.OData.ODataOptions {
 public class Microsoft.AspNet.OData.ODataQueryContext {
 	public ODataQueryContext (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmType elementType, ODataPath path)
 	public ODataQueryContext (Microsoft.OData.Edm.IEdmModel model, System.Type elementClrType, ODataPath path)
+	public ODataQueryContext (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmType elementType, System.Type elementClrType, ODataPath path)
 
 	DefaultQuerySettings DefaultQuerySettings  { public get; }
 	System.Type ElementClrType  { public get; }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -46,10 +46,12 @@ public interface Microsoft.AspNet.OData.IEdmEnumObject : IEdmObject {
 }
 
 public interface Microsoft.AspNet.OData.IEdmModelClrTypeMappingHandler {
+	void InitializeClrInstanceForDeserialization (Microsoft.OData.Edm.IEdmModel edmModel, Microsoft.OData.Edm.IEdmStructuredTypeReference typeReference, object clrInstance)
 	Microsoft.OData.Edm.IEdmCollectionType MapClrEnumerableToEdmCollection (Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType, System.Type elementClrType)
 	Microsoft.OData.Edm.IEdmType MapClrInstanceToEdmType (Microsoft.OData.Edm.IEdmModel edmModel, object clrInstance)
 	Microsoft.OData.Edm.IEdmTypeReference MapClrInstanceToEdmTypeReference (Microsoft.OData.Edm.IEdmModel edmModel, object clrInstance)
 	Microsoft.OData.Edm.IEdmType MapClrTypeToEdmType (Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType)
+	Microsoft.OData.Edm.IEdmTypeReference MapClrTypeToTypeReference (Microsoft.OData.Edm.IEdmModel edmModel, System.Type clrType, ODataPath path)
 }
 
 public interface Microsoft.AspNet.OData.IEdmObject {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1634 .*

### Description

This pull request is a WIP change which aims to solve the issue described in #1634. It adds a new interface `IEdmModelClrTypeMappingHandler` allowing developers to define how the OData API framework should map CLR types and objects to their corresponding EDM types and back. This ultimately allows developers to map a single CLR type to different EDM types. 

The change is designed to be an opt-in option and tries not to influence any behavior unless developers register their own handler taking over certain operations. Also it does not directly implement the support of 1 CLR type being the data store for multiple EDM types. It provides a system to hook into the mapping and serialization/deserialization process to bypass the default 1:1 mapping system. 

I added a sample project using this new type mapping handler interface to achieve a user-definable model system. This should illustrate the idea and how to use this new interface. 

### Checklist (Uncheck if it is not completed)

- [x] *Initial Interface defined*
- [x] *Query system updated to utilize new mapper interface*
- [x] *Ensured existing tests are not broken*
- [x] *Sample project with a user-defined model system added (likely needs to go to OData/ODataSamples for final merge)*
- [x] *Deserialization system updated (deserialize EDM objects correctly into their matching CLR object model)* 
- [x] *Update non-core version of codebase* 
- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Breaking Changes

- `SelectExpandBinder.CreateTypeNameExpression` now returns the full type name even if no inheritance is used. This is required to support polymorphic result sets.

### Additional work necessary

- Documentation needs to be updated to describe this new feature
