### PR TITLE
Fix issue #1631, Singleton and single navigation property possible without key defined on its type

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
@@ -659,6 +659,17 @@ namespace Microsoft.AspNet.OData.Common
                 return ResourceManager.GetString("EntityTypeDoesntHaveKeyDefined", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The entity type &apos;{0}&apos; of navigation property &apos;{1}&apos; on structural type &apos;{2}&apos; does not have a key defined..
+        /// </summary>
+        internal static string CollectionNavigationPropertyEntityTypeDoesntHaveKeyDefined
+        {
+            get
+            {
+                return ResourceManager.GetString("CollectionNavigationPropertyEntityTypeDoesntHaveKeyDefined", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to The entity type &apos;{0}&apos; does not match the expected entity type &apos;{1}&apos; as set on the query context..
@@ -1374,6 +1385,17 @@ namespace Microsoft.AspNet.OData.Common
         internal static string NavigationSourceTypeHasNoKeys {
             get {
                 return ResourceManager.GetString("NavigationSourceTypeHasNoKeys", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The entity set &apos;{0}&apos; is based on type &apos;{1}&apos; that has no keys defined..
+        /// </summary>
+        internal static string EntitySetTypeHasNoKeys
+        {
+            get
+            {
+                return ResourceManager.GetString("EntitySetTypeHasNoKeys", resourceCulture);
             }
         }
         

--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
@@ -730,6 +730,9 @@
   <data name="EntityTypeDoesntHaveKeyDefined" xml:space="preserve">
     <value>The entity '{0}' does not have a key defined.</value>
   </data>
+  <data name="CollectionNavigationPropertyEntityTypeDoesntHaveKeyDefined" xml:space="preserve">
+    <value>The entity type '{0}' of navigation property '{1}' on structural type '{2}' does not have a key defined.</value>
+  </data>
   <data name="InvalidPropertyMapper" xml:space="preserve">
     <value>The mapper provider must return a valid '{0}' instance for the given '{1}' IEdmType.</value>
   </data>
@@ -810,6 +813,9 @@
   </data>
   <data name="NavigationSourceTypeHasNoKeys" xml:space="preserve">
     <value>The entity set or singleton '{0}' is based on type '{1}' that has no keys defined.</value>
+  </data>
+  <data name="EntitySetTypeHasNoKeys" xml:space="preserve">
+    <value>The entity set '{0}' is based on type '{1}' that has no keys defined.</value>
   </data>
   <data name="ParameterTypeIsNotCollection" xml:space="preserve">
     <value>The type '{0}' of the parameter '{1}' must be a collection.</value>

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/Conventions/ODataConventionModelBuilderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/Conventions/ODataConventionModelBuilderTests.cs
@@ -1941,7 +1941,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
         }
 
         [Fact]
-        public void ModelBuilder_DeclareNavigationSourceOnAbstractEntityTypeWithKeyThrows()
+        public void ModelBuilder_DeclareEntitySetOnAbstractEntityTypeWithoutKeyThrows()
         {
             // Arrange
             var builder = ODataConventionModelBuilderFactory.Create();
@@ -1950,7 +1950,22 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             // Act & Assert
             ExceptionAssert.Throws<InvalidOperationException>(
                 () => builder.GetEdmModel(),
-            "The entity set or singleton 'entitySet' is based on type 'Microsoft.AspNet.OData.Test.Builder.Conventions.AbstractEntityType' that has no keys defined.");
+            "The entity set 'entitySet' is based on type 'Microsoft.AspNet.OData.Test.Builder.Conventions.AbstractEntityType' that has no keys defined.");
+        }
+
+        [Fact]
+        public void ModelBuilder_DeclareSingletonOnAbstractEntityTypeWithoutKeyWorks()
+        {
+            // Arrange
+            var builder = ODataConventionModelBuilderFactory.Create();
+            builder.Singleton<AbstractEntityType>("Me");
+
+            // Act
+            IEdmModel modle = builder.GetEdmModel();
+
+            // Assert
+            Assert.NotNull(modle);
+            Assert.NotNull(modle.FindDeclaredSingleton("Me"));
         }
 
         [Fact]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/EntitySetTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/EntitySetTest.cs
@@ -342,7 +342,7 @@ namespace Microsoft.AspNet.OData.Test.Builderr
 
             // Act & Assert
             ExceptionAssert.Throws<InvalidOperationException>(() => builder.GetEdmModel(),
-                "The entity set or singleton 'Customers' is based on type 'Microsoft.AspNet.OData.Test.Builder.TestModels.Customer' that has no keys defined.");
+                "The entity set 'Customers' is based on type 'Microsoft.AspNet.OData.Test.Builder.TestModels.Customer' that has no keys defined.");
         }
 
         [Fact]


### PR DESCRIPTION
…thout key defined on its type

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1631.*

### Description

* Enable Singleton defined without key 
* Enable Single-Value navigation property defined without key.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
