### PR TITLE
Fixing N+1 query bug on expands

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/ExpressionHelperMethods.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ExpressionHelperMethods.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNet.OData
         private static MethodInfo _skipMethod = GenericMethodOf(_ => Queryable.Skip<int>(default(IQueryable<int>), default(int)));
         private static MethodInfo _enumerableSkipMethod = GenericMethodOf(_ => Enumerable.Skip<int>(default(IEnumerable<int>), default(int)));
         private static MethodInfo _whereMethod = GenericMethodOf(_ => Queryable.Where<int>(default(IQueryable<int>), default(Expression<Func<int, bool>>)));
+        private static MethodInfo _enumerableWhereMethod = GenericMethodOf(_ => Enumerable.Where<int>(default(IEnumerable<int>), default(Func<int, bool>)));
 
         private static MethodInfo _queryableEmptyAnyMethod = GenericMethodOf(_ => Queryable.Any<int>(default(IQueryable<int>)));
         private static MethodInfo _queryableNonEmptyAnyMethod = GenericMethodOf(_ => Queryable.Any<int>(default(IQueryable<int>), default(Expression<Func<int, bool>>)));
@@ -47,6 +48,7 @@ namespace Microsoft.AspNet.OData
         private static MethodInfo _enumerableTakeMethod = GenericMethodOf(_ => Enumerable.Take<int>(default(IEnumerable<int>), default(int)));
 
         private static MethodInfo _queryableAsQueryableMethod = GenericMethodOf(_ => Queryable.AsQueryable<int>(default(IEnumerable<int>)));
+        private static MethodInfo _queryableToListMethod = GenericMethodOf(_ => Enumerable.ToList<int>(default(IEnumerable<int>)));
 
         private static MethodInfo _toQueryableMethod = GenericMethodOf(_ => ExpressionHelperMethods.ToQueryable<int>(default(int)));
 
@@ -182,6 +184,11 @@ namespace Microsoft.AspNet.OData
             get { return _whereMethod; }
         }
 
+        public static MethodInfo EnumerableWhereGeneric
+        {
+            get { return _enumerableWhereMethod; }
+        }
+
         public static MethodInfo QueryableSelectGeneric
         {
             get { return _queryableSelectMethod; }
@@ -235,6 +242,11 @@ namespace Microsoft.AspNet.OData
         public static MethodInfo QueryableAsQueryable
         {
             get { return _queryableAsQueryableMethod; }
+        }
+
+        public static MethodInfo QueryableToList
+        {
+            get { return _queryableToListMethod; }
         }
 
         public static MethodInfo EntityAsQueryable

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -210,17 +210,12 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
                 if (isCollection)
                 {
-                    Expression filterSource =
-                        typeof(IEnumerable).IsAssignableFrom(source.Type.GetProperty(propertyName).PropertyType)
-                            ? Expression.Call(
-                                ExpressionHelperMethods.QueryableAsQueryable.MakeGenericMethod(clrElementType),
-                                nullablePropertyValue)
-                            : nullablePropertyValue;
+                    Expression filterSource = nullablePropertyValue;
 
                     // TODO: Implement proper support for $select/$expand after $apply
                     Expression filterPredicate = FilterBinder.Bind(null, filterClause, clrElementType, _context, querySettings);
                     filterResult = Expression.Call(
-                        ExpressionHelperMethods.QueryableWhereGeneric.MakeGenericMethod(clrElementType),
+                        ExpressionHelperMethods.EnumerableWhereGeneric.MakeGenericMethod(clrElementType),
                         filterSource,
                         filterPredicate);
 
@@ -641,7 +636,9 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
             // expression
             //      source.Select((ElementType element) => new Wrapper { })
-            Expression selectedExpresion = Expression.Call(GetSelectMethod(elementType, projection.Type), source, selector);
+            var selectMethod = GetSelectMethod(elementType, projection.Type);
+            var methodCallExpression = Expression.Call(selectMethod, source, selector);
+            Expression selectedExpresion = Expression.Call(ExpressionHelperMethods.QueryableToList.MakeGenericMethod(projection.Type), methodCallExpression);
 
             if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
             {

--- a/test/UnitTest/Microsoft.Test.AspNet.OData/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.Test.AspNet.OData/Query/Expressions/SelectExpandBinderTest.cs
@@ -636,7 +636,7 @@ namespace Microsoft.Test.AspNet.OData.Query.Expressions
             Assert.Equal(
                 string.Format(
                     "IIF((value({0}) == null), null, IIF((value({0}).Orders == null), null, " +
-                    "value({0}).Orders.AsQueryable().Where($it => ($it.ID == value({1}).TypedProperty))))",
+                    "value({0}).Orders.Where($it => ($it.ID == value({1}).TypedProperty))))",
                     customer.Type,
                     "Microsoft.AspNet.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]"),
                 filterInExpand.ToString());
@@ -671,7 +671,7 @@ namespace Microsoft.Test.AspNet.OData.Query.Expressions
             // Assert
             Assert.Equal(
                 string.Format(
-                    "value({0}).Orders.AsQueryable().Where($it => ($it.ID == value(" +
+                    "value({0}).Orders.Where($it => ($it.ID == value(" +
                     "Microsoft.AspNet.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]).TypedProperty))",
                     customer.Type),
                 filterInExpand.ToString());


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

BUG: OData ignoring EntityFrameworkCore included data, forces a requery and N+1
https://github.com/OData/WebApi/issues/1463

### Description

The way OData wraps queries to allow for the dynamic nature of what OData can return is invoking the lazy loading capabilities of EF Core.

Take a simple example:

    http://host/odata/Customers?$expand=Orders

First the customers are fetched:

    SELECT ... FROM Customers

Then as the JSON serializer evaluates the results, for each customer a separate query is made to lazy load the orders:

    SELECT ... FROM Orders WHERE CustomerId = @Id

Thus for 100 customers returned, there will be 101 queries (one to get the customers, and another 100 to look up the orders for each customer), yielding an exponential performance decrease.

The solution is to force EF Core to employ eager loading and evaluate the query fully in advance (which is always preferable as if we are returning the JSON we know we need all the data requested in one go).

There are two areas to address this.

The expression generated for `/Customers?$expand=Orders` looks like the below, however this PR adds the missing `ToList()` (as indicated) to trigger eager loading of the child collection:

	{
	value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[MsODataTest21.Customer])
		.Select
		(
			Param_0 => new SelectAllAndExpand`1() 
			{
				ModelID = "d1eb9bd5-df72-4404-9192-7f44cbc341e3", 
				Instance = Param_0, 
				UseInstanceForProperties = True, 
				Container = new NamedProperty`1() 
				{
					Name = "Orders", 
					Value = Param_0.Orders.Select(
						Param_1 => 
							new SelectAll`1() 
							{
								ModelID = "d1eb9bd5-df72-4404-9192-7f44cbc341e3", 
								Instance = Param_1, 
								UseInstanceForProperties = True
							})
							.ToList() // < ** This needs to be added **
				}
			}
		)
	}

Now we get two queries no matter the volume of customers returned:

    SELECT ... FROM Customers

Followed by:

	SELECT ...
	FROM Orders o
	INNER JOIN (
		SELECT Id
		FROM Customer
	) AS t ON o.CustomerId = t.Id

The second area of concern is when querying expanded child collectons:

    http://host/odata/Customers?$expand=Orders($filter=contains(DeliveryAddress,'b'))

This results in the below query (with the added `ToList()` from above):

	{
	value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[MsODataTest21.Customer])
		.Select
		(
		Param_0 => new SelectAllAndExpand`1() 
			{
				ModelID = "d1eb9bd5-df72-4404-9192-7f44cbc341e3", 
				Instance = Param_0, 
				UseInstanceForProperties = True, 
				Container = new NamedProperty`1() 
				{
					Name = "Orders", 
					Value = 
						Param_0
							.Orders
							.AsQueryable() // < We need to get rid of this
							.Where($it =>
								$it.Name.Contains(
									value(Microsoft.AspNet.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.String]).TypedProperty))
										.Select
											(
											Param_1 => 
												new SelectAll`1() 
												{
													ModelID = "d1eb9bd5-df72-4404-9192-7f44cbc341e3", 
													Instance = Param_1, 
													UseInstanceForProperties = True
												}
											)
											.ToList()
				}
			}
		)
	}

Again, the unnecessary call to `AsQueryable()` (indicated) triggers lazy loading from EF Core, and even with the initial `ToList()` implemented will still result in an inefficient query. However, removing the `AsQueryable()` yields as-expected eagerly loaded results.

Removing the `AsQueryable()` results in two queries as before, with the second query honouring the filter.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added* // Tests have been modified as necessary
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

There may be other areas where lazy loading is triggered, as the `AsQueryable` method is still employed elsewhere.