### PR TITLE
Individual query options to utilize DI config

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/CountQueryOption.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/CountQueryOption.cs
@@ -68,7 +68,8 @@ namespace Microsoft.AspNet.OData.Query
                 context.Model,
                 context.ElementType,
                 context.NavigationSource,
-                new Dictionary<string, string> { { "$count", rawValue } });
+                new Dictionary<string, string> { { "$count", rawValue } },
+                context.RequestContainer);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData.Shared/Query/FilterQueryOption.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/FilterQueryOption.cs
@@ -72,7 +72,8 @@ namespace Microsoft.AspNet.OData.Query
                 context.Model,
                 context.ElementType,
                 context.NavigationSource,
-                new Dictionary<string, string> { { "$filter", rawValue } });
+                new Dictionary<string, string> { { "$filter", rawValue } },
+                context.RequestContainer);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
@@ -721,7 +721,8 @@ namespace Microsoft.AspNet.OData.Query
                     Context.Model,
                     Context.ElementType,
                     Context.NavigationSource,
-                    queryParameters);
+                    queryParameters,
+                    Context.RequestContainer);
                 var originalSelectExpand = SelectExpand;
                 SelectExpand = new SelectExpandQueryOption(
                     autoSelectRawValue,
@@ -931,7 +932,8 @@ namespace Microsoft.AspNet.OData.Query
                         Context.Model,
                         Context.ElementType,
                         Context.NavigationSource,
-                        new Dictionary<string, string> { { "$count", "true" } }));
+                        new Dictionary<string, string> { { "$count", "true" } },
+                        Context.RequestContainer));
             }
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Query/OrderByQueryOption.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/OrderByQueryOption.cs
@@ -9,7 +9,6 @@ using System.Linq.Expressions;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Query.Expressions;
 using Microsoft.AspNet.OData.Query.Validators;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;

--- a/src/Microsoft.AspNet.OData.Shared/Query/OrderByQueryOption.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/OrderByQueryOption.cs
@@ -9,6 +9,7 @@ using System.Linq.Expressions;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Query.Expressions;
 using Microsoft.AspNet.OData.Query.Validators;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
@@ -78,7 +79,8 @@ namespace Microsoft.AspNet.OData.Query
                 context.Model,
                 context.ElementType,
                 context.NavigationSource,
-                new Dictionary<string, string> { { "$orderby", rawValue }, { "$apply", applyRaw } });
+                new Dictionary<string, string> { { "$orderby", rawValue }, { "$apply", applyRaw } },
+                context.RequestContainer);
             _queryOptionParser.ParseApply();
         }
 
@@ -102,7 +104,8 @@ namespace Microsoft.AspNet.OData.Query
                 context.Model,
                 context.ElementType,
                 context.NavigationSource,
-                new Dictionary<string, string> { { "$orderby", rawValue } });
+                new Dictionary<string, string> { { "$orderby", rawValue } },
+                context.RequestContainer);
         }
 
         internal OrderByQueryOption(OrderByQueryOption orderBy)

--- a/src/Microsoft.AspNet.OData.Shared/Query/SelectExpandQueryOption.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/SelectExpandQueryOption.cs
@@ -100,7 +100,8 @@ namespace Microsoft.AspNet.OData.Query
                 context.Model,
                 context.ElementType,
                 context.NavigationSource,
-                new Dictionary<string, string> { { "$select", select }, { "$expand", expand } });
+                new Dictionary<string, string> { { "$select", select }, { "$expand", expand } },
+                context.RequestContainer);
         }
 
         /// <summary>

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/FilterQueryOptionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/FilterQueryOptionTest.cs
@@ -46,6 +46,13 @@ namespace Microsoft.AspNet.OData.Test.Query
 
                     // Navigational properties
                     { "Orders/any(order: order/OrderId eq 12)", new int[] { 1 } },
+
+                    // case insensitive forms
+                    { "NaME eq 'Highest'", new int[] { 2 } },
+                    { "AdDrEsS/CiTy eq 'redmond'", new int[] { 1 } },
+                    { "AlIaSeS/any(alias: alias eq 'alias34')", new int[] { 3, 4 } },
+                    { "OrDeRs/any(order: order/OrDeRId eq 12)", new int[] { 1 } },
+
                 };
             }
         }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/OrderByQueryOptionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/OrderByQueryOptionTest.cs
@@ -98,7 +98,6 @@ namespace Microsoft.AspNet.OData.Test.Query
         [InlineData("BadPropertyName")]
         [InlineData("''")]
         [InlineData(" ")]
-        [InlineData("customerid")]
         [InlineData("CustomerId,CustomerId")]
         [InlineData("CustomerId,Name,CustomerId")]
         public void ApplyInValidOrderbyQueryThrows(string orderbyValue)
@@ -109,6 +108,28 @@ namespace Microsoft.AspNet.OData.Test.Query
 
             ExceptionAssert.Throws<ODataException>(() =>
                 orderby.ApplyTo(ODataQueryOptionTest.Customers));
+        }
+
+        [Theory]
+        [InlineData("customerid")]
+        [InlineData("cUsToMeRiD")]
+        [InlineData("CUSTOMERID")]
+        public void CanApplyOrderByQueryCaseInsensitive(string orderbyValue)
+        {
+            var model = new ODataModelBuilder().Add_Customer_EntityType().Add_Customers_EntitySet().GetEdmModel();
+            var context = new ODataQueryContext(model, typeof(Customer)) { RequestContainer = new MockContainer() };
+            var orderby = new OrderByQueryOption(orderbyValue, context);
+
+            var customers = (new List<Customer>{
+                new Customer { CustomerId = 2, Name = "Aaron" },
+                new Customer { CustomerId = 1, Name = "Andy" },
+                new Customer { CustomerId = 3, Name = "Alex" }
+            }).AsQueryable();
+
+            var results = orderby.ApplyTo(customers).ToArray();
+            Assert.Equal(1, results[0].CustomerId);
+            Assert.Equal(2, results[1].CustomerId);
+            Assert.Equal(3, results[2].CustomerId);
         }
 
         [Fact]


### PR DESCRIPTION
…nfig is available.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1659.*

### Description

*ODataQueryOptions already use dependency-injected config settings from container. We should make such injected config settings available for sub-query option classes such as OrderByQueryOption, FilterQueryOption, SelectExpandQueryOption; the rest such as Top, Skip are not needed for now since value types are int-type (case-insensitive), but could be added if desired.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
