### PR TITLE
Allow ODataFeature.TotalCount set to null.

### DIFF
--- a/src/Microsoft.AspNet.OData/Extensions/HttpRequestMessageProperties.cs
+++ b/src/Microsoft.AspNet.OData/Extensions/HttpRequestMessageProperties.cs
@@ -104,9 +104,9 @@ namespace Microsoft.AspNet.OData.Extensions
                 object totalCount;
                 if (_request.Properties.TryGetValue(TotalCountKey, out totalCount))
                 {
-                    // Fairly big problem if following cast fails. Indicates something else is writing properties with
-                    // names we've chosen. Do not silently return null because that will hide the problem.
-                    return (long)totalCount;
+                    // TotalCount is defined as null-able long, allowed to be set as null, so it should be
+                    // safe to cast to null-able type of long as result.
+                    return (long?)totalCount;
                 }
 
                 if (this.TotalCountFunc != null)
@@ -120,11 +120,6 @@ namespace Microsoft.AspNet.OData.Extensions
             }
             set
             {
-                if (!value.HasValue)
-                {
-                    throw Error.ArgumentNull("value");
-                }
-
                 _request.Properties[TotalCountKey] = value;
             }
         }

--- a/src/Microsoft.AspNetCore.OData/ODataFeature.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataFeature.cs
@@ -101,11 +101,6 @@ namespace Microsoft.AspNet.OData
 
             set
             {
-                if (!value.HasValue)
-                {
-                    throw Error.ArgumentNull("value");
-                }
-
                 this.totalCount = value;
                 this.totalCountSet = true;
             }

--- a/src/Microsoft.AspNetCore.OData/ODataFeature.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataFeature.cs
@@ -102,7 +102,7 @@ namespace Microsoft.AspNet.OData
             set
             {
                 this.totalCount = value;
-                this.totalCountSet = true;
+                this.totalCountSet = value.HasValue;
             }
         }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/ODataResourceSetSerializerTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/ODataResourceSetSerializerTests.cs
@@ -647,6 +647,23 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             Assert.Equal(3, resourceSet.Functions.Count());
         }
 
+        [Fact]
+        public void SetODataFeatureTotalCountValueNull()
+        {
+            // Arrange
+            ODataResourceSetSerializer serializer = new ODataResourceSetSerializer(_serializerProvider);
+            var request = RequestFactory.Create();
+            request.ODataContext().TotalCount = null;
+
+            var result = new object[0];
+
+            // Act
+            ODataResourceSet resourceSet = serializer.CreateResourceSet(result, _customersType, new ODataSerializerContext { Request = request });
+
+            // Assert
+            Assert.Null(resourceSet.Count);
+        }
+
         [Theory]
         [InlineData(ODataMetadataLevel.MinimalMetadata)]
         [InlineData(ODataMetadataLevel.NoMetadata)]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1637.*

### Description

*Removed the null check, this will align with IODataFeature which already has a nullable type for TotalCount.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
