### PR TITLE
Fix assignment of CollectionExpandedProperty.TotalCount when using EF

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/PropertyContainer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/PropertyContainer.cs
@@ -118,7 +118,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
                 if (property.CountOption != null && property.CountOption.Value)
                 {
-                    memberBindings.Add(Expression.Bind(namedPropertyType.GetProperty("TotalCount"), property.TotalCount));
+                    memberBindings.Add(Expression.Bind(namedPropertyType.GetProperty("TotalCount"), ExpressionHelpers.ToNullable(property.TotalCount)));
                 }
             }
             else

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/SelectExpandNestedDollarCountTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/SelectExpandNestedDollarCountTest.cs
@@ -131,7 +131,7 @@ namespace Microsoft.AspNet.OData.Test
             Assert.Contains("\"Categories@odata.count\":9", payload); // Categories
         }
 
-        private Task<HttpResponseMessage> GetResponse(string uri, string acceptHeader, bool handleNullPropagation = true)
+        private Task<HttpResponseMessage> GetResponse(string uri, string acceptHeader)
         {
             var controllers = new[] {
                 typeof(MsCustomersController),


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1565 

### Description

As the expression contained in NamedPropertyExpression.TotalCount can be either Int64 or Nullable<Int64> depending on ODataQuerySettings.HandleNullPropagation, cast result of expression to the nullable type before assigning, otherwise the property is set to some random number.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*