### PR TITLE
handle string literal constant nodes in template parser

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/RoutingConventionHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/RoutingConventionHelpers.cs
@@ -320,6 +320,10 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
                     {
                         nameInRouteData = uriTemplateExpression.LiteralText.Trim();
                     }
+                    else
+                    {
+                        nameInRouteData = node.Value as string;
+                    }
                 }
                 else
                 {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/AttributeRoutingTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/AttributeRoutingTest.cs
@@ -226,6 +226,14 @@ namespace Microsoft.AspNet.OData.Test.Routing
             {
                 return "GetWholeSalary(" + min + "," + max + "," + ave + ")";
             }
+            
+            [HttpGet]
+            [ODataRoute("Customers/NS.GetAvailability(Region='{Region}',Unit={Unit})")]
+            public string GetAvailability(string Region, int Unit)
+            {
+                return "GetAvailability('" + Region + "'," + Unit + ")";
+            }
+
 
             [HttpGet]
             [ODataRoute("Customers({id})/NS.SpecialCustomer/NS.GetSalary()")]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/DefaultODataPathHandlerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/DefaultODataPathHandlerTest.cs
@@ -111,6 +111,14 @@ namespace Microsoft.AspNet.OData.Test.Routing
         }
 
         [Fact]
+        public void Parse_OperationTemplate()
+        {
+            string odataPath = "Availability/Default.FindAvailability(Region='{Region}',Unit={Unit})";
+
+            _parser.Parse(_model, _serviceRoot, odataPath);
+        }
+        
+        [Fact]
         public void Parse_ForInvalidCast_ThrowsODataException()
         {
             string odataPath = "RoutingCustomers/Microsoft.AspNet.OData.Test.Routing.Product";
@@ -2286,6 +2294,7 @@ namespace Microsoft.AspNet.OData.Test.Routing
         [InlineData("Customers/NS.GetWholeSalary(minSalary=7)", "Customers/NS.GetWholeSalary(minSalary={min})", new string[] { "min:7" })]
         [InlineData("Customers/NS.GetWholeSalary(minSalary=7,maxSalary=8)", "Customers/NS.GetWholeSalary(minSalary={min},maxSalary={max})", new string[] { "min:7", "max:8" })]
         [InlineData("Customers/NS.GetWholeSalary(minSalary=7,maxSalary=8,aveSalary=9)", "Customers/NS.GetWholeSalary(minSalary={min},maxSalary={max},aveSalary={ave})", new string[] { "min:7", "max:8", "ave:9" })]
+        [InlineData("Customers/NS.GetAvailability(Region='NZ',Unit=5)", "Customers/NS.GetAvailability(Region='{Region}',Unit={Unit})", new string[] { "Region:NZ", "Unit:5"})]
         public void ParseTemplate(string path, string template, string[] keyValues)
         {
             // Arrange

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/DefaultODataPathHandlerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/DefaultODataPathHandlerTest.cs
@@ -111,14 +111,6 @@ namespace Microsoft.AspNet.OData.Test.Routing
         }
 
         [Fact]
-        public void Parse_OperationTemplate()
-        {
-            string odataPath = "Availability/Default.FindAvailability(Region='{Region}',Unit={Unit})";
-
-            _parser.Parse(_model, _serviceRoot, odataPath);
-        }
-        
-        [Fact]
         public void Parse_ForInvalidCast_ThrowsODataException()
         {
             string odataPath = "RoutingCustomers/Microsoft.AspNet.OData.Test.Routing.Product";

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/TestCommon/CustomersModelWithInheritance.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/TestCommon/CustomersModelWithInheritance.cs
@@ -310,6 +310,12 @@ namespace Microsoft.AspNet.OData.Test.Common
             getSalaray.AddOptionalParameter("aveSalary", intType, "129");
             model.AddElement(getSalaray);
 
+            //function with int and string parameter
+            EdmFunction getAvailability = new EdmFunction("NS", "GetAvailability", stringType, isBound: true, entitySetPathExpression: null, isComposable: false);
+            getAvailability.AddParameter("entityset", new EdmCollectionTypeReference(new EdmCollectionType(new EdmEntityTypeReference(customer, false))));
+            getAvailability.AddParameter("Region", stringType);
+            getAvailability.AddParameter("Unit", intType);
+            model.AddElement(getAvailability);
             // navigation properties
             EdmNavigationProperty ordersNavProp = customer.AddUnidirectionalNavigation(
                 new EdmNavigationPropertyInfo


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description
Fixes issue #1791 .

The purpose of this PR is to handle prevent failure during parsing of odata templates when driven by https://github.com/Microsoft/aspnet-api-versioning currently the parser produces operation segments and subsequently fails to build the parameter mapping when parsing something like the following "Availability/Default.FindAvailability(Region='{Region}',Unit='{Unit}',Member={Member},MemberArea={MemberArea},FunctionType='{FunctionType}',Adults={Adults},Children={Children},ReservationType={ReservationType},RateCode='{RateCode}')"

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

