### PR TITLE
[Regression] Fix ODataModelBinderConverterTests in debug mode

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
@@ -1803,7 +1803,18 @@ namespace Microsoft.AspNet.OData.Common
                 return ResourceManager.GetString("PropertyMustBeDateTimeOffsetOrDate", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to The value must be a boolean..
+        /// </summary>
+        internal static string PropertyMustBeBoolean
+        {
+            get
+            {
+                return ResourceManager.GetString("PropertyMustBeBoolean", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The value with type &apos;{0}&apos; must have type &apos;{1}&apos;..
         /// </summary>

--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
@@ -895,4 +895,7 @@
   <data name="AggregateKindNotSupported" xml:space="preserve">
     <value>{0} type of aggregation is not supported.</value>
   </data>
+  <data name="PropertyMustBeBoolean" xml:space="preserve">
+    <value>The value must be a boolean.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/EdmPrimitiveHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/EdmPrimitiveHelpers.cs
@@ -118,6 +118,16 @@ namespace Microsoft.AspNet.OData.Formatter
 
                     throw new ValidationException(Error.Format(SRResources.PropertyMustBeTimeOfDay));
                 }
+                else if (type == typeof(bool))
+                {
+                    bool result;
+                    if (str != null && Boolean.TryParse(str, out result))
+                    {
+                        return result;
+                    }
+
+                    throw new ValidationException(Error.Format(SRResources.PropertyMustBeBoolean));
+                }
                 else
                 {
                     Contract.Assert(type == typeof(uint) || type == typeof(ushort) || type == typeof(ulong));

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataModelBinderConverterTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataModelBinderConverterTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
                 return new TheoryDataSet<object, EdmPrimitiveTypeKind, Type, object>
                 {
                     { "true", EdmPrimitiveTypeKind.Boolean, typeof(bool), true },
+                    { true, EdmPrimitiveTypeKind.Boolean, typeof(bool), true },
                     { 5, EdmPrimitiveTypeKind.Int32, typeof(int),  5 },
                     { new Guid("C2AEFDF2-B533-4971-8B6A-A539373BFC32"), EdmPrimitiveTypeKind.Guid, typeof(Guid), new Guid("C2AEFDF2-B533-4971-8B6A-A539373BFC32") }
                 };


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

PR #1742 introduced regression when building in Debug mode (Visual Studio or .\build.ps -q)
Test for converting from string to Boolean will fail in EdmPrimitiveHelpers.ConvertPrimitiveValue on following Contart.Assert in debug mode 
```
 else
                {
                    Contract.Assert(type == typeof(uint) || type == typeof(ushort) || type == typeof(ulong));

                    // Note that we are not casting the return value to nullable<T> as even if we do it
                    // CLR would unbox it back to T.
                    return Convert.ChangeType(value, type, CultureInfo.InvariantCulture);
                }
```
however will work in Release mode, because "true" is convertible to bool.true
That affect development + for incorrect Boolean string will return internal .NET error instead of nice ODataException

To solved that case, I added special treatment for Boolean data type.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*


