### PR TITLE
Enable $ref after $expand

### DIFF
--- a/samples/AspNetCoreODataSample.Web/Controllers/MoviesController.cs
+++ b/samples/AspNetCoreODataSample.Web/Controllers/MoviesController.cs
@@ -64,7 +64,21 @@ namespace AspNetCoreODataSample.Web.Controllers
                     Title = "Conan",
                     ReleaseDate = new DateTimeOffset(new DateTime(2018, 3, 3)),
                     Genre = Genre.Comedy,
-                    Price = 1.99m
+                    Price = 1.99m,
+                    Stars = new List<MovieStar>{
+                        new MovieStar
+                        {
+                            FirstName = "Arnold",
+                            LastName = "Schwarzenegger",
+                            MovieId = 1
+                        },
+                        new MovieStar
+                        {
+                            FirstName = "Jackie",
+                            LastName = "Chan",
+                            MovieId = 1
+                        }
+                    }
                 },
                 new Movie
                 {
@@ -72,7 +86,15 @@ namespace AspNetCoreODataSample.Web.Controllers
                     Title = "James",
                     ReleaseDate = new DateTimeOffset(new DateTime(2017, 3, 3)),
                     Genre = Genre.Adult,
-                    Price = 91.99m
+                    Price = 91.99m,
+                    Stars = new List<MovieStar>{
+                        new MovieStar
+                        {
+                            FirstName = "Bruce",
+                            LastName = "Willis",
+                            MovieId = 2
+                        }
+                    }
                 }
             };
         }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -336,13 +336,23 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 ODataResource resource = CreateResource(selectExpandNode, resourceContext);
                 if (resource != null)
                 {
-                    writer.WriteStart(resource);
-                    WriteComplexProperties(selectExpandNode.SelectedComplexProperties, resourceContext, writer);
-                    WriteDynamicComplexProperties(resourceContext, writer);
-                    WriteNavigationLinks(selectExpandNode.SelectedNavigationProperties, resourceContext, writer);
-                    WriteExpandedNavigationProperties(selectExpandNode.ExpandedProperties,
-                        resourceContext, writer);
-                    writer.WriteEnd();
+                    if (resourceContext.SerializerContext.ExpandReference)
+                    {
+                        writer.WriteEntityReferenceLink(new ODataEntityReferenceLink
+                        {
+                            Url = resource.Id
+                        });
+                    }
+                    else
+                    {
+                        writer.WriteStart(resource);
+                        WriteComplexProperties(selectExpandNode.SelectedComplexProperties, resourceContext, writer);
+                        WriteDynamicComplexProperties(resourceContext, writer);
+                        WriteNavigationLinks(selectExpandNode.SelectedNavigationProperties, resourceContext, writer);
+                        WriteExpandedNavigationProperties(selectExpandNode.ExpandedProperties, resourceContext, writer);
+                        WriteReferencedNavigationProperties(selectExpandNode.ReferencedNavigationProperties, resourceContext, writer);
+                        writer.WriteEnd();
+                    }
                 }
             }
         }
@@ -394,8 +404,15 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 throw Error.ArgumentNull("resourceContext");
             }
 
-            string typeName = resourceContext.StructuredType.FullTypeName();
+            if (resourceContext.SerializerContext.ExpandReference)
+            {
+                return new ODataResource
+                {
+                    Id = resourceContext.GenerateSelfLink(false)
+                };
+            }
 
+            string typeName = resourceContext.StructuredType.FullTypeName();
             ODataResource resource = new ODataResource
             {
                 TypeName = typeName,
@@ -763,7 +780,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
         private void WriteComplexAndExpandedNavigationProperty(IEdmProperty edmProperty, ExpandedNavigationSelectItem expandedNavigationSelectItem,
             ResourceContext resourceContext,
-            ODataWriter writer)
+            ODataWriter writer, bool expandReference = false)
         {
             Contract.Assert(edmProperty != null);
             Contract.Assert(resourceContext != null);
@@ -795,7 +812,9 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             else
             {
                 // create the serializer context for the complex and expanded item.
+
                 ODataSerializerContext nestedWriteContext = new ODataSerializerContext(resourceContext, edmProperty, resourceContext.SerializerContext.QueryContext, expandedNavigationSelectItem);
+                nestedWriteContext.ExpandReference = expandReference;
 
                 // write object.
                 ODataEdmTypeSerializer serializer = SerializerProvider.GetEdmTypeSerializer(edmProperty.Type);
@@ -806,6 +825,25 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 }
 
                 serializer.WriteObjectInline(propertyValue, edmProperty.Type, writer, nestedWriteContext);
+            }
+        }
+
+        private void WriteReferencedNavigationProperties(ISet<IEdmNavigationProperty> referencedPropertiesToExpand,
+            ResourceContext resourceContext, ODataWriter writer)
+        {
+            Contract.Assert(referencedPropertiesToExpand != null);
+            Contract.Assert(resourceContext != null);
+            Contract.Assert(writer != null);
+
+            foreach (IEdmNavigationProperty navigationProperty in referencedPropertiesToExpand)
+            {
+                ODataNestedResourceInfo nestedResourceInfo = CreateNavigationLink(navigationProperty, resourceContext);
+                if (nestedResourceInfo != null)
+                {
+                    writer.WriteStart(nestedResourceInfo);
+                    WriteComplexAndExpandedNavigationProperty(navigationProperty, null, resourceContext, writer, true);
+                    writer.WriteEnd();
+                }
             }
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataSerializerContext.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataSerializerContext.cs
@@ -73,6 +73,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             SkipExpensiveAvailabilityChecks = context.SkipExpensiveAvailabilityChecks;
             MetadataLevel = context.MetadataLevel;
             Items = context.Items;
+            ExpandReference = context.ExpandReference;
 
             QueryContext = queryContext;
             ExpandedResource = resource; // parent resource
@@ -202,6 +203,11 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         /// Gets or sets the resource that is being expanded.
         /// </summary>
         public ResourceContext ExpandedResource { get; set; }
+
+        /// <summary>
+        /// Gets or sets the boolean value indicating whether it's $ref expanded.
+        /// </summary>
+        public bool ExpandReference { get; set; }
 
         /// <summary>
         /// Gets or sets the complex property being nested or navigation property being expanded.

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/Models/Order.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/Models/Order.cs
@@ -9,6 +9,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization.Models
     {
         public int ID { get; set; }
         public string Name { get; set; }
+        public string City { get; set; }
         public Customer Customer { get; set; }
         public IDictionary<string, object> OrderProperties { get; set; }
     }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -3278,6 +3278,7 @@ public class Microsoft.AspNet.OData.Formatter.Serialization.ODataSerializerConte
 
 	Microsoft.OData.Edm.IEdmProperty EdmProperty  { public get; public set; }
 	ResourceContext ExpandedResource  { public get; public set; }
+	bool ExpandReference  { public get; public set; }
 	System.Collections.Generic.IDictionary`2[[System.Object],[System.Object]] Items  { public get; }
 	ODataMetadataLevel MetadataLevel  { public get; public set; }
 	Microsoft.OData.Edm.IEdmModel Model  { public get; public set; }
@@ -3304,6 +3305,7 @@ public class Microsoft.AspNet.OData.Formatter.Serialization.SelectExpandNode {
 	public SelectExpandNode (SelectExpandNode selectExpandNodeToCopy)
 	public SelectExpandNode (Microsoft.OData.Edm.IEdmStructuredType structuredType, ODataSerializerContext writeContext)
 	public SelectExpandNode (Microsoft.OData.UriParser.SelectExpandClause selectExpandClause, Microsoft.OData.Edm.IEdmStructuredType structuredType, Microsoft.OData.Edm.IEdmModel model)
+	public SelectExpandNode (Microsoft.OData.UriParser.SelectExpandClause selectExpandClause, Microsoft.OData.Edm.IEdmStructuredType structuredType, Microsoft.OData.Edm.IEdmModel model, bool expandedReference)
 
 	[
 	ObsoleteAttribute(),
@@ -3311,6 +3313,7 @@ public class Microsoft.AspNet.OData.Formatter.Serialization.SelectExpandNode {
 	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.SelectExpandClause]] ExpandedNavigationProperties  { public get; }
 
 	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.ExpandedNavigationSelectItem]] ExpandedProperties  { public get; }
+	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmNavigationProperty]] ReferencedNavigationProperties  { public get; }
 	bool SelectAllDynamicProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmAction]] SelectedActions  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] SelectedComplexProperties  { public get; }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -3410,6 +3410,7 @@ public class Microsoft.AspNet.OData.Formatter.Serialization.ODataSerializerConte
 
 	Microsoft.OData.Edm.IEdmProperty EdmProperty  { public get; public set; }
 	ResourceContext ExpandedResource  { public get; public set; }
+	bool ExpandReference  { public get; public set; }
 	System.Collections.Generic.IDictionary`2[[System.Object],[System.Object]] Items  { public get; }
 	ODataMetadataLevel MetadataLevel  { public get; public set; }
 	Microsoft.OData.Edm.IEdmModel Model  { public get; public set; }
@@ -3435,6 +3436,7 @@ public class Microsoft.AspNet.OData.Formatter.Serialization.SelectExpandNode {
 	public SelectExpandNode (SelectExpandNode selectExpandNodeToCopy)
 	public SelectExpandNode (Microsoft.OData.Edm.IEdmStructuredType structuredType, ODataSerializerContext writeContext)
 	public SelectExpandNode (Microsoft.OData.UriParser.SelectExpandClause selectExpandClause, Microsoft.OData.Edm.IEdmStructuredType structuredType, Microsoft.OData.Edm.IEdmModel model)
+	public SelectExpandNode (Microsoft.OData.UriParser.SelectExpandClause selectExpandClause, Microsoft.OData.Edm.IEdmStructuredType structuredType, Microsoft.OData.Edm.IEdmModel model, bool expandedReference)
 
 	[
 	ObsoleteAttribute(),
@@ -3442,6 +3444,7 @@ public class Microsoft.AspNet.OData.Formatter.Serialization.SelectExpandNode {
 	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.SelectExpandClause]] ExpandedNavigationProperties  { public get; }
 
 	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.ExpandedNavigationSelectItem]] ExpandedProperties  { public get; }
+	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmNavigationProperty]] ReferencedNavigationProperties  { public get; }
 	bool SelectAllDynamicProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmAction]] SelectedActions  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] SelectedComplexProperties  { public get; }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue https://github.com/OData/WebApi/issues/1751.*

### Description

* Enable $expand=navigationProperty/$ref

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
