### PR TITLE
Support leading and trailing spaces in query options

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
@@ -748,13 +748,14 @@ namespace Microsoft.AspNet.OData.Query
 
             foreach (KeyValuePair<string, string> kvp in InternalRequest.QueryParameters)
             {
+                string key = kvp.Key.Trim();
                 // Check supported system query options per $-sign-prefix option.
                 if (!_enableNoDollarSignQueryOptions)
                 {
                     // This is the original case for required $-sign prefix.
-                    if (kvp.Key.StartsWith("$", StringComparison.Ordinal))
+                    if (key.StartsWith("$", StringComparison.Ordinal))
                     {
-                        result.Add(kvp.Key, kvp.Value);
+                        result.Add(key, kvp.Value);
                     }
                 }
                 else
@@ -763,15 +764,15 @@ namespace Microsoft.AspNet.OData.Query
                     {
                         // Normalized the supported system query key by adding the $-prefix if needed.
                         result.Add(
-                            !kvp.Key.StartsWith("$", StringComparison.Ordinal) ? "$" + kvp.Key : kvp.Key,
+                            !key.StartsWith("$", StringComparison.Ordinal) ? "$" + key : key,
                             kvp.Value);
                     }
                 }
 
                 // check parameter alias
-                if (kvp.Key.StartsWith("@", StringComparison.Ordinal))
+                if (key.StartsWith("@", StringComparison.Ordinal))
                 {
-                    result.Add(kvp.Key, kvp.Value);
+                    result.Add(key, kvp.Value);
                 }
             }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/ODataQueryOptionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/ODataQueryOptionTest.cs
@@ -240,6 +240,7 @@ namespace Microsoft.AspNet.OData.Test.Query
         [Fact]
         public void CanExtractQueryOptionsCorrectly()
         {
+            // Arrange
             var model = new ODataModelBuilder().Add_Customer_EntityType().Add_Customers_EntitySet().GetEdmModel();
 
             var message = RequestFactory.Create(
@@ -247,7 +248,10 @@ namespace Microsoft.AspNet.OData.Test.Query
                 "http://server/service/Customers/?$filter=Filter&$select=Select&$orderby=OrderBy&$expand=Expand&$top=10&$skip=20&$count=true&$skiptoken=SkipToken&$deltatoken=DeltaToken"
             );
 
+            // Act
             var queryOptions = new ODataQueryOptions(new ODataQueryContext(model, typeof(Customer)), message);
+
+            // Assert
             Assert.Equal("Filter", queryOptions.RawValues.Filter);
             Assert.NotNull(queryOptions.Filter);
             Assert.Equal("OrderBy", queryOptions.RawValues.OrderBy);
@@ -264,13 +268,15 @@ namespace Microsoft.AspNet.OData.Test.Query
             Assert.Equal("DeltaToken", queryOptions.RawValues.DeltaToken);
         }
 
-
         [Theory]
         [InlineData(" $filter=Filter& $select=Select& $orderby=OrderBy& $expand=Expand& $top=10& $skip=20& $count=true& $skiptoken=SkipToken& $deltatoken=DeltaToken")]
         [InlineData("%20$filter=Filter&%20$select=Select&%20$orderby=OrderBy&%20$expand=Expand&%20$top=10&%20$skip=20&%20$count=true&%20$skiptoken=SkipToken&%20$deltatoken=DeltaToken")]
         [InlineData("$filter =Filter&$select =Select&$orderby =OrderBy&$expand =Expand&$top =10&$skip =20&$count =true&$skiptoken =SkipToken&$deltatoken =DeltaToken")]
-        public void CanExtractQueryOptionsWitLeadingSpacesCorrectly(string clause)
+        [InlineData("$filter%20=Filter&$select%20=Select&$orderby%20=OrderBy&$expand%20=Expand&$top%20=10&$skip%20=20&$count%20=true&$skiptoken%20=SkipToken&$deltatoken%20=DeltaToken")]
+        [InlineData(" $filter =Filter& $select =Select& $orderby =OrderBy& $expand =Expand& $top =10& $skip =20& $count =true& $skiptoken =SkipToken& $deltatoken =DeltaToken")]
+        public void CanExtractQueryOptionsWithExtraSpacesCorrectly(string clause)
         {
+            // Arrange
             var model = new ODataModelBuilder().Add_Customer_EntityType().Add_Customers_EntitySet().GetEdmModel();
 
             var message = RequestFactory.Create(
@@ -278,7 +284,10 @@ namespace Microsoft.AspNet.OData.Test.Query
                 "http://server/service/Customers/?"+ clause
             );
 
+            // Act
             var queryOptions = new ODataQueryOptions(new ODataQueryContext(model, typeof(Customer)), message);
+
+            // Assert
             Assert.Equal("Filter", queryOptions.RawValues.Filter);
             Assert.NotNull(queryOptions.Filter);
             Assert.Equal("OrderBy", queryOptions.RawValues.OrderBy);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/ODataQueryOptionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/ODataQueryOptionTest.cs
@@ -264,6 +264,37 @@ namespace Microsoft.AspNet.OData.Test.Query
             Assert.Equal("DeltaToken", queryOptions.RawValues.DeltaToken);
         }
 
+
+        [Theory]
+        [InlineData(" $filter=Filter& $select=Select& $orderby=OrderBy& $expand=Expand& $top=10& $skip=20& $count=true& $skiptoken=SkipToken& $deltatoken=DeltaToken")]
+        [InlineData("%20$filter=Filter&%20$select=Select&%20$orderby=OrderBy&%20$expand=Expand&%20$top=10&%20$skip=20&%20$count=true&%20$skiptoken=SkipToken&%20$deltatoken=DeltaToken")]
+        [InlineData("$filter =Filter&$select =Select&$orderby =OrderBy&$expand =Expand&$top =10&$skip =20&$count =true&$skiptoken =SkipToken&$deltatoken =DeltaToken")]
+        public void CanExtractQueryOptionsWitLeadingSpacesCorrectly(string clause)
+        {
+            var model = new ODataModelBuilder().Add_Customer_EntityType().Add_Customers_EntitySet().GetEdmModel();
+
+            var message = RequestFactory.Create(
+                HttpMethod.Get,
+                "http://server/service/Customers/?"+ clause
+            );
+
+            var queryOptions = new ODataQueryOptions(new ODataQueryContext(model, typeof(Customer)), message);
+            Assert.Equal("Filter", queryOptions.RawValues.Filter);
+            Assert.NotNull(queryOptions.Filter);
+            Assert.Equal("OrderBy", queryOptions.RawValues.OrderBy);
+            Assert.NotNull(queryOptions.OrderBy);
+            Assert.Equal("10", queryOptions.RawValues.Top);
+            Assert.NotNull(queryOptions.Top);
+            Assert.Equal("20", queryOptions.RawValues.Skip);
+            Assert.NotNull(queryOptions.Skip);
+            Assert.Equal("Expand", queryOptions.RawValues.Expand);
+            Assert.Equal("Select", queryOptions.RawValues.Select);
+            Assert.NotNull(queryOptions.SelectExpand);
+            Assert.Equal("true", queryOptions.RawValues.Count);
+            Assert.Equal("SkipToken", queryOptions.RawValues.SkipToken);
+            Assert.Equal("DeltaToken", queryOptions.RawValues.DeltaToken);
+        }
+
         [Fact]
         public void ApplyTo_Throws_With_Null_Queryable()
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1822.*

### Description

Adds Trim() to allow following queries ` $filter=Filter` (notice leading space), `$filter =Filter` (notice space before =), `%20$filter=Filter` 

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

