### PR TITLE
Improvement support continue-on-error in batch request

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchHandler.cs
@@ -16,7 +16,8 @@ namespace Microsoft.AspNet.OData.Batch
         private ODataMessageQuotas _messageQuotas = new ODataMessageQuotas { MaxReceivedMessageSize = Int64.MaxValue };
 
         // Preference odata.continue-on-error.
-        internal const string PreferenceContinueOnError = "odata.continue-on-error";
+        internal const string PreferenceContinueOnError = "continue-on-error";
+        internal const string PreferenceContinueOnErrorFalse = "continue-on-error=false";
 
         /// <summary>
         /// Gets the <see cref="ODataMessageQuotas"/> used for reading/writing the batch request/response.
@@ -44,7 +45,8 @@ namespace Microsoft.AspNet.OData.Batch
         internal void SetContinueOnError(IWebApiHeaders header, bool enableContinueOnErrorHeader)
         {
             string preferHeader = RequestPreferenceHelpers.GetRequestPreferHeader(header);
-            if ((preferHeader != null && preferHeader.Contains(PreferenceContinueOnError)) || (!enableContinueOnErrorHeader))
+            if ((preferHeader != null && preferHeader.Contains(PreferenceContinueOnError) && !preferHeader.Contains(PreferenceContinueOnErrorFalse)) 
+                || (!enableContinueOnErrorHeader))
             {
                 ContinueOnError = true;
             }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/UnbufferedODataBatchHandlerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/UnbufferedODataBatchHandlerTest.cs
@@ -188,9 +188,21 @@ namespace Microsoft.AspNet.OData.Test.Batch
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ProcessBatchAsync_ContinueOnError(bool enableContinueOnError)
+        [InlineData(true, "", 2)]
+        [InlineData(true, "odata.continue-on-error", 3)]
+        [InlineData(true, "odata.continue-on-error=true", 3)]
+        [InlineData(true, "odata.continue-on-error=false", 2)]
+        [InlineData(true, "continue-on-error", 3)]
+        [InlineData(true, "continue-on-error=true", 3)]
+        [InlineData(true, "continue-on-error=false", 2)]
+        [InlineData(false, "", 3)]
+        [InlineData(false, "odata.continue-on-error", 3)]
+        [InlineData(false, "odata.continue-on-error=true", 3)]
+        [InlineData(false, "odata.continue-on-error=false", 3)]
+        [InlineData(false, "continue-on-error", 3)]
+        [InlineData(false, "continue-on-error=true", 3)]
+        [InlineData(false, "continue-on-error=false", 3)]
+        public async Task ProcessBatchAsync_ContinueOnError(bool enableContinueOnError, string preferenceHeader, int expectedResponses)
         {
             // Arrange
             MockHttpServer server = new MockHttpServer(async request =>
@@ -234,44 +246,19 @@ namespace Microsoft.AspNet.OData.Test.Batch
             var enableContinueOnErrorconfig = new HttpConfiguration();
             enableContinueOnErrorconfig.EnableODataDependencyInjectionSupport();
             enableContinueOnErrorconfig.EnableContinueOnErrorHeader();
-            batchRequest.SetConfiguration(enableContinueOnErrorconfig);
-            batchRequest.EnableHttpDependencyInjectionSupport();
-            HttpRequestMessage batchRequestWithPrefContinueOnError = new HttpRequestMessage(HttpMethod.Post, "http://example.com/$batch")
-            {
-                Content = new MultipartContent("mixed")
-                {
-                    ODataBatchRequestHelper.CreateODataRequestContent(new HttpRequestMessage(HttpMethod.Get, "http://example.com/")),
-                    new MultipartContent("mixed") // ChangeSet
-                    {
-                        ODataBatchRequestHelper.CreateODataRequestContent(new HttpRequestMessage(HttpMethod.Post, "http://example.com/values")
-                        {
-                            Content = new StringContent("foo")
-                        })
-                    },
-                    ODataBatchRequestHelper.CreateODataRequestContent(new HttpRequestMessage(HttpMethod.Post, "http://example.com/values")
-                    {
-                        Content = new StringContent("bar")
-                    }),
-                }
-            };
-            batchRequestWithPrefContinueOnError.EnableHttpDependencyInjectionSupport();
             if (enableContinueOnError)
-            {
-                batchRequestWithPrefContinueOnError.SetConfiguration(enableContinueOnErrorconfig);
-                batchRequestWithPrefContinueOnError.Headers.Add("prefer", "odata.continue-on-error");
-            }
+                batchRequest.SetConfiguration(enableContinueOnErrorconfig);
+            if (!string.IsNullOrEmpty(preferenceHeader))
+                batchRequest.Headers.Add("prefer", preferenceHeader);
+            batchRequest.EnableHttpDependencyInjectionSupport();
 
             // Act
             var response = await batchHandler.ProcessBatchAsync(batchRequest, CancellationToken.None);
             var batchContent = Assert.IsType<ODataBatchContent>(response.Content);
             var batchResponses = batchContent.Responses.ToArray();
-            var responseWithPrefContinueOnError = await batchHandler.ProcessBatchAsync(batchRequestWithPrefContinueOnError, CancellationToken.None);
-            var batchContentWithPrefContinueOnError = Assert.IsType<ODataBatchContent>(responseWithPrefContinueOnError.Content);
-            var batchResponsesWithPrefContinueOnError = batchContentWithPrefContinueOnError.Responses.ToArray();
 
             // Assert
-            Assert.Equal(2, batchResponses.Length);
-            Assert.Equal(3, batchResponsesWithPrefContinueOnError.Length);
+            Assert.Equal(expectedResponses, batchResponses.Length);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

#1832 

### Description

Support continue-on-error without odata prefix.
Support `continue-on-error=false`

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
