### PR TITLE
Support default value for primitive and enum property

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/Conventions/Attributes/DefaultValueAttributeEdmPropertyConvention.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/Conventions/Attributes/DefaultValueAttributeEdmPropertyConvention.cs
@@ -37,13 +37,13 @@ namespace Microsoft.AspNet.OData.Builder.Conventions.Attributes
             DefaultValueAttribute defaultValueAttribute = attribute as DefaultValueAttribute;
             if (!edmProperty.AddedExplicitly && defaultValueAttribute != null && defaultValueAttribute.Value != null)
             {
-                if(edmProperty.Kind == PropertyKind.Primitive)
+                if (edmProperty.Kind == PropertyKind.Primitive)
                 {
                     PrimitivePropertyConfiguration primitiveProperty = edmProperty as PrimitivePropertyConfiguration;
                     primitiveProperty.DefaultValueString = defaultValueAttribute.Value.ToString();
                 }
 
-                if(edmProperty.Kind == PropertyKind.Enum)
+                if (edmProperty.Kind == PropertyKind.Enum)
                 {
                     EnumPropertyConfiguration enumProperty = edmProperty as EnumPropertyConfiguration;
                     enumProperty.DefaultValueString = defaultValueAttribute.Value.ToString();

--- a/src/Microsoft.AspNet.OData.Shared/Builder/Conventions/Attributes/DefaultValueAttributeEdmPropertyConvention.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/Conventions/Attributes/DefaultValueAttributeEdmPropertyConvention.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using Microsoft.AspNet.OData.Common;
+
+namespace Microsoft.AspNet.OData.Builder.Conventions.Attributes
+{
+    /// <summary>
+    /// Sets default value for properties that have <see cref="DefaultValueAttribute"/>
+    /// </summary>
+    internal class DefaultValueAttributeEdmPropertyConvention : AttributeEdmPropertyConvention<PropertyConfiguration>
+    {
+        public DefaultValueAttributeEdmPropertyConvention()
+            : base(attribute => attribute.GetType() == typeof(DefaultValueAttribute), allowMultiple: false)
+        {
+        }
+
+        /// <summary>
+        /// Sets property default value the on the edm type.
+        /// </summary>
+        /// <param name="edmProperty">The edm property.</param>
+        /// <param name="structuralTypeConfiguration">The edm type being configured.</param>
+        /// <param name="attribute">The <see cref="Attribute"/> found.</param>
+        /// <param name="model">The ODataConventionModelBuilder used to build the model.</param>
+        public override void Apply(PropertyConfiguration edmProperty,
+            StructuralTypeConfiguration structuralTypeConfiguration,
+            Attribute attribute,
+            ODataConventionModelBuilder model)
+        {
+            if (edmProperty == null)
+            {
+                throw Error.ArgumentNull("edmProperty");
+            }
+
+            DefaultValueAttribute defaultValueAttribute = attribute as DefaultValueAttribute;
+            if (!edmProperty.AddedExplicitly && defaultValueAttribute != null && defaultValueAttribute.Value != null)
+            {
+                if(edmProperty.Kind == PropertyKind.Primitive)
+                {
+                    PrimitivePropertyConfiguration primitiveProperty = edmProperty as PrimitivePropertyConfiguration;
+                    primitiveProperty.DefaultValueString = defaultValueAttribute.Value.ToString();
+                }
+
+                if(edmProperty.Kind == PropertyKind.Enum)
+                {
+                    EnumPropertyConfiguration enumProperty = edmProperty as EnumPropertyConfiguration;
+                    enumProperty.DefaultValueString = defaultValueAttribute.Value.ToString();
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.OData.Shared/Builder/EdmTypeBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EdmTypeBuilder.cs
@@ -253,7 +253,7 @@ namespace Microsoft.AspNet.OData.Builder
                         edmProperty = type.AddStructuralProperty(
                             primitiveProperty.Name,
                             primitiveTypeReference,
-                            defaultValue: null);
+                            defaultValue: primitiveProperty.DefaultValueString);
                         break;
 
                     case PropertyKind.Complex:
@@ -353,7 +353,7 @@ namespace Microsoft.AspNet.OData.Builder
             return type.AddStructuralProperty(
                 enumProperty.Name,
                 enumTypeReference,
-                defaultValue: null);
+                defaultValue: enumProperty.DefaultValueString);
         }
 
         private void CreateComplexTypeBody(EdmComplexType type, ComplexTypeConfiguration config)

--- a/src/Microsoft.AspNet.OData.Shared/Builder/EnumPropertyConfiguration.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EnumPropertyConfiguration.cs
@@ -23,6 +23,11 @@ namespace Microsoft.AspNet.OData.Builder
         }
 
         /// <summary>
+        /// Gets or sets a value string representation of default value.
+        /// </summary>
+        public string DefaultValueString { get; set; }
+
+        /// <summary>
         /// Gets the type of this property.
         /// </summary>
         public override PropertyKind Kind

--- a/src/Microsoft.AspNet.OData.Shared/Builder/ODataConventionModelBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/ODataConventionModelBuilder.cs
@@ -30,6 +30,7 @@ namespace Microsoft.AspNet.OData.Builder
             new NotMappedAttributeConvention(), // NotMappedAttributeConvention has to run before EntityKeyConvention
             new DataMemberAttributeEdmPropertyConvention(),
             new RequiredAttributeEdmPropertyConvention(),
+            new DefaultValueAttributeEdmPropertyConvention(),
             new ConcurrencyCheckAttributeEdmPropertyConvention(),
             new TimestampAttributeEdmPropertyConvention(),
             new ColumnAttributeEdmPropertyConvention(),

--- a/src/Microsoft.AspNet.OData.Shared/Builder/PrimitivePropertyConfiguration.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/PrimitivePropertyConfiguration.cs
@@ -24,6 +24,11 @@ namespace Microsoft.AspNet.OData.Builder
         }
 
         /// <summary>
+        /// Gets or sets a value string representation of default value.
+        /// </summary>
+        public string DefaultValueString { get; set; }
+
+        /// <summary>
         /// Gets the type of this property.
         /// </summary>
         public override PropertyKind Kind

--- a/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
+++ b/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchContent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\Conventions\Attributes\MaxLengthAttributeEdmPropertyConvention.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Builder\Conventions\Attributes\DefaultValueAttributeEdmPropertyConvention.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\DecimalPropertyConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\LengthPropertyConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\PrecisionPropertyConfiguration.cs" />

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ModelBuilder/AttributeConventionModelBuilderTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ModelBuilder/AttributeConventionModelBuilderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
@@ -27,6 +28,10 @@ namespace Microsoft.Test.E2E.AspNet.OData.ModelBuilder
 
         [DataMember(IsRequired = true)]
         public string RequiredProperty2 { get; set; }
+
+        [DataMember(IsRequired = true)]
+        [DefaultValue("default")]
+        public string RequiredPropertyWithDefaultValue { get; set; }
 
         public string NotDataMember { get; set; }
 
@@ -81,13 +86,17 @@ namespace Microsoft.Test.E2E.AspNet.OData.ModelBuilder
             var model = builder.GetEdmModel();
 
             var simpleDataContractModel = model.SchemaElements.OfType<IEdmEntityType>().First(t => t.Name == typeof(SimpleDataContractModel).Name);
-            Assert.Equal(5, simpleDataContractModel.Properties().Count());
+            Assert.Equal(6, simpleDataContractModel.Properties().Count());
 
             Assert.Equal("KeyProperty", simpleDataContractModel.Key().Single().Name);
 
             var requiredProperty2 = simpleDataContractModel.Properties().Single(p => p.Name == "RequiredProperty2") as EdmProperty;
 
             Assert.False(requiredProperty2.Type.IsNullable);
+
+            var requiredPropertyWithDefaultValue = simpleDataContractModel.Properties().Single(p => p.Name == "RequiredPropertyWithDefaultValue") as EdmStructuralProperty;
+
+            Assert.Equal("default", requiredPropertyWithDefaultValue.DefaultValueString);
 
             var navigationProperty1 = simpleDataContractModel.Properties().Single(p => p.Name == "NavigationProperty1") as EdmNavigationProperty;
             Assert.Equal(EdmMultiplicity.One, navigationProperty1.TargetMultiplicity());

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/Conventions/Attributes/DefaultValueAttributeEdmPropertyConventionTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/Conventions/Attributes/DefaultValueAttributeEdmPropertyConventionTests.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Builder.Conventions.Attributes;
+using Microsoft.AspNet.OData.Test.Abstraction;
+using Microsoft.AspNet.OData.Test.Common;
+using Microsoft.OData.Edm;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.OData.Test.Builder.Conventions.Attributes
+{
+    public class DefaultValueAttributeEdmPropertyConventionTests
+    {
+        enum TestEnum
+        {
+            Member1,
+            Member2
+        }
+
+        [Fact]
+        public void Empty_Ctor_DoesnotThrow()
+        {
+            ExceptionAssert.DoesNotThrow(() => new DefaultValueAttributeEdmPropertyConvention());
+        }
+
+        [Fact]
+        public void Apply_SetsDefaultValueProperty()
+        {
+            // Arrange
+            Mock<PropertyInfo> property = new Mock<PropertyInfo>();
+            property.Setup(p => p.Name).Returns("Property");
+            property.Setup(p => p.PropertyType).Returns(typeof(string));
+            property.Setup(p => p.GetCustomAttributes(It.IsAny<bool>())).Returns(new[] { new DefaultValueAttribute("defaultValue") });
+
+            Mock<StructuralTypeConfiguration> structuralType = new Mock<StructuralTypeConfiguration>();
+            Mock<PrimitivePropertyConfiguration> structuralProperty = new Mock<PrimitivePropertyConfiguration>(property.Object, structuralType.Object);
+            structuralProperty.Object.AddedExplicitly = false;
+
+            // Act
+            new DefaultValueAttributeEdmPropertyConvention().Apply(structuralProperty.Object, structuralType.Object, ODataConventionModelBuilderFactory.Create());
+
+            // Assert
+            Assert.Equal("defaultValue", structuralProperty.Object.DefaultValueString);
+        }
+
+        [Fact]
+        public void DefaultValueAttributeEdmPropertyConvention_ConfiguresDefaultValuePropertyAsDefaultValue()
+        {
+            MockType type =
+                new MockType("Entity")
+                .Property(typeof(int), "ID")
+                .Property(typeof(int), "Count", new DefaultValueAttribute(0))
+                .Property(typeof(TestEnum), "Kind", new DefaultValueAttribute(TestEnum.Member2));
+
+            ODataConventionModelBuilder builder = ODataConventionModelBuilderFactory.Create();
+            builder.AddEntityType(type);
+
+            IEdmModel model = builder.GetEdmModel();
+            IEdmEntityType entity = model.AssertHasEntityType(type);
+            IEdmStructuralProperty property = entity.AssertHasPrimitiveProperty(model, "Count", EdmPrimitiveTypeKind.Int32, isNullable: false);
+            Assert.Equal("0", property.DefaultValueString);
+            IEdmStructuralProperty enumProperty = entity.AssertHasProperty<IEdmStructuralProperty>(model, "Kind", typeof(TestEnum), isNullable: false);
+            Assert.Equal("Member2", enumProperty.DefaultValueString);
+        }
+
+        [Fact]
+        public void DefaultValueAttributeEdmPropertyConvention_DoesnotOverwriteExistingConfiguration()
+        {
+            MockType type =
+                new MockType("Entity")
+                .Property(typeof(int), "ID")
+                .Property(typeof(int), "Count", new DefaultValueAttribute("10"));
+
+            ODataConventionModelBuilder builder = ODataConventionModelBuilderFactory.Create();
+            builder.AddEntityType(type).AddProperty(type.GetProperty("Count")).DefaultValueString="0";
+
+            IEdmModel model = builder.GetEdmModel();
+            IEdmEntityType entity = model.AssertHasEntityType(type);
+            IEdmStructuralProperty property = entity.AssertHasPrimitiveProperty(model, "Count", EdmPrimitiveTypeKind.Int32, isNullable: false);
+            Assert.Equal("0", property.DefaultValueString); 
+        }
+    }
+}

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
@@ -34,6 +34,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Builder\ComplexTypeConfigurationTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\ComplexTypeTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\ContainmentPathBuilderTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Builder\Conventions\Attributes\DefaultValueAttributeEdmPropertyConventionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\Conventions\RecursiveComplexTypesTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\Conventions\RecursiveComplexTypesModels.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\DynamicPropertyDictionaryAnnotationTest.cs" />

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -1438,6 +1438,7 @@ public class Microsoft.AspNet.OData.Builder.EnumMemberConfiguration {
 public class Microsoft.AspNet.OData.Builder.EnumPropertyConfiguration : StructuralPropertyConfiguration {
 	public EnumPropertyConfiguration (System.Reflection.PropertyInfo property, StructuralTypeConfiguration declaringType)
 
+	string DefaultValueString  { public get; public set; }
 	PropertyKind Kind  { public virtual get; }
 	System.Type RelatedClrType  { public virtual get; }
 
@@ -1650,6 +1651,7 @@ public class Microsoft.AspNet.OData.Builder.PrecisionPropertyConfiguration : Pri
 public class Microsoft.AspNet.OData.Builder.PrimitivePropertyConfiguration : StructuralPropertyConfiguration {
 	public PrimitivePropertyConfiguration (System.Reflection.PropertyInfo property, StructuralTypeConfiguration declaringType)
 
+	string DefaultValueString  { public get; public set; }
 	PropertyKind Kind  { public virtual get; }
 	System.Type RelatedClrType  { public virtual get; }
 	System.Nullable`1[[Microsoft.OData.Edm.EdmPrimitiveTypeKind]] TargetEdmTypeKind  { public get; }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -1486,6 +1486,7 @@ public class Microsoft.AspNet.OData.Builder.EnumMemberConfiguration {
 public class Microsoft.AspNet.OData.Builder.EnumPropertyConfiguration : StructuralPropertyConfiguration {
 	public EnumPropertyConfiguration (System.Reflection.PropertyInfo property, StructuralTypeConfiguration declaringType)
 
+	string DefaultValueString  { public get; public set; }
 	PropertyKind Kind  { public virtual get; }
 	System.Type RelatedClrType  { public virtual get; }
 
@@ -1699,6 +1700,7 @@ public class Microsoft.AspNet.OData.Builder.PrecisionPropertyConfiguration : Pri
 public class Microsoft.AspNet.OData.Builder.PrimitivePropertyConfiguration : StructuralPropertyConfiguration {
 	public PrimitivePropertyConfiguration (System.Reflection.PropertyInfo property, StructuralTypeConfiguration declaringType)
 
+	string DefaultValueString  { public get; public set; }
 	PropertyKind Kind  { public virtual get; }
 	System.Type RelatedClrType  { public virtual get; }
 	System.Nullable`1[[Microsoft.OData.Edm.EdmPrimitiveTypeKind]] TargetEdmTypeKind  { public get; }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

#1819 

### Description

Support set default value for primitive and enum properties.
Sets default value for properties that have DefaultValueAttribute.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
