### PR TITLE
Fix error response in ValidateODataBatchRequest

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs
@@ -247,7 +247,7 @@ namespace Microsoft.AspNet.OData.Batch
             {
                 response.StatusCode = (int)HttpStatusCode.BadRequest;
                 await response.WriteAsync(Error.Format(SRResources.BatchRequestInvalidMediaType,
-                    $"{BatchMediaTypeMime} or {BatchMediaTypeJson}"));
+                    BatchMediaTypeMime, BatchMediaTypeJson));
                 return false;
             }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

### Description

The [BatchRequestInvalidMediaType](https://github.com/OData/WebApi/blob/7ab7dbf5e7f814c19f140e27404061036dff49fa/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx#L553) template takes two strings, however, `ValidateODataBatchRequest` in the AspNetCore implementation only provides one which leads to an exception being thrown and the server returning 500 instead of a valid error response. 

The [AspNet WebApi implementation correctly provides two strings already](https://github.com/OData/WebApi/blob/7ab7dbf5e7f814c19f140e27404061036dff49fa/src/Microsoft.AspNet.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs#L243).

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

