### PR TITLE
Fix ordering the keys according to the ColumnAttribute.Order property

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/Conventions/Attributes/ColumnAttributeEdmPropertyConvention.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/Conventions/Attributes/ColumnAttributeEdmPropertyConvention.cs
@@ -37,16 +37,17 @@ namespace Microsoft.AspNet.OData.Builder.Conventions.Attributes
                 return;
             }
 
+            // Respect order in the column attribute
+            var columnAttribute = attribute as ColumnAttribute;
+            if (columnAttribute != null && columnAttribute.Order > 0)
+            {
+                edmProperty.Order = columnAttribute.Order;
+            }
+
             var primitiveProperty = edmProperty as PrimitivePropertyConfiguration;
             if (primitiveProperty == null)
             {
                 return; // ignore non-primitive property
-            }
-
-            var columnAttribute = attribute as ColumnAttribute;
-            if (columnAttribute != null && columnAttribute.Order > 0)
-            {
-                primitiveProperty.Order = columnAttribute.Order;
             }
 
             if (columnAttribute == null || columnAttribute.TypeName == null)

--- a/src/Microsoft.AspNet.OData.Shared/Builder/EdmTypeBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/EdmTypeBuilder.cs
@@ -370,11 +370,11 @@ namespace Microsoft.AspNet.OData.Builder
             Contract.Assert(config != null);
 
             CreateStructuralTypeBody(type, config);
-            IEnumerable<IEdmStructuralProperty> keys = config.Keys.Select(p => type.DeclaredProperties.OfType<IEdmStructuralProperty>().First(dp => dp.Name == p.Name));
-            type.AddKeys(keys);
-
-            // Add the Enum keys
-            keys = config.EnumKeys.Select(p => type.DeclaredProperties.OfType<IEdmStructuralProperty>().First(dp => dp.Name == p.Name));
+            var keys = ((IEnumerable<PropertyConfiguration>)config.Keys)
+                                     .Concat(config.EnumKeys)
+                                     .OrderBy(p => p.Order)
+                                     .ThenBy(p => p.Name)
+                                     .Select(p => type.DeclaredProperties.OfType<IEdmStructuralProperty>().First(dp => dp.Name == p.Name));
             type.AddKeys(keys);
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
@@ -610,13 +610,10 @@ namespace Microsoft.AspNet.OData.Query
                     ? entityType.Key()
                     : entityType
                         .StructuralProperties()
-                        .Where(property => property.Type.IsPrimitive() && !property.Type.IsStream());
+                        .Where(property => property.Type.IsPrimitive() && !property.Type.IsStream())
+                        .OrderBy(p => p.Name);
 
-            return properties.OrderBy(o =>
-            {
-                var value = o.DeclaringType as PrimitivePropertyConfiguration;
-                return value == null ? 0 : value.Order;
-            }).ThenBy(o => o.Name).ToList();
+            return properties.ToList();
         }
 
         // Generates the OrderByQueryOption to use by default for $skip or $top

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -1462,6 +1462,18 @@
     <Compile Include="..\ODataCountTest\CountTest.cs">
       <Link>ODataCountTest\CountTest.cs</Link>
     </Compile>
+    <Compile Include="..\ODataOrderByTest\OrderByController.cs">
+      <Link>ODataOrderByTest\OrderByController.cs</Link>
+    </Compile>
+    <Compile Include="..\ODataOrderByTest\OrderByDataModel.cs">
+      <Link>ODataOrderByTest\OrderByDataModel.cs</Link>
+    </Compile>
+    <Compile Include="..\ODataOrderByTest\OrderByEdmModel.cs">
+      <Link>ODataOrderByTest\OrderByEdmModel.cs</Link>
+    </Compile>
+    <Compile Include="..\ODataOrderByTest\OrderByTest.cs">
+      <Link>ODataOrderByTest\OrderByTest.cs</Link>
+    </Compile>
     <Compile Include="..\ODataPathHandler\LinkGenerationTests.cs">
       <Link>ODataPathHandler\LinkGenerationTests.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -66,6 +66,18 @@
     <Compile Include="..\Common\TestEntitySetRoutingConvention.cs">
       <Link>Common\TestEntitySetRoutingConvention.cs</Link>
     </Compile>
+    <Compile Include="..\ODataOrderByTest\OrderByController.cs">
+      <Link>ODataOrderByTest\OrderByController.cs</Link>
+    </Compile>
+    <Compile Include="..\ODataOrderByTest\OrderByDataModel.cs">
+      <Link>ODataOrderByTest\OrderByDataModel.cs</Link>
+    </Compile>
+    <Compile Include="..\ODataOrderByTest\OrderByEdmModel.cs">
+      <Link>ODataOrderByTest\OrderByEdmModel.cs</Link>
+    </Compile>
+    <Compile Include="..\ODataOrderByTest\OrderByTest.cs">
+      <Link>ODataOrderByTest\OrderByTest.cs</Link>
+    </Compile>
     <Compile Include="..\QueryComposition\EFWideCustomer.cs">
       <Link>QueryComposition\EFWideCustomer.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ODataOrderByTest/OrderByController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ODataOrderByTest/OrderByController.cs
@@ -1,39 +1,73 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
-using System.Web.Http;
 using Microsoft.AspNet.OData;
 using Microsoft.AspNet.OData.Routing;
+using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
 
 namespace Microsoft.Test.E2E.AspNet.OData.ODataOrderByTest
 {
-    public class ItemsController : ODataController
+    public class ItemsController : TestODataController
     {
         private static readonly OrderByEdmModel.OrderByContext Db = new OrderByEdmModel.OrderByContext();
-
+        private static readonly IQueryable<ItemWithoutColumn> _itemWithoutColumns;
         static ItemsController()
         {
-            if (Db.Items.Any() && Db.Items2.Any())
+            _itemWithoutColumns = new List<ItemWithoutColumn>()
+            {
+                // The key is A, B, C
+                new ItemWithoutColumn() { A = 2, B = 1, C = 1, ExpectedOrder = 4 },
+                new ItemWithoutColumn() { A = 1, B = 2, C = 1, ExpectedOrder = 3 },
+                new ItemWithoutColumn() { A = 1, B = 1, C = 2, ExpectedOrder = 2 },
+                new ItemWithoutColumn() { A = 1, B = 1, C = 1, ExpectedOrder = 1 }
+            }.AsQueryable();
+
+            if (Db.Items.Any() && Db.Items2.Any() && Db.ItemsWithEnum.Any())
             {
                 return;
             }
 
-            Db.Items.Add(new Item() { A = 1, C = 1, B = 99, Name = "#1 - A1 C1 B99" });
-            Db.Items.Add(new Item() { A = 1, C = 2, B = 98, Name = "#2 - A1 C2 B98" });
-            Db.Items.Add(new Item() { A = 1, C = 3, B = 97, Name = "#3 - A1 C3 B97" });
-            Db.Items.Add(new Item() { A = 1, C = 4, B = 96, Name = "#4 - A1 C4 B96" });
+            AddInSet(
+                Db.Items,
+                // The key is C, A, B
+                new Item() { A = 1, B = 99, C = 2, ExpectedOrder = 4 },
+                new Item() { A = 2, B = 2, C = 1, ExpectedOrder = 3 },
+                new Item() { A = 2, B = 1, C = 1, ExpectedOrder = 2 },
+                new Item() { A = 1, B = 96, C = 1, ExpectedOrder = 1 }
+                );
+            AddInSet(
+                Db.Items2,
+                // The key is C, B, A
+                new Item2() { A = "AA", C = "BB", B = 99, ExpectedOrder = 2 },
+                new Item2() { A = "BB", C = "AA", B = 98, ExpectedOrder = 1 },
+                new Item2() { A = "01", C = "XX", B = 1, ExpectedOrder = 3 },
+                new Item2() { A = "00", C = "ZZ", B = 96, ExpectedOrder = 4 }
+                );
 
-
-            Db.Items2.Add(new Item2() { A = "AA", C = "BB", B = 99, Name = "#2" });
-            Db.Items2.Add(new Item2() { A = "BB", C = "AA", B = 98, Name = "#1" });
-            Db.Items2.Add(new Item2() { A = "01", C = "XX", B = 1, Name = "#3" });
-            Db.Items2.Add(new Item2() { A = "00", C = "ZZ", B = 96, Name = "#4" });
+            AddInSet(
+                Db.ItemsWithEnum,
+                // The key is C, B, A
+                new ItemWithEnum() { A = SmallNumber.One, B = "A", C = SmallNumber.One, ExpectedOrder = 1 },
+                new ItemWithEnum() { A = SmallNumber.One, B = "B", C = SmallNumber.One, ExpectedOrder = 3 },
+                new ItemWithEnum() { A = SmallNumber.One, B = "B", C = SmallNumber.Two, ExpectedOrder = 4 },
+                new ItemWithEnum() { A = SmallNumber.Two, B = "A", C = SmallNumber.One, ExpectedOrder = 2 }
+            );
             Db.SaveChanges();
         }
 
+        private static void AddInSet<T>(IDbSet<T> set, params T[] items) where T : class
+        {            
+            foreach (var item in items)
+            {
+                set.Add(item);
+            }
+        }
+
         [EnableQuery]
-        public IHttpActionResult GetItems()
+        public ITestActionResult GetItems()
         {
             return Ok(Db.Items);
         }
@@ -41,10 +75,25 @@ namespace Microsoft.Test.E2E.AspNet.OData.ODataOrderByTest
         [EnableQuery]
         [HttpGet]
         [ODataRoute("Items2")]
-        public IHttpActionResult GetItems2()
+        public ITestActionResult GetItems2()
         {
             return Ok(Db.Items2);
         }
 
+        [EnableQuery]
+        [HttpGet]
+        [ODataRoute("ItemsWithEnum")]
+        public ITestActionResult GetItemsWithEnum()
+        {
+            return Ok(Db.ItemsWithEnum);
+        }
+
+        [EnableQuery]
+        [HttpGet]
+        [ODataRoute("ItemsWithoutColumn")]
+        public ITestActionResult GetItemsWithoutColumn()
+        {
+            return Ok(_itemWithoutColumns);
+        }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ODataOrderByTest/OrderByDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ODataOrderByTest/OrderByDataModel.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.Test.E2E.AspNet.OData.ODataOrderByTest
 {
-    public class Item
+    public class Item:OrderedItem
     {
         [Key]
         [Column(Order = 2)]
@@ -19,13 +19,9 @@ namespace Microsoft.Test.E2E.AspNet.OData.ODataOrderByTest
         [Key]
         [Column(Order = 3)]
         public int B { get; set; }
-
-        [Required]
-        [StringLength(50)]
-        public string Name { get; set; }
     }
 
-    public class Item2
+    public class Item2 : OrderedItem
     {
         [Key]
         [Column(Order = 3)]
@@ -33,15 +29,51 @@ namespace Microsoft.Test.E2E.AspNet.OData.ODataOrderByTest
 
         [Key]
         [Column(Order = 1)]
-        public string C { get; set; }  
+        public string C { get; set; }
 
         [Key]
         [Column(Order = 2)]
         public int B { get; set; }
+    }
 
-        [Required]
-        [StringLength(50)]
-        public string Name { get; set; }
+    public class ItemWithEnum : OrderedItem
+    {
+        [Key]
+        [Column(Order = 3)]
+        public SmallNumber A { get; set; }
+
+        [Key]
+        [Column(Order = 2)]
+        public string B { get; set; }
+
+        [Key]
+        [Column(Order = 1)]
+        public SmallNumber C { get; set; }
+    }
+
+    public class ItemWithoutColumn : OrderedItem
+    {
+        [Key]
+        public int C { get; set; }
+
+        [Key]
+        public int B { get; set; }
+
+        [Key]
+        public int A { get; set; }
+    }
+
+    public enum SmallNumber
+    {
+        One,
+        Two,
+        Three,
+        Four
+    }
+
+    public abstract class OrderedItem
+    {
+        public int ExpectedOrder { get; set; }
     }
 }
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ODataOrderByTest/OrderByEdmModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ODataOrderByTest/OrderByEdmModel.cs
@@ -4,6 +4,7 @@
 using System.Data.Entity;
 using Microsoft.AspNet.OData.Builder;
 using Microsoft.OData.Edm;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
 
 namespace Microsoft.Test.E2E.AspNet.OData.ODataOrderByTest
 {
@@ -21,13 +22,17 @@ namespace Microsoft.Test.E2E.AspNet.OData.ODataOrderByTest
 
             public IDbSet<Item> Items { get; set; }
             public IDbSet<Item2> Items2 { get; set; }
+            public IDbSet<ItemWithEnum> ItemsWithEnum { get; set; }
         }
 
-        public static IEdmModel GetModel()
+        public static IEdmModel GetModel(WebRouteConfiguration config)
         {
-            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            ODataConventionModelBuilder builder = config.CreateConventionModelBuilder();
             builder.EntitySet<Item>("Items");
             builder.EntitySet<Item2>("Items2");
+            builder.EntitySet<ItemWithEnum>("ItemsWithEnum");
+            builder.EntitySet<ItemWithoutColumn>("ItemsWithoutColumn");
+            builder.EnumType<SmallNumber>();
             return builder.GetEdmModel();
         }
     }


### PR DESCRIPTION
This pull request fixes issue #1085 

### Description

In order to ensure a stable ordering of the results with different request, the library adds a default order when required.
When an entity has a composite key, the order of the properties matters, and if not specified correctly, the query may have bad performances.

The fix ensures that the order specified in the model via the ColumnAttribute.Order property is respected when the stable order is ensured by the library.
It does it by configuring the keys in the correct order in the EDM model, and not in the function applying the default order.

Also, previously the order of the key in the model was arbitrarely chosen, which could be suprising for the user when the default order was applied because it would not match what it in the model. Now the order in the model will be the same as the default order.

#### Side effect
A side effect is that the fix will may change the order to the key in the EDM model.

### Checklist (Uncheck if it is not completed)

- [x] Test cases added
- [x] Build and test with one-click build and test script passed

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*