### PR TITLE
Ensure that all expand item options preserved when translating SELECT *

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/SelectExpandQueryOption.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/SelectExpandQueryOption.cs
@@ -592,7 +592,16 @@ namespace Microsoft.AspNet.OData.Query
                 item = new ExpandedNavigationSelectItem(
                     expandItem.PathToNavigationProperty,
                     expandItem.NavigationSource,
-                    currentSelectExpandClause);
+                    currentSelectExpandClause,
+                    expandItem.FilterOption,
+                    expandItem.OrderByOption,
+                    expandItem.TopOption,
+                    expandItem.SkipOption,
+                    expandItem.CountOption,
+                    expandItem.SearchOption,
+                    null,
+                    expandItem.ComputeOption,
+                    expandItem.ApplyOption);
 
                 level--;
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/SelectExpandQueryOptionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/SelectExpandQueryOptionTest.cs
@@ -254,6 +254,42 @@ namespace Microsoft.AspNet.OData.Test.Query
                 "The query option is not bound to any CLR type. 'ApplyTo' is only supported with a query option bound to a CLR type.");
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ProcessLevelsCorrectly_PreserveOtherOptions(bool autoSelect)
+        {
+            // Arrange
+            var model = ODataLevelsTest.GetEdmModel();
+            var entityType = model.FindDeclaredType("Microsoft.AspNet.OData.Test.Routing.LevelsEntity");
+            var context = new ODataQueryContext(
+                model,
+                entityType);
+
+            if (autoSelect)
+            {
+                var modelBound = model.GetAnnotationValue<ModelBoundQuerySettings>(entityType) ?? new ModelBoundQuerySettings();
+                modelBound.DefaultSelectType = SelectExpandType.Automatic;
+                model.SetAnnotationValue(entityType, modelBound);
+            }
+
+            context.RequestContainer = new MockContainer();
+            var selectExpand = new SelectExpandQueryOption(
+                select: null,
+                expand: "Parent($filter=Cnt gt 1;$apply=aggregate($count as Cnt))",
+                context: context);
+            selectExpand.LevelsMaxLiteralExpansionDepth = 1;
+
+            // Act
+            SelectExpandClause clause = selectExpand.ProcessLevels();
+
+            // Assert
+            var item = Assert.IsType<ExpandedNavigationSelectItem>(clause.SelectedItems.Single());
+            Assert.NotNull(item.FilterOption);
+            Assert.NotNull(item.ApplyOption);
+        }
+
+
         [Fact]
         public void ProcessLevelsCorrectly_AllSelected()
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->
### Description

When WebAPI executed `$expand` and `$select` it takes SelectExpandClause and transforms it to apply all selects, level and expand filters. For example
it you have `WorkItems?$expand=Children` it will be automatically (in same cases) converted into
`WorkItems?$select=<list of all columns>&$expand=Children($select=<list of all columns>)`.
It's implemented as creating new SelectExpandClause, however other options inside `$expand` were ignored as a result `WorkItems?$expand=Children($filter=State eq 'Active')` was translated to `WorkItems?$select=<list of all columns>&$expand=Children($select=<list of all columns>)`

Fixing that issue.

It's stepping stone to support `$expand=Collection($apply=..;$compute=..)`

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

