### PR TITLE
Copy EnableCorrelatedSubqueryBuffering in ODataQuerySettings

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/ODataQuerySettings.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ODataQuerySettings.cs
@@ -134,6 +134,7 @@ namespace Microsoft.AspNet.OData.Query
             PageSize = settings.PageSize;
             ModelBoundPageSize = settings.ModelBoundPageSize;
             HandleReferenceNavigationPropertyExpandFilter = settings.HandleReferenceNavigationPropertyExpandFilter;
+            EnableCorrelatedSubqueryBuffering = settings.EnableCorrelatedSubqueryBuffering;
         }
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/ODataQuerySettingsTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/ODataQuerySettingsTest.cs
@@ -62,5 +62,14 @@ namespace Microsoft.AspNet.OData.Test.Query
                 o => o.EnableConstantParameterization,
                 expectedDefaultValue: true);
         }
+
+        [Fact]
+        public void EnableCorrelatedSubqueryBuffering_Property_RoundTrips()
+        {
+            ReflectionAssert.BooleanProperty<ODataQuerySettings>(
+                new ODataQuerySettings(),
+                o => o.EnableCorrelatedSubqueryBuffering,
+                expectedDefaultValue: false);
+        }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1882.*

### Description

Include the new EnableCorrelatedSubqueryBuffering query option in ODataQuerySettings.CopyFrom.

### Checklist (Uncheck if it is not completed)

- [x ] *Test cases added*
- [x ] *Build and test with one-click build and test script passed*

### Additional work necessary

*None*
