### PR TITLE
Ensure generated skip token respects casing conventions

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
@@ -116,24 +116,24 @@ namespace Microsoft.AspNet.OData.Query
             int lastIndex = propertiesForSkipToken.Count() - 1;
             IEdmStructuredObject obj = lastMember as IEdmStructuredObject;
 
-            foreach (IEdmProperty property in propertiesForSkipToken)
+            foreach (IEdmProperty edmProperty in propertiesForSkipToken)
             {
                 bool islast = count == lastIndex;
-                string propertyName = EdmLibHelpers.GetClrPropertyName(property, model);
+                string clrPropertyName = EdmLibHelpers.GetClrPropertyName(edmProperty, model);
                 if (obj != null)
                 {
-                    obj.TryGetPropertyValue(propertyName, out value);
+                    obj.TryGetPropertyValue(clrPropertyName, out value);
                 }
                 else
                 {
-                    value = lastMember.GetType().GetProperty(propertyName).GetValue(lastMember);
+                    value = lastMember.GetType().GetProperty(clrPropertyName).GetValue(lastMember);
                 }
 
                 if (value == null)
                 {
                     uriLiteral = ODataUriUtils.ConvertToUriLiteral(value, ODataVersion.V401);
                 }
-                else if (property.Type.IsEnum())
+                else if (edmProperty.Type.IsEnum())
                 {
                     ODataEnumValue enumValue = new ODataEnumValue(value.ToString(), value.GetType().FullName);
                     uriLiteral = ODataUriUtils.ConvertToUriLiteral(enumValue, ODataVersion.V401, model);
@@ -143,7 +143,7 @@ namespace Microsoft.AspNet.OData.Query
                     uriLiteral = ODataUriUtils.ConvertToUriLiteral(value, ODataVersion.V401, model);
                 }
 
-                skipTokenBuilder.Append(propertyName).Append(propertyDelimiter).Append(uriLiteral).Append(islast ? String.Empty : CommaDelimiter.ToString());
+                skipTokenBuilder.Append(edmProperty.Name).Append(propertyDelimiter).Append(uriLiteral).Append(islast ? String.Empty : CommaDelimiter.ToString());
                 count++;
             }
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/LowerCamelCase/LowerCamelCaseController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/LowerCamelCase/LowerCamelCaseController.cs
@@ -94,6 +94,12 @@ namespace Microsoft.Test.E2E.AspNet.OData.LowerCamelCase
             return Ok(_employees.AsQueryable());
         }
 
+        [EnableQuery(AllowedQueryOptions = AllowedQueryOptions.SkipToken, PageSize = 2)]
+        public ITestActionResult GetPagedOnCollectionOfEmployee()
+        {
+            return Ok(_employees.AsQueryable());
+        }
+
         [EnableQuery(MaxExpansionDepth = 3)]
         [ODataRoute("Employees/Microsoft.Test.E2E.AspNet.OData.LowerCamelCase.Manager")]
         public ITestActionResult GetManagers()

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/LowerCamelCase/LowerCamelCaseEdmModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/LowerCamelCase/LowerCamelCaseEdmModel.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.LowerCamelCase
             employee.EnumProperty<Gender>(e => e.Sex).Name = "Gender";
 
             employee.Collection.Function("GetEarliestTwoEmployees").ReturnsCollectionFromEntitySet<Employee>("Employees");
+            employee.Collection.Function("GetPaged").ReturnsCollectionFromEntitySet<Employee>("Employees");
 
             var functionConfiguration = builder.Function("GetAddress");
             functionConfiguration.Parameter<int>("id");

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/LowerCamelCase/LowerCamelCaseTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/LowerCamelCase/LowerCamelCaseTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.LowerCamelCase
             configuration.AddControllers(controllers);
 
             configuration.Routes.Clear();
-            configuration.Count().Filter().OrderBy().Expand().MaxTop(null).Select();
+            configuration.Count().Filter().OrderBy().Expand().MaxTop(null).Select().SkipToken();
             configuration.MapODataServiceRoute("OData", "odata", LowerCamelCaseEdmModel.GetConventionModel(configuration));
             configuration.EnsureInitialized();
         }
@@ -350,7 +350,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.LowerCamelCase
                  format
              );
 
-            HttpResponseMessage response = await this.Client.GetAsync(requestUri);
+            HttpResponseMessage response = await this.Client.GetAsync(requestUri);          
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             JObject content = await response.Content.ReadAsObject<JObject>();
@@ -466,6 +466,18 @@ namespace Microsoft.Test.E2E.AspNet.OData.LowerCamelCase
             Assert.Equal(8, secondEmployee["id"].Value<int>());
         }
 
+        [Theory]
+        [MemberData(nameof(MediaTypes))]
+        public async Task QueryEntitiesWithSkipToken(string format)
+        {
+            string requestUri = string.Format("{0}/odata/Employees/Microsoft.Test.E2E.AspNet.OData.LowerCamelCase.GetPaged()?format={1}", this.BaseAddress, format);
+            HttpResponseMessage response = await this.Client.GetAsync(requestUri);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var result = await response.Content.ReadAsObject<JObject>();
+            var value = result["@odata.nextLink"].Value<string>();
+            Assert.Contains("$skiptoken=id", value);
+        }
 
         [Fact]
         public async Task AddEntity()


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1894.*

### Description

When an ODataConventionModelBuilder enables camel-case formatting of property names via the EnableLowerCamelCase extension, generated skip tokens use the model's original property name rather than the formatted camel-case name. This can cause unexpected errors when the skip token handler attempts to resolve the property during filtering operations.

This pull request modifies the default skip token handler to use formatted property names on the EDM rather than the original model.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
