### PR TITLE
AmbiguousMatchException in ApplyTo method

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -185,7 +185,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             }
 
             string propertyName = EdmLibHelpers.GetClrPropertyName(property, _model);
-            var propertyInfo = source.Type.GetProperty(propertyName);
+            PropertyInfo propertyInfo = source.Type.GetProperty(propertyName);
             Expression propertyValue = Expression.Property(source, propertyInfo);
             Type nullablePropertyType = TypeHelper.ToNullable(propertyValue.Type);
             Expression nullablePropertyValue = ExpressionHelpers.ToNullable(propertyValue);

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -185,7 +185,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             }
 
             string propertyName = EdmLibHelpers.GetClrPropertyName(property, _model);
-            Expression propertyValue = Expression.Property(source, propertyName);
+            var propertyInfo = source.Type.GetProperty(propertyName);
+            Expression propertyValue = Expression.Property(source, propertyInfo);
             Type nullablePropertyType = TypeHelper.ToNullable(propertyValue.Type);
             Expression nullablePropertyValue = ExpressionHelpers.ToNullable(propertyValue);
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/SelectExpandTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/SelectExpandTest.cs
@@ -353,6 +353,22 @@ namespace Microsoft.AspNet.OData.Test
             Assert.Equal(5, result["value"].Count());
         }
 
+        [Fact]
+        public async Task SelectExpand_Works_ForSelectCaseSensitivityProperties()
+        {
+            // Arrange
+            const string URI = "/odata2/Players?$select=Title,TITLE";
+
+            // Act
+            HttpResponseMessage response = await GetResponse(URI, AcceptJsonFullMetadata);
+            string responseString = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            JObject result = JObject.Parse(responseString);
+            Assert.Equal(5, result["value"].Count());
+        }
+
         [Theory]
         [InlineData("Default.Container.*")]
         [InlineData("Container.*")]
@@ -407,7 +423,7 @@ namespace Microsoft.AspNet.OData.Test
                 config.Routes.MapHttpRoute("api", "api/{controller}", new { controller = "NonODataSelectExpandTestCustomers" });
 #endif
                 config.EnableDependencyInjection();
-                });
+            });
 
             HttpClient client = TestServerFactory.CreateClient(server);
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://localhost" + uri);
@@ -778,7 +794,9 @@ namespace Microsoft.AspNet.OData.Test
                         Id = i,
                         Name = "PayerName " + i,
                         Category = "Category " + i,
-                        Address = "Address " + i
+                        Address = "Address " + i,
+                        Title = "Title" + i,
+                        TITLE = "TITLE" + i
                     }).ToList();
 
         [EnableQuery]
@@ -794,5 +812,7 @@ namespace Microsoft.AspNet.OData.Test
         public string Name { get; set; }
         public string Category { get; set; }
         public string Address { get; set; }
+        public string Title { get; set; }
+        public string TITLE { get; set; }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1899 .*

### Description
As you know in C# we can create the same properties in different cases. For example, I can create Title and TITLE properties. When I create properties like that in ApplyTo method I was getting **Ambiguous match found exception.** The issue was coming from **Expression.Property(source, propertyName);** in **CreatePropertyValueExpressionWithFilter** method. It seems **Expression.Property** method throws this exception if the class has the same properties with different case sensitivity. So, I changed **propertyName** to **propertyInfo**

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
