### PR TITLE
Allow IN operator for enums

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -13,6 +13,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.AspNet.OData.Adapters;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Formatter;
+using Microsoft.AspNet.OData.Formatter.Deserialization;
 using Microsoft.AspNet.OData.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData;
@@ -399,7 +400,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             // so using a foreach loop and doing an implicit cast from object to the CLR type of ItemType.
             foreach (ConstantNode item in node.Collection)
             {
-                castedList.Add(item.Value);
+                castedList.Add(EnumDeserializationHelpers.ConvertEnumValue(item.Value, constantType));
             }
 
             return Expression.Constant(castedList);

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -400,7 +400,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             // so using a foreach loop and doing an implicit cast from object to the CLR type of ItemType.
             foreach (ConstantNode item in node.Collection)
             {
-                castedList.Add(EnumDeserializationHelpers.ConvertEnumValue(item.Value, constantType));
+                object member = constantType.IsEnum ? (EnumDeserializationHelpers.ConvertEnumValue(item.Value, constantType)) : item.Value;
+                castedList.Add(member);
             }
 
             return Expression.Constant(castedList);
@@ -728,7 +729,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         /// </summary>
         /// <param name="node">The node to bind.</param>
         /// <returns>The LINQ <see cref="Expression"/> created.</returns>
-        [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", 
+        [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity",
             Justification = "These are simple binding functions and cannot be split up.")]
         public virtual Expression BindSingleValueFunctionCallNode(SingleValueFunctionCallNode node)
         {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNet.OData.Query;
 using Microsoft.AspNet.OData.Query.Expressions;
 using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
+using Microsoft.AspNet.OData.Test.Common.Types;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
@@ -1632,6 +1633,20 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 "LongProp lt -987654321L and LongProp gt -123456789l",
                 "$it => (($it.LongProp < -987654321) AndAlso ($it.LongProp > -123456789))");
         }
+        
+        [Fact]
+        public void EnumInExpression()
+        {
+            var result = VerifyQueryDeserialization<DataTypes>(
+                "SimpleEnumProp in ('First', 'Second')",
+                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Contains($it.SimpleEnumProp)");
+            Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
+
+            // expression tree is guaranteed by expression string above
+            var values = (IList<SimpleEnum>)((ConstantExpression)((MethodCallExpression) expression.Body).Arguments[0]).Value;
+            Assert.Equal(new[] {SimpleEnum.First, SimpleEnum.Second}, values);
+        }
+        
 
         [Fact]
         public void RealLiteralSuffixes()


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1676 .*

### Description

The query parser for OData returns for enums not the direct enum value but a `ODataEnumValue`. This must be considered when building the collection within the `FilterBinder.BindCollectionConstantNode`

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

For me already some tests are failing on the master branch. My changes did not introduce new failing tests on my environment. 