### PR TITLE
Feature/ Make SelectExpandBinder and AggregationBinder public and let override there methods

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Extensions/ContainerBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Extensions/ContainerBuilderExtensions.cs
@@ -80,6 +80,9 @@ namespace Microsoft.AspNet.OData.Extensions
             builder.AddService<ODataMetadataSerializer>(ServiceLifetime.Singleton);
             builder.AddService<ODataRawValueSerializer>(ServiceLifetime.Singleton);
 
+            // BinderProvider.
+            builder.AddService<ODataBinderProvider, DefaultODataBinderProvider>(ServiceLifetime.Singleton);
+
             // Binders.
             builder.AddService<ODataQuerySettings>(ServiceLifetime.Scoped);
             builder.AddService<FilterBinder>(ServiceLifetime.Transient);

--- a/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
+++ b/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
@@ -69,6 +69,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)ODataNullValueMessageHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PerRouteContainerBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\DefaultSkipTokenHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\DefaultODataBinderProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\ODataBinderProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\OrderByCountNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\SkipTokenHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\DynamicTypeWrapperConverter.cs" />

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/DefaultODataBinderProvider.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/DefaultODataBinderProvider.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser.Aggregation;
+
 namespace Microsoft.AspNet.OData.Query.Expressions
 {
     /// <summary>
@@ -12,6 +16,13 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         public override SelectExpandBinder GetSelectExpandBinder(ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
         {
             return new SelectExpandBinder(settings, selectExpandQuery);
+        }
+
+        /// <inheritdoc />
+        public override AggregationBinder GetAggregationBinder(ODataQuerySettings settings, IServiceProvider requestContainer, Type elementType,
+            IEdmModel model, TransformationNode transformation)
+        {
+            return new AggregationBinder(settings, requestContainer, elementType, model, transformation);
         }
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/DefaultODataBinderProvider.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/DefaultODataBinderProvider.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.OData.Query.Expressions
+{
+    /// <summary>
+    /// The default <see cref="ODataBinderProvider"/>.
+    /// </summary>
+    public class DefaultODataBinderProvider : ODataBinderProvider
+    {
+        /// <inheritdoc />
+        public override SelectExpandBinder GetSelectExpandBinder(ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
+        {
+            return new SelectExpandBinder(settings, selectExpandQuery);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ODataBinderProvider.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ODataBinderProvider.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.OData.Query.Expressions
+{
+    /// <summary>
+    /// An ODataBinderProvider is a factory for creating OData binders.
+    /// </summary>
+    public abstract class ODataBinderProvider
+    {
+        /// <summary>
+        /// Gets a <see cref="SelectExpandBinder"/>.
+        /// </summary>
+        /// <param name="settings">The <see cref="ODataQuerySettings"/> to use during binding.</param>
+        /// <param name="selectExpandQuery">The <see cref="SelectExpandQueryOption"/> that contains the OData $select and $expand query options.</param>
+        /// <returns>The <see cref="SelectExpandBinder"/>.</returns>
+        public abstract SelectExpandBinder GetSelectExpandBinder(ODataQuerySettings settings,
+            SelectExpandQueryOption selectExpandQuery);
+    }
+}

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ODataBinderProvider.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ODataBinderProvider.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser.Aggregation;
+
 namespace Microsoft.AspNet.OData.Query.Expressions
 {
     /// <summary>
@@ -16,5 +20,17 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         /// <returns>The <see cref="SelectExpandBinder"/>.</returns>
         public abstract SelectExpandBinder GetSelectExpandBinder(ODataQuerySettings settings,
             SelectExpandQueryOption selectExpandQuery);
+
+        /// <summary>
+        /// Gets a <see cref="AggregationBinder"/>.
+        /// </summary>
+        /// <param name="settings">The <see cref="ODataQuerySettings"/> to use during binding.</param>
+        /// <param name="elementType">ClrType for result of transformations.</param>
+        /// <param name="requestContainer">The request container.</param>
+        /// <param name="model">The EDM model.</param>
+        /// <param name="transformation">The transformation node.</param>
+        /// <returns>The <see cref="AggregationBinder"/>.</returns>
+        public abstract AggregationBinder GetAggregationBinder(ODataQuerySettings settings, IServiceProvider requestContainer, 
+            Type elementType, IEdmModel model, TransformationNode transformation);
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
@@ -50,9 +50,10 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             // Arrange
             SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(select: "ID", expand: null, context: _context);
+            SelectExpandBinder binder = new SelectExpandBinder(_settings, selectExpand);
 
             // Act
-            IQueryable queryable = SelectExpandBinder.Bind(_queryable, _settings, selectExpand);
+            IQueryable queryable = binder.Bind(_queryable);
 
             // Assert
             Assert.NotNull(queryable);
@@ -69,9 +70,10 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             SelectExpandQueryOption selectExpand = new SelectExpandQueryOption("Orders", "Orders,Orders($expand=Customer)", _context);
             IPropertyMapper mapper = new IdentityPropertyMapper();
             _model.Model.SetAnnotationValue(_model.Order, new DynamicPropertyDictionaryAnnotation(typeof(Order).GetProperty("OrderProperties")));
+            SelectExpandBinder binder = new SelectExpandBinder(_settings, selectExpand);
 
             // Act
-            IQueryable queryable = SelectExpandBinder.Bind(_queryable, _settings, selectExpand);
+            IQueryable queryable = binder.Bind(_queryable);
 
             // Assert
             IEnumerator enumerator = queryable.GetEnumerator();

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -3355,6 +3355,18 @@ public abstract class Microsoft.AspNet.OData.Query.Expressions.ExpressionBinderB
 	public static int GuidCompare (System.Guid firstValue, System.Guid secondValue)
 }
 
+public abstract class Microsoft.AspNet.OData.Query.Expressions.ODataBinderProvider {
+	protected ODataBinderProvider ()
+
+	public abstract SelectExpandBinder GetSelectExpandBinder (ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
+}
+
+public class Microsoft.AspNet.OData.Query.Expressions.DefaultODataBinderProvider : ODataBinderProvider {
+	public DefaultODataBinderProvider ()
+
+	public virtual SelectExpandBinder GetSelectExpandBinder (ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
+}
+
 public class Microsoft.AspNet.OData.Query.Expressions.FilterBinder : ExpressionBinderBase {
 	public FilterBinder (System.IServiceProvider requestContainer)
 
@@ -3378,6 +3390,17 @@ public class Microsoft.AspNet.OData.Query.Expressions.FilterBinder : ExpressionB
 	public virtual System.Linq.Expressions.Expression BindSingleResourceFunctionCallNode (Microsoft.OData.UriParser.SingleResourceFunctionCallNode node)
 	public virtual System.Linq.Expressions.Expression BindSingleValueFunctionCallNode (Microsoft.OData.UriParser.SingleValueFunctionCallNode node)
 	public virtual System.Linq.Expressions.Expression BindUnaryOperatorNode (Microsoft.OData.UriParser.UnaryOperatorNode unaryOperatorNode)
+}
+
+public class Microsoft.AspNet.OData.Query.Expressions.SelectExpandBinder {
+	protected SelectExpandBinder (ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
+
+	protected virtual System.Linq.IQueryable Bind (System.Linq.IQueryable queryable)
+	protected virtual object Bind (object entity)
+	protected virtual System.Linq.Expressions.Expression CreatePropertyAccessExpression (System.Linq.Expressions.Expression source, Microsoft.OData.Edm.IEdmProperty edmProperty)
+	protected virtual System.Linq.Expressions.Expression CreatePropertyNameExpression (Microsoft.OData.Edm.IEdmEntityType elementType, Microsoft.OData.Edm.IEdmProperty edmProperty, System.Linq.Expressions.Expression source)
+	protected virtual System.Linq.Expressions.Expression CreatePropertyValueExpressionWithFilter (Microsoft.OData.Edm.IEdmEntityType elementType, Microsoft.OData.Edm.IEdmProperty edmProperty, System.Linq.Expressions.Expression source, Microsoft.OData.UriParser.FilterClause filterClause)
+	protected virtual System.Linq.Expressions.Expression CreateTotalCountExpression (System.Linq.Expressions.Expression source, Microsoft.OData.UriParser.ExpandedReferenceSelectItem expandItem)
 }
 
 public class Microsoft.AspNet.OData.Query.Validators.CountQueryValidator {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -3358,12 +3358,28 @@ public abstract class Microsoft.AspNet.OData.Query.Expressions.ExpressionBinderB
 public abstract class Microsoft.AspNet.OData.Query.Expressions.ODataBinderProvider {
 	protected ODataBinderProvider ()
 
+	public abstract AggregationBinder GetAggregationBinder (ODataQuerySettings settings, System.IServiceProvider requestContainer, System.Type elementType, Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.UriParser.Aggregation.TransformationNode transformation)
 	public abstract SelectExpandBinder GetSelectExpandBinder (ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
+}
+
+public class Microsoft.AspNet.OData.Query.Expressions.AggregationBinder : ExpressionBinderBase {
+	protected AggregationBinder (ODataQuerySettings settings, System.IServiceProvider requestContainer, System.Type elementType, Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.UriParser.Aggregation.TransformationNode transformation)
+
+	System.Type ResultClrType  { public get; }
+
+	public virtual System.Linq.IQueryable Bind (System.Linq.IQueryable query)
+	protected virtual System.Linq.Expressions.Expression CreateEntitySetAggregateExpression (System.Linq.Expressions.ParameterExpression accumulativeParameter, Microsoft.OData.UriParser.Aggregation.EntitySetAggregateExpression expression, System.Type baseType)
+	protected virtual System.Linq.Expressions.Expression CreateOpenPropertyAccessExpression (Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode openNode)
+	protected virtual System.Linq.Expressions.Expression CreatePropertyAccessExpression (System.Linq.Expressions.Expression source, Microsoft.OData.Edm.IEdmProperty edmProperty)
+	protected virtual System.Linq.Expressions.Expression CreatePropertyAccessExpression (System.Linq.Expressions.Expression source, Microsoft.OData.Edm.IEdmProperty edmProperty, string propertyPath)
+	protected virtual System.Linq.Expressions.Expression CreatePropertyAggregateExpression (System.Linq.Expressions.ParameterExpression accumulativeParameter, Microsoft.OData.UriParser.Aggregation.AggregateExpression expression, System.Type baseType)
+	internal virtual bool IsClassicEF (System.Linq.IQueryable query)
 }
 
 public class Microsoft.AspNet.OData.Query.Expressions.DefaultODataBinderProvider : ODataBinderProvider {
 	public DefaultODataBinderProvider ()
 
+	public virtual AggregationBinder GetAggregationBinder (ODataQuerySettings settings, System.IServiceProvider requestContainer, System.Type elementType, Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.UriParser.Aggregation.TransformationNode transformation)
 	public virtual SelectExpandBinder GetSelectExpandBinder (ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
 }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -3489,12 +3489,28 @@ public abstract class Microsoft.AspNet.OData.Query.Expressions.ExpressionBinderB
 public abstract class Microsoft.AspNet.OData.Query.Expressions.ODataBinderProvider {
 	protected ODataBinderProvider ()
 
+	public abstract AggregationBinder GetAggregationBinder (ODataQuerySettings settings, System.IServiceProvider requestContainer, System.Type elementType, Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.UriParser.Aggregation.TransformationNode transformation)
 	public abstract SelectExpandBinder GetSelectExpandBinder (ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
+}
+
+public class Microsoft.AspNet.OData.Query.Expressions.AggregationBinder : ExpressionBinderBase {
+	protected AggregationBinder (ODataQuerySettings settings, System.IServiceProvider requestContainer, System.Type elementType, Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.UriParser.Aggregation.TransformationNode transformation)
+
+	System.Type ResultClrType  { public get; }
+
+	public virtual System.Linq.IQueryable Bind (System.Linq.IQueryable query)
+	protected virtual System.Linq.Expressions.Expression CreateEntitySetAggregateExpression (System.Linq.Expressions.ParameterExpression accumulativeParameter, Microsoft.OData.UriParser.Aggregation.EntitySetAggregateExpression expression, System.Type baseType)
+	protected virtual System.Linq.Expressions.Expression CreateOpenPropertyAccessExpression (Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode openNode)
+	protected virtual System.Linq.Expressions.Expression CreatePropertyAccessExpression (System.Linq.Expressions.Expression source, Microsoft.OData.Edm.IEdmProperty edmProperty)
+	protected virtual System.Linq.Expressions.Expression CreatePropertyAccessExpression (System.Linq.Expressions.Expression source, Microsoft.OData.Edm.IEdmProperty edmProperty, string propertyPath)
+	protected virtual System.Linq.Expressions.Expression CreatePropertyAggregateExpression (System.Linq.Expressions.ParameterExpression accumulativeParameter, Microsoft.OData.UriParser.Aggregation.AggregateExpression expression, System.Type baseType)
+	internal virtual bool IsClassicEF (System.Linq.IQueryable query)
 }
 
 public class Microsoft.AspNet.OData.Query.Expressions.DefaultODataBinderProvider : ODataBinderProvider {
 	public DefaultODataBinderProvider ()
 
+	public virtual AggregationBinder GetAggregationBinder (ODataQuerySettings settings, System.IServiceProvider requestContainer, System.Type elementType, Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.UriParser.Aggregation.TransformationNode transformation)
 	public virtual SelectExpandBinder GetSelectExpandBinder (ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
 }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -3486,6 +3486,18 @@ public abstract class Microsoft.AspNet.OData.Query.Expressions.ExpressionBinderB
 	public static int GuidCompare (System.Guid firstValue, System.Guid secondValue)
 }
 
+public abstract class Microsoft.AspNet.OData.Query.Expressions.ODataBinderProvider {
+	protected ODataBinderProvider ()
+
+	public abstract SelectExpandBinder GetSelectExpandBinder (ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
+}
+
+public class Microsoft.AspNet.OData.Query.Expressions.DefaultODataBinderProvider : ODataBinderProvider {
+	public DefaultODataBinderProvider ()
+
+	public virtual SelectExpandBinder GetSelectExpandBinder (ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
+}
+
 public class Microsoft.AspNet.OData.Query.Expressions.FilterBinder : ExpressionBinderBase {
 	public FilterBinder (System.IServiceProvider requestContainer)
 
@@ -3509,6 +3521,17 @@ public class Microsoft.AspNet.OData.Query.Expressions.FilterBinder : ExpressionB
 	public virtual System.Linq.Expressions.Expression BindSingleResourceFunctionCallNode (Microsoft.OData.UriParser.SingleResourceFunctionCallNode node)
 	public virtual System.Linq.Expressions.Expression BindSingleValueFunctionCallNode (Microsoft.OData.UriParser.SingleValueFunctionCallNode node)
 	public virtual System.Linq.Expressions.Expression BindUnaryOperatorNode (Microsoft.OData.UriParser.UnaryOperatorNode unaryOperatorNode)
+}
+
+public class Microsoft.AspNet.OData.Query.Expressions.SelectExpandBinder {
+	protected SelectExpandBinder (ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
+
+	protected virtual System.Linq.IQueryable Bind (System.Linq.IQueryable queryable)
+	protected virtual object Bind (object entity)
+	protected virtual System.Linq.Expressions.Expression CreatePropertyAccessExpression (System.Linq.Expressions.Expression source, Microsoft.OData.Edm.IEdmProperty edmProperty)
+	protected virtual System.Linq.Expressions.Expression CreatePropertyNameExpression (Microsoft.OData.Edm.IEdmEntityType elementType, Microsoft.OData.Edm.IEdmProperty edmProperty, System.Linq.Expressions.Expression source)
+	protected virtual System.Linq.Expressions.Expression CreatePropertyValueExpressionWithFilter (Microsoft.OData.Edm.IEdmEntityType elementType, Microsoft.OData.Edm.IEdmProperty edmProperty, System.Linq.Expressions.Expression source, Microsoft.OData.UriParser.FilterClause filterClause)
+	protected virtual System.Linq.Expressions.Expression CreateTotalCountExpression (System.Linq.Expressions.Expression source, Microsoft.OData.UriParser.ExpandedReferenceSelectItem expandItem)
 }
 
 public class Microsoft.AspNet.OData.Query.Validators.CountQueryValidator {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue implements feature  #1900 .

### Description

SelectExpandBinder and AggregationBinder were made public and some of there methods were made protected virtual to let developers override it's functionality (like in FilterBinder). Creation of these classes were moved to new DataBinderProvider class, because approach with registering them with IServiceProvider will require big refactoring.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary
I think no
