### PR TITLE
Ensures nullable enums are properly handled for in-operator

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -393,7 +393,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             }
 
             Type constantType = RetrieveClrTypeForConstant(node.ItemType, ref value);
-            Type nullableConstantType = node.ItemType.IsNullable
+            Type nullableConstantType = node.ItemType.IsNullable && constantType.IsValueType
                 ? typeof(Nullable<>).MakeGenericType(constantType)
                 : constantType;
             Type listType = typeof(List<>).MakeGenericType(nullableConstantType);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -1646,7 +1646,40 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             var values = (IList<SimpleEnum>)((ConstantExpression)((MethodCallExpression) expression.Body).Arguments[0]).Value;
             Assert.Equal(new[] {SimpleEnum.First, SimpleEnum.Second}, values);
         }
+
+        [Fact]
+        public void EnumInExpression_WithNullValue_Throws()
+        {
+            ExceptionAssert.Throws<ODataException>(
+                () => VerifyQueryDeserialization<DataTypes>("SimpleEnumProp in ('First', null)"),
+                "A null value was found with the expected type 'Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum[Nullable=False]'. The expected type 'Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum[Nullable=False]' does not allow null values.");
+        }
+
+        [Fact]
+        public void EnumInExpression_NullableEnum_WithNullable()
+        {
+            var result = VerifyQueryDeserialization<DataTypes>(
+                "NullableSimpleEnumProp in ('First', 'Second')",
+                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Contains($it.NullableSimpleEnumProp)");
+            Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
+
+            // expression tree is guaranteed by expression string above
+            var values = (IList<SimpleEnum?>)((ConstantExpression)((MethodCallExpression) expression.Body).Arguments[0]).Value;
+            Assert.Equal(new SimpleEnum?[] {SimpleEnum.First, SimpleEnum.Second}, values);
+        }
         
+        [Fact]
+        public void EnumInExpression_NullableEnum_WithNullValue()
+        {
+            var result = VerifyQueryDeserialization<DataTypes>(
+                "NullableSimpleEnumProp in ('First', null)",
+                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Contains($it.NullableSimpleEnumProp)");
+            Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
+
+            // expression tree is guaranteed by expression string above
+            var values = (IList<SimpleEnum?>)((ConstantExpression)((MethodCallExpression) expression.Body).Arguments[0]).Value;
+            Assert.Equal(new SimpleEnum?[] {SimpleEnum.First, null}, values);
+        }
 
         [Fact]
         public void RealLiteralSuffixes()


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1676.*

### Description

Ensures the correct nullability handling on enum-collections (actually all value types).

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
