### PR TITLE
Enable $select improvement with path and nested query options

### DIFF
--- a/samples/AspNetCoreODataSample.Web/Controllers/CustomersController.cs
+++ b/samples/AspNetCoreODataSample.Web/Controllers/CustomersController.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using AspNetCoreODataSample.Web.Models;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspNetCoreODataSample.Web.Controllers
+{
+    public class CustomersController : ODataController
+    {
+        public static IList<Customer> Customers;
+
+        static CustomersController()
+        {
+            Customers = new List<Customer>
+            {
+                new Customer
+                {
+                    CustomerId = 1,
+                    Name = "John",
+                    HomeAddress = new Address
+                    {
+                        RelatedCity = new City { Id = 31, Name = "Redmond"},
+                        Street = "148TH AVE NE",
+                        Region = "Redmond",
+                        Emails = new List<string>{ "abc@look.com", "xyz@eye.com" }
+                    },
+                    Addresses = new List<Address>
+                    {
+                        new CnAddress { Street = "LianHua Rd", Region = "Shanghai", PostCode = "201501", Emails = new List<string>{ "shangh_abc@look.com", "shangh_xyz@eye.com" }, RelatedCity = new City { Id = 81, Name = "Redm81"}, },
+                        new CnAddress { Street = "Tiananmen Rd", Region = "Beijing", PostCode = "101501", Emails = new List<string>{ "beijing_abc@look.com", "beijing_xyz@eye.com" }, RelatedCity = new City { Id = 82, Name = "Redm82"},},
+                        new UsAddress { Street = "Klahanie Rd", Region = "Remond", ZipCode = "98029", Emails = new List<string>{ "Remond_abc@look.com", "Remond_xyz@eye.com" }, RelatedCity = null },
+                        new UsAddress { Street = "Sammamish Rd", Region = "Sammamish", ZipCode = "98072", Emails = new List<string>{ "Sammamish_abc@look.com", "Sammamish_xyz@eye.com" }, RelatedCity = new City { Id = 83, Name = "Redm83"}, },
+                    },
+                    HomeOrder = new Order
+                    {
+                        Id = 11,
+                        Title = "John's Order",
+                    }
+                },
+                new VipCustomer
+                {
+                    CustomerId = 2,
+                    Name = "Smith",
+                    HomeAddress = new Address
+                    {
+                        RelatedCity = new City { Id = 41, Name = "Oklawevue"},
+                        Street = "18dfTH ST",
+                        Region = "Seattle",
+                        Emails = new List<string>{ "kfg@alis.com", "could@easdfe.com" }
+                    },
+                    Addresses = new List<Address>
+                    {
+                        new CnAddress { Street = "Shafng Rd", Region = "Zhedsdjiang", PostCode = "301501", Emails = new List<string>{ "Zhejiasng_abc@look.com", "Zhejdiang_xyz@eye.com" }, RelatedCity = new City { Id = 61, Name = "Redm21"}, },
+                        new CnAddress { Street = "Chondiu Rd", Region = "Jiadsngsu", PostCode = "40d1501", Emails = new List<string>{ "Jiandgsu_abc@look.com", "Jiasngsu_xyz@eye.com" }, RelatedCity = null},
+                        new UsAddress { Street = "Issdah Rd", Region = "Issdsaquah", ZipCode = "98d031", Emails = new List<string>{ "Issadquah_abc@look.com", "Issadquah_xyz@eye.com" }, RelatedCity = new City { Id = 62, Name = "Red352"}, },
+                        new UsAddress { Street = "Beded Rd", Region = "Redmdond", ZipCode = "98d052", Emails = new List<string>{ "Redd_abc@look.com", "Red_sxyz@eye.com" }, RelatedCity = new City { Id = 63, Name = "Re453"}, },
+                    },
+                    HomeOrder = new Order
+                    {
+                        Id = 21,
+                        Title = "Smith's Order"
+                    },
+                    VipPrice = 99,
+                    VipTaxes = new [] { 9, 8, 7 },
+                    VipAddress = new Address
+                    {
+                        RelatedCity = new City { Id = 91, Name = "Vipvue"},
+                        Street = "1Vip1TH ST",
+                        Region = "Seasdfattle",
+                        Emails = new List<string>{ "kfadffg@alis.com", "coasdfuld@easdfe.com" }
+                    },
+                    VipAddresses = new List<Address>
+                    {
+                        new CnAddress { Street = "VipShafng Rd", Region = "VipZhedsdjiang", PostCode = "30adsf1501", Emails = new List<string>{ "Zjiasng_abc@look.com", "Zhejdiafasd_xyz@eye.com" }, RelatedCity = new City { Id = 71, Name = "Redm21"}, },
+                        new UsAddress { Street = "VipBeded Rd", Region = "VipRedmdond", ZipCode = "98dfsda52", Emails = new List<string>{ "Rfd_abc@look.com", "Red_afsyz@eye.com" }, RelatedCity = new City { Id = 73, Name = "Re453"}, },
+                    }
+                },
+                new Customer
+                {
+                    CustomerId = 3,
+                    Name = "Ketti",
+                    HomeAddress = new Address
+                    {
+                        RelatedCity = new City { Id = 31, Name = "Kettievue"},
+                        Street = "98TH ST",
+                        Region = "Kettlelevue",
+                        Emails = new List<string>{ "Kett@alis.com", "Kett123@eye.com" }
+                    },
+                    Addresses = new List<Address>
+                    {
+                        new CnAddress { Street = "ShaKetthong Rd", Region = "ZhKettang", PostCode = "3011501", Emails = new List<string>{ "ZheKettg_abc@look.com", "ZhKettg_xyz@eye.com" }, RelatedCity = new City { Id = 71, Name = "ReKett51"}, },
+                        new CnAddress { Street = "ChoKettgqiu Rd", Region = "JiaKettgsu", PostCode = "431501", Emails = new List<string>{ "JiKettabc@look.com", "JianKett_xyz@eye.com" }, RelatedCity = null},
+                        new UsAddress { Street = "IssKettuah Rd", Region = "IssKettquah", ZipCode = "948031", Emails = new List<string>{ "IsKettah_abc@look.com", "IsKetth_xyz@eye.com" }, RelatedCity = new City { Id = 62, Name = "ReKett2"}, },
+                        new UsAddress { Street = "BeKettd Rd", Region = "ReKettdmond", ZipCode = "980552", Emails = new List<string>{ "ReKettabc@look.com", "ReKettz@eye.com" }, RelatedCity = new City { Id = 93, Name = "RedKett3"}, },
+                    },
+                    HomeOrder = new Order
+                    {
+                        Id = 31,
+                        Title = "Ketti's Order"
+                    }
+                },
+                // null, // It's not allowed in ResourceSet Serializer
+                new VipCustomer
+                {
+                    CustomerId = 5,
+                    Name = "Peter",
+                    HomeAddress = new Address
+                    {
+                        RelatedCity = new City { Id = 61, Name = "OPeterevue"},
+                        Street = "18PeterH ST",
+                        Region = "SePetertle",
+                        Emails = new List<string>{ "Peterg@alis.com", "couPeterd@easdfe.com" }
+                    },
+                    Addresses = new List<Address>
+                    {
+                        new CnAddress { Street = "ShaPeterng Rd", Region = "ZhedPeterjiang", PostCode = "304501", Emails = new List<string>{ "ZhejPeterng_abc@look.com", "ZhejPeterg_xyz@eye.com" }, RelatedCity = new City { Id = 81, Name = "RePeter21"}, },
+                        new CnAddress { Street = "ChPeteru Rd", Region = "JiadPetergsu", PostCode = "40d41501", Emails = new List<string>{ "JiandPeterabc@look.com", "JiasnPeteryz@eye.com" }, RelatedCity = null},
+                        new UsAddress { Street = "IssPeter Rd", Region = "IssdsPeterquah", ZipCode = "98d0531", Emails = new List<string>{ "IssadqPeterabc@look.com", "IssaPeterh_xyz@eye.com" }, RelatedCity = new City { Id = 82, Name = "RePeter2"}, },
+                        new UsAddress { Street = "BedPeterRd", Region = "RPetermdond", ZipCode = "98d0552", Emails = new List<string>{ "Redd_Peterc@look.com", "RePeterz@eye.com" }, RelatedCity = new City { Id = 83, Name = "Peter3"}, },
+                    },
+                    HomeOrder = new Order
+                    {
+                        Id = 41,
+                        Title = "Peter's Order"
+                    },
+                    VipPrice = 99,
+                    VipTaxes = new [] { 9, 8, 7 },
+                    VipAddress = new Address
+                    {
+                        RelatedCity = new City { Id = 91, Name = "Vipvue"},
+                        Street = "1Vip1TH ST",
+                        Region = "Seasdfattle",
+                        Emails = new List<string>{ "kfadffg@alis.com", "coasdfuld@easdfe.com" }
+                    },
+                    VipAddresses = new List<Address>
+                    {
+                        new CnAddress { Street = "VipShafng Rd", Region = "VipZhedsdjiang", PostCode = "30adsf1501", Emails = new List<string>{ "Zjiasng_abc@look.com", "Zhejdiafasd_xyz@eye.com" }, RelatedCity = new City { Id = 71, Name = "Redm21"}, },
+                        new UsAddress { Street = "VipBeded Rd", Region = "VipRedmdond", ZipCode = "98dfsda52", Emails = new List<string>{ "Rfd_abc@look.com", "Red_afsyz@eye.com" }, RelatedCity = new City { Id = 73, Name = "Re453"}, },
+                    },
+                }
+
+            };
+        }
+
+        public int VipPrice { get; set; }
+
+        public IList<int> VipTax { get; set; }
+
+        public Address VipAddress { get; set; }
+
+        public IList<Address> VipAddresses { get; set; }
+
+        [EnableQuery]
+        public IActionResult Get()
+        {
+            return Ok(Customers);
+        }
+
+        [EnableQuery]
+        public IActionResult Get(int key)
+        {
+            Customer c = Customers.FirstOrDefault(k => k.CustomerId == key);
+            if (c == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(c);
+        }
+
+        [EnableQuery]
+        public IActionResult GetFromVipCustomer()
+        {
+            return Ok(Customers.Where(c => c is VipCustomer));
+        }
+    }
+}

--- a/samples/AspNetCoreODataSample.Web/Models/CustomerOrderModel.cs
+++ b/samples/AspNetCoreODataSample.Web/Models/CustomerOrderModel.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace AspNetCoreODataSample.Web.Models
+{
+    public class Address
+    {
+        public string Street { get; set; }
+
+        public string Region { get; set; }
+
+        public IList<string> Emails { get; set; }
+
+        public City RelatedCity { get; set; }
+    }
+
+    public class Customer
+    {
+        public int CustomerId { get; set; }
+
+        public string Name { get; set; }
+
+        public Address HomeAddress { get; set; }
+
+        public IList<Address> Addresses { get; set; }
+
+        public Order HomeOrder { get; set; }
+
+        public IList<Order> Orders { get; set; }
+    }
+
+    public class VipCustomer : Customer
+    {
+        public int VipPrice { get; set; }
+
+        public IList<int> VipTaxes { get; set; }
+
+        public Address VipAddress { get; set; }
+
+        public IList<Address> VipAddresses { get; set; }
+    }
+
+    public class Order
+    {
+        public int Id { get; set; }
+
+        public string Title { get; set; }
+    }
+
+    public class City
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    public class UsAddress : Address
+    {
+        public string ZipCode { get; set; }
+    }
+
+    public class CnAddress : Address
+    {
+        public string PostCode { get; set; }
+    }
+}

--- a/samples/AspNetCoreODataSample.Web/Models/EdmModelBuilder.cs
+++ b/samples/AspNetCoreODataSample.Web/Models/EdmModelBuilder.cs
@@ -34,5 +34,14 @@ namespace AspNetCoreODataSample.Web.Models
             type.HasKey(x => new { x.FirstName, x.LastName });
             return builder.GetEdmModel();
         }
+
+        public static IEdmModel GetCustomerOrderModel()
+        {
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<Customer>("Customers");
+            builder.EntitySet<Order>("Orders");
+            builder.EntitySet<City>("Cities");
+            return builder.GetEdmModel();
+        }
     }
 }

--- a/samples/AspNetCoreODataSample.Web/Properties/launchSettings.json
+++ b/samples/AspNetCoreODataSample.Web/Properties/launchSettings.json
@@ -19,7 +19,7 @@
     "AspNetCoreODataSample.Web": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "efcore/Movies",
+      "launchUrl": "odata/$metadata",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/samples/AspNetCoreODataSample.Web/Startup.cs
+++ b/samples/AspNetCoreODataSample.Web/Startup.cs
@@ -47,6 +47,9 @@ namespace AspNetCoreODataSample.Web
                 builder.MapODataServiceRoute("odata2", "inmem", model);
 
                 builder.MapODataServiceRoute("odata3", "composite", EdmModelBuilder.GetCompositeModel());
+
+                builder.MapODataServiceRoute("odata4", "odata", EdmModelBuilder.GetCustomerOrderModel());
+
             });
         }
     }

--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
@@ -2377,6 +2377,28 @@ namespace Microsoft.AspNet.OData.Common
                 return ResourceManager.GetString("UnsupportedSelectExpandPath", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to A segment &apos;{0}&apos; within the select or expand query option is not supported..
+        /// </summary>
+        internal static string InvalidSegmentInSelectExpandPath
+        {
+            get
+            {
+                return ResourceManager.GetString("InvalidSegmentInSelectExpandPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The last segment &apos;{0}&apos; of the select or expand query option is not supported...
+        /// </summary>
+        internal static string InvalidLastSegmentInSelectExpandPath
+        {
+            get
+            {
+                return ResourceManager.GetString("InvalidLastSegmentInSelectExpandPath", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Unterminated string literal at {0} in segment &apos;{1}&apos;..

--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
@@ -580,6 +580,12 @@
   <data name="UnsupportedSelectExpandPath" xml:space="preserve">
     <value>A path within the select or expand query option is not supported.</value>
   </data>
+  <data name="InvalidSegmentInSelectExpandPath" xml:space="preserve">
+    <value>A segment '{0}' within the select or expand query option is not supported.</value>
+  </data>
+  <data name="InvalidLastSegmentInSelectExpandPath" xml:space="preserve">
+    <value>The last segment '{0}' of the select or expand query option is not supported.</value>
+  </data>
   <data name="UrlHelperNull" xml:space="preserve">
     <value>The property 'Url' of {0} cannot be null.</value>
   </data>

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -129,7 +129,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 if (resource != null)
                 {
                     writer.WriteStart(resource);
-                    WriteDeltaComplexProperties(selectExpandNode.SelectedComplexProperties, resourceContext, writer);
+                    WriteDeltaComplexProperties(selectExpandNode, resourceContext, writer);
                     //TODO: Need to add support to write Navigation Links, etc. using Delta Writer
                     //https://github.com/OData/odata.net/issues/155
                     //CLEANUP: merge delta logic with regular logic; requires common base between ODataWriter and ODataDeltaWriter
@@ -142,22 +142,30 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             }
         }
 
-        private void WriteDeltaComplexProperties(IEnumerable<IEdmStructuralProperty> complexProperties,
+        private void WriteDeltaComplexProperties(SelectExpandNode selectExpandNode,
             ResourceContext resourceContext, ODataWriter writer)
         {
-            Contract.Assert(complexProperties != null);
             Contract.Assert(resourceContext != null);
             Contract.Assert(writer != null);
+
+            if (selectExpandNode.SelectedComplexes == null)
+            {
+                return;
+            }
+            var complexProperties = selectExpandNode.SelectedComplexes;
 
             if (null != resourceContext.EdmObject && resourceContext.EdmObject.IsDeltaResource())
             {
                 IDelta deltaObject = resourceContext.EdmObject as IDelta;
                 IEnumerable<string> changedProperties = deltaObject.GetChangedPropertyNames();
-                complexProperties = complexProperties.Where(p => changedProperties.Contains(p.Name));
+
+                complexProperties = complexProperties.Where(p => changedProperties.Contains(p.Key.Name)).ToDictionary(a => a.Key, a => a.Value);
             }
 
-            foreach (IEdmStructuralProperty complexProperty in complexProperties)
+            foreach (var selectedComplex in complexProperties)
             {
+                IEdmStructuralProperty complexProperty = selectedComplex.Key;
+
                 ODataNestedResourceInfo nestedResourceInfo = new ODataNestedResourceInfo
                 {
                     IsCollection = complexProperty.Type.IsCollection(),
@@ -348,9 +356,9 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                         writer.WriteStart(resource);
                         WriteComplexProperties(selectExpandNode, resourceContext, writer);
                         WriteDynamicComplexProperties(resourceContext, writer);
-                        WriteNavigationLinks(selectExpandNode.SelectedNavigationProperties, resourceContext, writer);
+                        WriteNavigationLinks(selectExpandNode, resourceContext, writer);
                         WriteExpandedNavigationProperties(selectExpandNode, resourceContext, writer);
-                        WriteReferencedNavigationProperties(selectExpandNode.ReferencedNavigationProperties, resourceContext, writer);
+                        WriteReferencedNavigationProperties(selectExpandNode, resourceContext, writer);
                         writer.WriteEnd();
                     }
                 }
@@ -417,7 +425,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             ODataResource resource = new ODataResource
             {
                 TypeName = typeName,
-                Properties = CreateStructuralPropertyBag(selectExpandNode.SelectedStructuralProperties, resourceContext),
+                Properties = CreateStructuralPropertyBag(selectExpandNode, resourceContext),
             };
 
             if (resourceContext.EdmObject is EdmDeltaEntityObject && resourceContext.NavigationSource != null)
@@ -436,16 +444,22 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             // Try to add the dynamic properties if the structural type is open.
             AppendDynamicProperties(resource, selectExpandNode, resourceContext);
 
-            IEnumerable<ODataAction> actions = CreateODataActions(selectExpandNode.SelectedActions, resourceContext);
-            foreach (ODataAction action in actions)
+            if (selectExpandNode.SelectedActions != null)
             {
-                resource.AddAction(action);
+                IEnumerable<ODataAction> actions = CreateODataActions(selectExpandNode.SelectedActions, resourceContext);
+                foreach (ODataAction action in actions)
+                {
+                    resource.AddAction(action);
+                }
             }
 
-            IEnumerable<ODataFunction> functions = CreateODataFunctions(selectExpandNode.SelectedFunctions, resourceContext);
-            foreach (ODataFunction function in functions)
+            if (selectExpandNode.SelectedFunctions != null)
             {
-                resource.AddFunction(function);
+                IEnumerable<ODataFunction> functions = CreateODataFunctions(selectExpandNode.SelectedFunctions, resourceContext);
+                foreach (ODataFunction function in functions)
+                {
+                    resource.AddFunction(function);
+                }
             }
 
             IEdmStructuredType pathType = GetODataPathType(resourceContext.SerializerContext);
@@ -510,7 +524,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             Contract.Assert(resourceContext != null);
 
             if (!resourceContext.StructuredType.IsOpen || // non-open type
-                (!selectExpandNode.SelectAllDynamicProperties && !selectExpandNode.SelectedDynamicProperties.Any()))
+                (!selectExpandNode.SelectAllDynamicProperties && selectExpandNode.SelectedDynamicProperties == null))
             {
                 return;
             }
@@ -551,10 +565,9 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             HashSet<string> declaredPropertyNameSet = new HashSet<string>(resource.Properties.Select(p => p.Name));
             List<ODataProperty> dynamicProperties = new List<ODataProperty>();
             IEnumerable<KeyValuePair<string, object>> dynamicPropertiesToSelect =
-                dynamicPropertyDictionary.Where(
-                    x =>
-                        !selectExpandNode.SelectedDynamicProperties.Any() ||
-                        selectExpandNode.SelectedDynamicProperties.Contains(x.Key));
+                dynamicPropertyDictionary.Where(x =>
+                selectExpandNode.SelectedDynamicProperties == null // if SelectedDynamicProperties == null, means SelectAllDynamicProperties == true
+                || selectExpandNode.SelectedDynamicProperties.Contains(x.Key));
             foreach (KeyValuePair<string, object> dynamicProperty in dynamicPropertiesToSelect)
             {
                 if (String.IsNullOrEmpty(dynamicProperty.Key))
@@ -654,69 +667,23 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             return null;
         }
 
-        private void WriteNavigationLinks(
-            IEnumerable<IEdmNavigationProperty> navigationProperties, ResourceContext resourceContext, ODataWriter writer)
-        {
-            Contract.Assert(resourceContext != null);
-
-            IEnumerable<ODataNestedResourceInfo> navigationLinks = CreateNavigationLinks(navigationProperties, resourceContext);
-            foreach (ODataNestedResourceInfo navigationLink in navigationLinks)
-            {
-                writer.WriteStart(navigationLink);
-                writer.WriteEnd();
-            }
-        }
-
-        private void WriteComplexProperties(SelectExpandNode selectExpandNode,
-            ResourceContext resourceContext, ODataWriter writer)
+        /// <summary>
+        /// Write the navigation link for the select navigation properties.
+        /// </summary>
+        private void WriteNavigationLinks(SelectExpandNode selectExpandNode, ResourceContext resourceContext, ODataWriter writer)
         {
             Contract.Assert(selectExpandNode != null);
             Contract.Assert(resourceContext != null);
-            Contract.Assert(writer != null);
 
-            IEnumerable<IEdmStructuralProperty> complexProperties = selectExpandNode.SelectedComplexProperties;
-
-            Contract.Assert(complexProperties != null);
-
-            if (null != resourceContext.EdmObject && resourceContext.EdmObject.IsDeltaResource())
+            if (selectExpandNode.SelectedNavigationProperties == null)
             {
-                IDelta deltaObject = resourceContext.EdmObject as IDelta;
-                IEnumerable<string> changedProperties = deltaObject.GetChangedPropertyNames();
-                complexProperties = complexProperties.Where(p => changedProperties.Contains(p.Name));
+                return;
             }
 
-            foreach (IEdmStructuralProperty complexProperty in complexProperties)
+            IEnumerable<ODataNestedResourceInfo> navigationLinks = CreateNavigationLinks(selectExpandNode.SelectedNavigationProperties, resourceContext);
+            foreach (ODataNestedResourceInfo navigationLink in navigationLinks)
             {
-                if (selectExpandNode.ExpandedPropertiesOnSubChildren.ContainsKey(complexProperty))
-                {
-                    // We will write the property when the property is expanded.
-                    continue;
-                }
-
-                ODataNestedResourceInfo nestedResourceInfo = new ODataNestedResourceInfo
-                {
-                    IsCollection = complexProperty.Type.IsCollection(),
-                    Name = complexProperty.Name
-                };
-
-                writer.WriteStart(nestedResourceInfo);
-                WriteComplexAndExpandedNavigationProperty(complexProperty, null, resourceContext, writer);
-                writer.WriteEnd();
-            }
-
-            foreach (var item in selectExpandNode.ExpandedPropertiesOnSubChildren)
-            {
-                IEdmStructuralProperty complexProperty = item.Key;
-                ExpandedNavigationSelectItem expandedNavigationSelectItem = selectExpandNode.ExpandedPropertiesOnSubChildren[complexProperty];
-
-                ODataNestedResourceInfo nestedResourceInfo = new ODataNestedResourceInfo
-                {
-                    IsCollection = complexProperty.Type.IsCollection(),
-                    Name = complexProperty.Name
-                };
-
-                writer.WriteStart(nestedResourceInfo);
-                WriteComplexAndExpandedNavigationProperty(complexProperty, expandedNavigationSelectItem, resourceContext, writer);
+                writer.WriteStart(navigationLink);
                 writer.WriteEnd();
             }
         }
@@ -782,17 +749,51 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             serializer.WriteObjectInline(propertyValue, edmType, writer, nestedWriteContext);
         }
 
-        private void WriteExpandedNavigationProperties(
-           SelectExpandNode selectExpandNode,
-            ResourceContext resourceContext,
-            ODataWriter writer)
+        private void WriteComplexProperties(SelectExpandNode selectExpandNode, ResourceContext resourceContext, ODataWriter writer)
+        {
+            Contract.Assert(selectExpandNode != null);
+            Contract.Assert(resourceContext != null);
+            Contract.Assert(writer != null);
+
+            var complexProperties = selectExpandNode.SelectedComplexes;
+            if (complexProperties == null)
+            {
+                return;
+            }
+
+            if (null != resourceContext.EdmObject && resourceContext.EdmObject.IsDeltaResource())
+            {
+                IDelta deltaObject = resourceContext.EdmObject as IDelta;
+                IEnumerable<string> changedProperties = deltaObject.GetChangedPropertyNames();
+                complexProperties = complexProperties.Where(p => changedProperties.Contains(p.Key.Name)).ToDictionary(a => a.Key, a => a.Value);
+            }
+
+            foreach (var selectedComplex in complexProperties)
+            {
+                IEdmStructuralProperty complexProperty = selectedComplex.Key;
+
+                ODataNestedResourceInfo nestedResourceInfo = new ODataNestedResourceInfo
+                {
+                    IsCollection = complexProperty.Type.IsCollection(),
+                    Name = complexProperty.Name
+                };
+
+                writer.WriteStart(nestedResourceInfo);
+                WriteComplexAndExpandedNavigationProperty(complexProperty, selectedComplex.Value, resourceContext, writer);
+                writer.WriteEnd();
+            }
+        }
+
+        private void WriteExpandedNavigationProperties(SelectExpandNode selectExpandNode, ResourceContext resourceContext, ODataWriter writer)
         {
             Contract.Assert(resourceContext != null);
             Contract.Assert(writer != null);
 
-            IDictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem> navigationPropertiesToExpand = selectExpandNode.ExpandedProperties;
-
-            Contract.Assert(navigationPropertiesToExpand != null);
+            var navigationPropertiesToExpand = selectExpandNode.ExpandedProperties;
+            if (navigationPropertiesToExpand == null)
+            {
+                return;
+            }
 
             foreach (KeyValuePair<IEdmNavigationProperty, ExpandedNavigationSelectItem> navPropertyToExpand in navigationPropertiesToExpand)
             {
@@ -802,15 +803,38 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 if (navigationLink != null)
                 {
                     writer.WriteStart(navigationLink);
-                    WriteComplexAndExpandedNavigationProperty(navPropertyToExpand.Key, navPropertyToExpand.Value, resourceContext, writer);
+                    WriteComplexAndExpandedNavigationProperty(navigationProperty, navPropertyToExpand.Value, resourceContext, writer);
                     writer.WriteEnd();
                 }
             }
         }
 
-        private void WriteComplexAndExpandedNavigationProperty(IEdmProperty edmProperty, ExpandedNavigationSelectItem expandedNavigationSelectItem,
-            ResourceContext resourceContext,
-            ODataWriter writer, bool expandReference = false)
+        private void WriteReferencedNavigationProperties(SelectExpandNode selectExpandNode, ResourceContext resourceContext, ODataWriter writer)
+        {
+            Contract.Assert(resourceContext != null);
+            Contract.Assert(writer != null);
+
+            var referencedPropertiesToExpand = selectExpandNode.ReferencedProperties;
+            if (referencedPropertiesToExpand == null)
+            {
+                return;
+            }
+
+            foreach (var referenced in referencedPropertiesToExpand)
+            {
+                IEdmNavigationProperty navigationProperty = referenced.Key;
+
+                ODataNestedResourceInfo nestedResourceInfo = CreateNavigationLink(navigationProperty, resourceContext);
+                if (nestedResourceInfo != null)
+                {
+                    writer.WriteStart(nestedResourceInfo);
+                    WriteComplexAndExpandedNavigationProperty(navigationProperty, referenced.Value, resourceContext, writer);
+                    writer.WriteEnd();
+                }
+            }
+        }
+
+        private void WriteComplexAndExpandedNavigationProperty(IEdmProperty edmProperty, SelectItem selectItem, ResourceContext resourceContext, ODataWriter writer)
         {
             Contract.Assert(edmProperty != null);
             Contract.Assert(resourceContext != null);
@@ -842,38 +866,16 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             else
             {
                 // create the serializer context for the complex and expanded item.
-
-                ODataSerializerContext nestedWriteContext = new ODataSerializerContext(resourceContext, edmProperty, resourceContext.SerializerContext.QueryContext, expandedNavigationSelectItem);
-                nestedWriteContext.ExpandReference = expandReference;
+                ODataSerializerContext nestedWriteContext = new ODataSerializerContext(resourceContext, edmProperty, resourceContext.SerializerContext.QueryContext, selectItem);
 
                 // write object.
                 ODataEdmTypeSerializer serializer = SerializerProvider.GetEdmTypeSerializer(edmProperty.Type);
                 if (serializer == null)
                 {
-                    throw new SerializationException(
-                        Error.Format(SRResources.TypeCannotBeSerialized, edmProperty.Type.ToTraceString()));
+                    throw new SerializationException(Error.Format(SRResources.TypeCannotBeSerialized, edmProperty.Type.ToTraceString()));
                 }
 
                 serializer.WriteObjectInline(propertyValue, edmProperty.Type, writer, nestedWriteContext);
-            }
-        }
-
-        private void WriteReferencedNavigationProperties(ISet<IEdmNavigationProperty> referencedPropertiesToExpand,
-            ResourceContext resourceContext, ODataWriter writer)
-        {
-            Contract.Assert(referencedPropertiesToExpand != null);
-            Contract.Assert(resourceContext != null);
-            Contract.Assert(writer != null);
-
-            foreach (IEdmNavigationProperty navigationProperty in referencedPropertiesToExpand)
-            {
-                ODataNestedResourceInfo nestedResourceInfo = CreateNavigationLink(navigationProperty, resourceContext);
-                if (nestedResourceInfo != null)
-                {
-                    writer.WriteStart(nestedResourceInfo);
-                    WriteComplexAndExpandedNavigationProperty(navigationProperty, null, resourceContext, writer, true);
-                    writer.WriteEnd();
-                }
             }
         }
 
@@ -905,19 +907,21 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             {
                 throw Error.ArgumentNull("navigationProperty");
             }
+
             if (resourceContext == null)
             {
                 throw Error.ArgumentNull("resourceContext");
             }
 
             ODataSerializerContext writeContext = resourceContext.SerializerContext;
+            IEdmNavigationSource navigationSource = writeContext.NavigationSource;
             ODataNestedResourceInfo navigationLink = null;
 
-            if (writeContext.NavigationSource != null)
+            if (navigationSource != null)
             {
                 IEdmTypeReference propertyType = navigationProperty.Type;
                 IEdmModel model = writeContext.Model;
-                NavigationSourceLinkBuilderAnnotation linkBuilder = model.GetNavigationSourceLinkBuilder(writeContext.NavigationSource);
+                NavigationSourceLinkBuilderAnnotation linkBuilder = model.GetNavigationSourceLinkBuilder(navigationSource);
                 Uri navigationUrl = linkBuilder.BuildNavigationLink(resourceContext, navigationProperty, writeContext.MetadataLevel);
 
                 navigationLink = new ODataNestedResourceInfo
@@ -935,27 +939,30 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             return navigationLink;
         }
 
-        private IEnumerable<ODataProperty> CreateStructuralPropertyBag(
-            IEnumerable<IEdmStructuralProperty> structuralProperties, ResourceContext resourceContext)
+        private IEnumerable<ODataProperty> CreateStructuralPropertyBag(SelectExpandNode selectExpandNode, ResourceContext resourceContext)
         {
-            Contract.Assert(structuralProperties != null);
+            Contract.Assert(selectExpandNode != null);
             Contract.Assert(resourceContext != null);
 
             List<ODataProperty> properties = new List<ODataProperty>();
-
-            if (null != resourceContext.EdmObject && resourceContext.EdmObject.IsDeltaResource())
+            if (selectExpandNode.SelectedStructuralProperties != null)
             {
-                IDelta deltaObject = resourceContext.EdmObject as IDelta;
-                IEnumerable<string> changedProperties = deltaObject.GetChangedPropertyNames();
-                structuralProperties = structuralProperties.Where(p => changedProperties.Contains(p.Name));
-            }
+                IEnumerable<IEdmStructuralProperty> structuralProperties = selectExpandNode.SelectedStructuralProperties;
 
-            foreach (IEdmStructuralProperty structuralProperty in structuralProperties)
-            {
-                ODataProperty property = CreateStructuralProperty(structuralProperty, resourceContext);
-                if (property != null)
+                if (null != resourceContext.EdmObject && resourceContext.EdmObject.IsDeltaResource())
                 {
-                    properties.Add(property);
+                    IDelta deltaObject = resourceContext.EdmObject as IDelta;
+                    IEnumerable<string> changedProperties = deltaObject.GetChangedPropertyNames();
+                    structuralProperties = structuralProperties.Where(p => changedProperties.Contains(p.Name));
+                }
+
+                foreach (IEdmStructuralProperty structuralProperty in structuralProperties)
+                {
+                    ODataProperty property = CreateStructuralProperty(structuralProperty, resourceContext);
+                    if (property != null)
+                    {
+                        properties.Add(property);
+                    }
                 }
             }
 

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -152,19 +152,19 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             {
                 return;
             }
-            var complexProperties = selectExpandNode.SelectedComplexes;
+            IEnumerable<IEdmStructuralProperty> complexProperties = selectExpandNode.SelectedComplexes.Keys;
 
             if (null != resourceContext.EdmObject && resourceContext.EdmObject.IsDeltaResource())
             {
                 IDelta deltaObject = resourceContext.EdmObject as IDelta;
                 IEnumerable<string> changedProperties = deltaObject.GetChangedPropertyNames();
 
-                complexProperties = complexProperties.Where(p => changedProperties.Contains(p.Key.Name)).ToDictionary(a => a.Key, a => a.Value);
+                complexProperties = complexProperties.Where(p => changedProperties.Contains(p.Name));
             }
 
             foreach (var selectedComplex in complexProperties)
             {
-                IEdmStructuralProperty complexProperty = selectedComplex.Key;
+                IEdmStructuralProperty complexProperty = selectedComplex;
 
                 ODataNestedResourceInfo nestedResourceInfo = new ODataNestedResourceInfo
                 {

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -148,11 +148,11 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             Contract.Assert(resourceContext != null);
             Contract.Assert(writer != null);
 
-            if (selectExpandNode.SelectedComplexes == null)
+            if (selectExpandNode.SelectedComplexTypeProperties == null)
             {
                 return;
             }
-            IEnumerable<IEdmStructuralProperty> complexProperties = selectExpandNode.SelectedComplexes.Keys;
+            IEnumerable<IEdmStructuralProperty> complexProperties = selectExpandNode.SelectedComplexTypeProperties.Keys;
 
             if (null != resourceContext.EdmObject && resourceContext.EdmObject.IsDeltaResource())
             {
@@ -756,7 +756,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             Contract.Assert(resourceContext != null);
             Contract.Assert(writer != null);
 
-            IDictionary<IEdmStructuralProperty, PathSelectItem> complexProperties = selectExpandNode.SelectedComplexes;
+            IDictionary<IEdmStructuralProperty, PathSelectItem> complexProperties = selectExpandNode.SelectedComplexTypeProperties;
             if (complexProperties == null)
             {
                 return;

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataSerializerContext.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataSerializerContext.cs
@@ -106,7 +106,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
             EdmProperty = edmProperty; // should be nested property
 
-            if (currentSelectItem == null)
+            if (currentSelectItem == null || (NavigationSource as IEdmUnknownEntitySet) != null)
             {
                 IEdmNavigationProperty navigationProperty = edmProperty as IEdmNavigationProperty;
                 if (navigationProperty != null && context.NavigationSource != null)

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/SelectExpandNode.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/SelectExpandNode.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -37,8 +38,8 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             SelectedStructuralProperties = selectExpandNodeToCopy.SelectedStructuralProperties == null ?
                 null : new HashSet<IEdmStructuralProperty>(selectExpandNodeToCopy.SelectedStructuralProperties);
 
-            SelectedComplexes = selectExpandNodeToCopy.SelectedComplexes == null ?
-                null : new Dictionary<IEdmStructuralProperty, PathSelectItem>(selectExpandNodeToCopy.SelectedComplexes);
+            SelectedComplexTypeProperties = selectExpandNodeToCopy.SelectedComplexTypeProperties == null ?
+                null : new Dictionary<IEdmStructuralProperty, PathSelectItem>(selectExpandNodeToCopy.SelectedComplexTypeProperties);
 
             SelectedNavigationProperties = selectExpandNodeToCopy.SelectedNavigationProperties == null ?
                 null : new HashSet<IEdmNavigationProperty>(selectExpandNodeToCopy.SelectedNavigationProperties);
@@ -108,16 +109,17 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         /// Gets the list of EDM nested properties (complex or collection of complex) to be included in the response.
         /// keeping this is only for non-breaking changes, This should be replaced by "SelectedComplexes".
         /// </summary>
+        [Obsolete("This property will be removed later, please use SelectedComplexTypeProperties.")]
         public ISet<IEdmStructuralProperty> SelectedComplexProperties
         {
             get
             {
-                if (SelectedComplexes == null)
+                if (SelectedComplexTypeProperties == null)
                 {
                     return null;
                 }
 
-                return new HashSet<IEdmStructuralProperty>(SelectedComplexes.Keys);
+                return new HashSet<IEdmStructuralProperty>(SelectedComplexTypeProperties.Keys);
             }
         }
 
@@ -137,7 +139,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         /// The key is the Edm structural property.
         /// The value is the potential sub select item.
         /// </summary>
-        public IDictionary<IEdmStructuralProperty, PathSelectItem> SelectedComplexes { get; internal set; }
+        public IDictionary<IEdmStructuralProperty, PathSelectItem> SelectedComplexTypeProperties { get; internal set; }
 
         /// <summary>
         /// Gets the list of EDM navigation properties to be expanded in the response along with the nested query options embedded in the expand.
@@ -548,12 +550,12 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
             if (isComplexOrCollectComplex)
             {
-                if (SelectedComplexes == null)
+                if (SelectedComplexTypeProperties == null)
                 {
-                    SelectedComplexes = new Dictionary<IEdmStructuralProperty, PathSelectItem>();
+                    SelectedComplexTypeProperties = new Dictionary<IEdmStructuralProperty, PathSelectItem>();
                 }
 
-                SelectedComplexes[structuralProperty] = pathSelectItem;
+                SelectedComplexTypeProperties[structuralProperty] = pathSelectItem;
             }
             else
             {
@@ -677,6 +679,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         /// <param name="structuredType">The structural type of the resource.</param>
         /// <param name="structuralProperties">The non-nested structural properties of the structural type.</param>
         /// <param name="nestedStructuralProperties">The nested structural properties of the structural type.</param>
+        [Obsolete("This public method is not used anymore. It will be removed later.")]
         public static void GetStructuralProperties(IEdmStructuredType structuredType, HashSet<IEdmStructuralProperty> structuralProperties,
             HashSet<IEdmStructuralProperty> nestedStructuralProperties)
         {

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/SelectExpandNode.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/SelectExpandNode.cs
@@ -208,7 +208,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 {
                     SelectAllDynamicProperties = true;
 
-                    // includes primitive, enum, complex or collection of them
+                    // includes navigation properties
                     SelectedNavigationProperties = structuralTypeInfo.AllNavigationProperties;
 
                     // includes all bound actions
@@ -245,7 +245,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             Contract.Assert(selectExpandClause != null);
             Contract.Assert(structuralTypeInfo != null);
 
-            var currentLevelPropertiesInclude = new Dictionary<IEdmStructuralProperty, SelectExpandIncludeProperty>();
+            var currentLevelPropertiesInclude = new Dictionary<IEdmStructuralProperty, SelectExpandIncludedProperty>();
 
             // Explicitly set SelectAllDynamicProperties as false,
             // Below will re-set it as true if it meets the select all condition.
@@ -301,7 +301,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             // at least to make sure the structural properties are in the same order of the order defined in the type.
             foreach (var structuralProperty in structuralTypeInfo.AllStructuralProperties)
             {
-                SelectExpandIncludeProperty includeProperty;
+                SelectExpandIncludedProperty includeProperty;
                 if (!currentLevelPropertiesInclude.TryGetValue(structuralProperty, out includeProperty))
                 {
                     continue;
@@ -319,7 +319,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         /// <param name="currentLevelPropertiesInclude">The current properties to include at current level.</param>
         /// <param name="structuralTypeInfo">The structural type properties.</param>
         private void BuildExpandItem(ExpandedReferenceSelectItem expandReferenceItem,
-            IDictionary<IEdmStructuralProperty, SelectExpandIncludeProperty> currentLevelPropertiesInclude,
+            IDictionary<IEdmStructuralProperty, SelectExpandIncludedProperty> currentLevelPropertiesInclude,
             EdmStructuralTypeInfo structuralTypeInfo)
         {
             Contract.Assert(expandReferenceItem != null && expandReferenceItem.PathToNavigationProperty != null);
@@ -340,10 +340,10 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
                 if (structuralTypeInfo.IsStructuralPropertyDefined(firstPropertySegment.Property))
                 {
-                    SelectExpandIncludeProperty newPropertySelectItem;
+                    SelectExpandIncludedProperty newPropertySelectItem;
                     if (!currentLevelPropertiesInclude.TryGetValue(firstPropertySegment.Property, out newPropertySelectItem))
                     {
-                        newPropertySelectItem = new SelectExpandIncludeProperty(firstPropertySegment);
+                        newPropertySelectItem = new SelectExpandIncludedProperty(firstPropertySegment);
                         currentLevelPropertiesInclude[firstPropertySegment.Property] = newPropertySelectItem;
                     }
 
@@ -394,7 +394,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         /// <param name="currentLevelPropertiesInclude">The current properties to include at current level.</param>
         /// <param name="structuralTypeInfo">The structural type properties.</param>
         private void BuildSelectItem(PathSelectItem pathSelectItem,
-            IDictionary<IEdmStructuralProperty, SelectExpandIncludeProperty> currentLevelPropertiesInclude,
+            IDictionary<IEdmStructuralProperty, SelectExpandIncludedProperty> currentLevelPropertiesInclude,
             EdmStructuralTypeInfo structuralTypeInfo)
         {
             Contract.Assert(pathSelectItem != null && pathSelectItem.SelectedPath != null);
@@ -412,10 +412,10 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 if (structuralTypeInfo.IsStructuralPropertyDefined(firstPropertySegment.Property))
                 {
                     // $select=abc/xyz/...
-                    SelectExpandIncludeProperty newPropertySelectItem;
+                    SelectExpandIncludedProperty newPropertySelectItem;
                     if (!currentLevelPropertiesInclude.TryGetValue(firstPropertySegment.Property, out newPropertySelectItem))
                     {
-                        newPropertySelectItem = new SelectExpandIncludeProperty(firstPropertySegment);
+                        newPropertySelectItem = new SelectExpandIncludedProperty(firstPropertySegment);
                         currentLevelPropertiesInclude[firstPropertySegment.Property] = newPropertySelectItem;
                     }
 
@@ -471,7 +471,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         }
 
         private static void MergeAllStructuralProperties(ISet<IEdmStructuralProperty> allStructuralProperties,
-            IDictionary<IEdmStructuralProperty, SelectExpandIncludeProperty> currentLevelPropertiesInclude)
+            IDictionary<IEdmStructuralProperty, SelectExpandIncludedProperty> currentLevelPropertiesInclude)
         {
             if (allStructuralProperties == null)
             {

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/SelectExpandNode.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/SelectExpandNode.cs
@@ -92,6 +92,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         /// Gets the list of EDM navigation properties to be expand referenced in the response.
         /// keeping this is only for non-breaking changes, This should be replaced by "ReferencedProperties" later.
         /// </summary>
+        [Obsolete("This property will be removed later, please use ReferencedProperties.")]
         public ISet<IEdmNavigationProperty> ReferencedNavigationProperties
         {
             get

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/SelectExpandNode.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/SelectExpandNode.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using Microsoft.AspNet.OData.Builder;
 using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Query.Expressions;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
@@ -20,25 +20,11 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
     public class SelectExpandNode
     {
         /// <summary>
-        /// Exists to support backward compatibility as we introduced ExpandedProperties.
-        /// </summary>
-        private Dictionary<IEdmNavigationProperty, SelectExpandClause> cachedExpandedClauses;
-
-        /// <summary>
         /// Creates a new instance of the <see cref="SelectExpandNode"/> class.
         /// </summary>
         /// <remarks>The default constructor is for unit testing only.</remarks>
         public SelectExpandNode()
         {
-            SelectedStructuralProperties = new HashSet<IEdmStructuralProperty>();
-            SelectedComplexProperties = new HashSet<IEdmStructuralProperty>();
-            SelectedNavigationProperties = new HashSet<IEdmNavigationProperty>();
-            ExpandedPropertiesOnSubChildren = new Dictionary<IEdmStructuralProperty, ExpandedNavigationSelectItem>();
-            ExpandedProperties = new Dictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem>();
-            ReferencedNavigationProperties = new HashSet<IEdmNavigationProperty>();
-            SelectedActions = new HashSet<IEdmAction>();
-            SelectedFunctions = new HashSet<IEdmFunction>();
-            SelectedDynamicProperties = new HashSet<string>();
         }
 
         /// <summary>
@@ -48,17 +34,31 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         /// <param name="selectExpandNodeToCopy">The instance from which the state for the new instance will be copied.</param>
         public SelectExpandNode(SelectExpandNode selectExpandNodeToCopy)
         {
-            ExpandedPropertiesOnSubChildren = new Dictionary<IEdmStructuralProperty, ExpandedNavigationSelectItem>(selectExpandNodeToCopy.ExpandedPropertiesOnSubChildren);
-            ExpandedProperties = new Dictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem>(selectExpandNodeToCopy.ExpandedProperties);
-            ReferencedNavigationProperties = new HashSet<IEdmNavigationProperty>(selectExpandNodeToCopy.ReferencedNavigationProperties);
+            SelectedStructuralProperties = selectExpandNodeToCopy.SelectedStructuralProperties == null ?
+                null : new HashSet<IEdmStructuralProperty>(selectExpandNodeToCopy.SelectedStructuralProperties);
 
-            SelectedActions = new HashSet<IEdmAction>(selectExpandNodeToCopy.SelectedActions);
+            SelectedComplexes = selectExpandNodeToCopy.SelectedComplexes == null ?
+                null : new Dictionary<IEdmStructuralProperty, PathSelectItem>(selectExpandNodeToCopy.SelectedComplexes);
+
+            SelectedNavigationProperties = selectExpandNodeToCopy.SelectedNavigationProperties == null ?
+                null : new HashSet<IEdmNavigationProperty>(selectExpandNodeToCopy.SelectedNavigationProperties);
+
+            ExpandedProperties = selectExpandNodeToCopy.ExpandedProperties == null ?
+                null : new Dictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem>(selectExpandNodeToCopy.ExpandedProperties);
+
+            ReferencedProperties = selectExpandNodeToCopy.ReferencedProperties == null ?
+                null : new Dictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem>();
+
             SelectAllDynamicProperties = selectExpandNodeToCopy.SelectAllDynamicProperties;
-            SelectedComplexProperties = new HashSet<IEdmStructuralProperty>(selectExpandNodeToCopy.SelectedComplexProperties);
-            SelectedDynamicProperties = new HashSet<string>(selectExpandNodeToCopy.SelectedDynamicProperties);
-            SelectedFunctions = new HashSet<IEdmFunction>(selectExpandNodeToCopy.SelectedFunctions);
-            SelectedNavigationProperties = new HashSet<IEdmNavigationProperty>(selectExpandNodeToCopy.SelectedNavigationProperties);
-            SelectedStructuralProperties = new HashSet<IEdmStructuralProperty>(selectExpandNodeToCopy.SelectedStructuralProperties);
+
+            SelectedDynamicProperties = selectExpandNodeToCopy.SelectedDynamicProperties == null ?
+                null : new HashSet<string>(selectExpandNodeToCopy.SelectedDynamicProperties);
+
+            SelectedActions = selectExpandNodeToCopy.SelectedActions == null ?
+                null : new HashSet<IEdmAction>(selectExpandNodeToCopy.SelectedActions);
+
+            SelectedFunctions = selectExpandNodeToCopy.SelectedFunctions == null ?
+                null : new HashSet<IEdmFunction>(selectExpandNodeToCopy.SelectedFunctions);
         }
 
         /// <summary>
@@ -71,8 +71,6 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         public SelectExpandNode(IEdmStructuredType structuredType, ODataSerializerContext writeContext)
             : this()
         {
-            Property = writeContext.EdmProperty;
-            PropertiesInPath = writeContext.PropertiesInPath;
             Initialize(writeContext.SelectExpandClause, structuredType, writeContext.Model, writeContext.ExpandReference);
         }
 
@@ -84,24 +82,102 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         /// <param name="structuredType">The structural type of the resource that would be written.</param>
         /// <param name="model">The <see cref="IEdmModel"/> that contains the given structural type.</param>
         public SelectExpandNode(SelectExpandClause selectExpandClause, IEdmStructuredType structuredType, IEdmModel model)
-            : this(selectExpandClause, structuredType, model, false)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new instance of the <see cref="SelectExpandNode"/> class describing the set of structural properties,
-        /// nested properties, navigation properties, and actions to select and expand for the given <paramref name="selectExpandClause"/>.
-        /// </summary>
-        /// <param name="selectExpandClause">The parsed $select and $expand query options.</param>
-        /// <param name="structuredType">The structural type of the resource that would be written.</param>
-        /// <param name="model">The <see cref="IEdmModel"/> that contains the given structural type.</param>
-        /// <param name="expandedReference">a boolean value indicating whether it's expanded reference.</param>
-        internal SelectExpandNode(SelectExpandClause selectExpandClause, IEdmStructuredType structuredType, IEdmModel model, bool expandedReference)
             : this()
         {
             Initialize(selectExpandClause, structuredType, model, false);
         }
 
+        /// <summary>
+        /// Gets the list of EDM navigation properties to be expand referenced in the response.
+        /// keeping this is only for non-breaking changes, This should be replaced by "ReferencedProperties" later.
+        /// </summary>
+        public ISet<IEdmNavigationProperty> ReferencedNavigationProperties
+        {
+            get
+            {
+                if (ReferencedProperties == null)
+                {
+                    return null;
+                }
+
+                return new HashSet<IEdmNavigationProperty>(ReferencedProperties.Keys);
+            }
+        }
+
+        /// <summary>
+        /// Gets the list of EDM nested properties (complex or collection of complex) to be included in the response.
+        /// keeping this is only for non-breaking changes, This should be replaced by "SelectedComplexes".
+        /// </summary>
+        public ISet<IEdmStructuralProperty> SelectedComplexProperties
+        {
+            get
+            {
+                if (SelectedComplexes == null)
+                {
+                    return null;
+                }
+
+                return new HashSet<IEdmStructuralProperty>(SelectedComplexes.Keys);
+            }
+        }
+
+        /// <summary>
+        /// Gets the list of EDM structural properties (primitive, enum or collection of them) to be included in the response.
+        /// It could be null if there's no property selected.
+        /// </summary>
+        public ISet<IEdmStructuralProperty> SelectedStructuralProperties { get; internal set; }
+
+        /// <summary>
+        /// Gets the list of EDM navigation properties to be included as links in the response. It could be null.
+        /// </summary>
+        public ISet<IEdmNavigationProperty> SelectedNavigationProperties { get; internal set; }
+
+        /// <summary>
+        /// Gets the list of Edm structural properties (complex or complex collection) to be included in the response.
+        /// The key is the Edm structural property.
+        /// The value is the potential sub select item.
+        /// </summary>
+        public IDictionary<IEdmStructuralProperty, PathSelectItem> SelectedComplexes { get; internal set; }
+
+        /// <summary>
+        /// Gets the list of EDM navigation properties to be expanded in the response along with the nested query options embedded in the expand.
+        /// It could be null if no navigation property to expand.
+        /// </summary>
+        public IDictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem> ExpandedProperties { get; internal set; }
+
+        /// <summary>
+        /// Gets the list of EDM navigation properties to be referenced in the response along with the nested query options embedded in the expand.
+        /// It could be null if no navigation property to reference.
+        /// </summary>
+        public IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> ReferencedProperties { get; internal set; }
+
+        /// <summary>s
+        /// Gets the list of dynamic properties to select. It could be null.
+        /// </summary>
+        public ISet<string> SelectedDynamicProperties { get; internal set; }
+
+        /// <summary>
+        /// Gets the flag to indicate the dynamic property to be included in the response or not.
+        /// </summary>
+        public bool SelectAllDynamicProperties { get; internal set; }
+
+        /// <summary>
+        /// Gets the list of OData actions to be included in the response. It could be null.
+        /// </summary>
+        public ISet<IEdmAction> SelectedActions { get; internal set; }
+
+        /// <summary>
+        /// Gets the list of OData functions to be included in the response. It could be null.
+        /// </summary>
+        public ISet<IEdmFunction> SelectedFunctions { get; internal set; }
+
+        /// <summary>
+        /// Initialize the Node from <see cref="SelectExpandClause"/> for the given <see cref="IEdmStructuredType"/>.
+        /// </summary>
+        /// <param name="selectExpandClause">The input select and expand clause ($select and $expand).</param>
+        /// <param name="structuredType">The related structural type to select and expand.</param>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="expandedReference">Is expanded reference.</param>
         private void Initialize(SelectExpandClause selectExpandClause, IEdmStructuredType structuredType, IEdmModel model, bool expandedReference)
         {
             if (structuredType == null)
@@ -113,9 +189,6 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             {
                 throw Error.ArgumentNull("model");
             }
-
-            // So far, it includes all properties of primitive, enum and collection of them
-            HashSet<IEdmStructuralProperty> allStructuralProperties = new HashSet<IEdmStructuralProperty>();
 
             IEdmEntityType entityType = structuredType as IEdmEntityType;
             if (expandedReference)
@@ -129,338 +202,78 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             }
             else
             {
-                // So far, it includes all properties of complex and collection of complex
-                HashSet<IEdmStructuralProperty> allComplexStructuralProperties = new HashSet<IEdmStructuralProperty>();
-                GetStructuralProperties(structuredType, allStructuralProperties, allComplexStructuralProperties);
-
-                // So far, it includes all navigation properties
-                HashSet<IEdmNavigationProperty> allNavigationProperties;
-                HashSet<IEdmAction> allActions;
-                HashSet<IEdmFunction> allFunctions;
-                IEnumerable<SelectItem> selectItems = new List<SelectItem>();
-
-                if (entityType != null)
-                {
-                    allNavigationProperties = new HashSet<IEdmNavigationProperty>(entityType.NavigationProperties());
-                    allActions = new HashSet<IEdmAction>(model.GetAvailableActions(entityType));
-                    allFunctions = new HashSet<IEdmFunction>(model.GetAvailableFunctions(entityType));
-                }
-                else if (structuredType != null)
-                {
-                    allNavigationProperties = new HashSet<IEdmNavigationProperty>(structuredType.NavigationProperties());
-                    
-                    // Currently, the library does not support for bounded operations on complex type. 
-                    allActions = new HashSet<IEdmAction>();
-                    allFunctions = new HashSet<IEdmFunction>();
-                }
-                else
-                {
-                    allNavigationProperties = new HashSet<IEdmNavigationProperty>();
-                    allActions = new HashSet<IEdmAction>();
-                    allFunctions = new HashSet<IEdmFunction>();
-                }
+                EdmStructuralTypeInfo structuralTypeInfo = new EdmStructuralTypeInfo(model, structuredType);
 
                 if (selectExpandClause == null)
                 {
-                    SelectedStructuralProperties = allStructuralProperties;
-                    SelectedComplexProperties = allComplexStructuralProperties;
-                    SelectedNavigationProperties = allNavigationProperties;
-                    SelectedActions = allActions;
-                    SelectedFunctions = allFunctions;
                     SelectAllDynamicProperties = true;
+
+                    // includes primitive, enum, complex or collection of them
+                    SelectedNavigationProperties = structuralTypeInfo.AllNavigationProperties;
+
+                    // includes all bound actions
+                    SelectedActions = structuralTypeInfo.AllActions;
+
+                    // includes all bound functions
+                    SelectedFunctions = structuralTypeInfo.AllFunctions;
+
+                    // includes all structural properties
+                    if (structuralTypeInfo.AllStructuralProperties != null)
+                    {
+                        foreach (var property in structuralTypeInfo.AllStructuralProperties)
+                        {
+                            AddStructuralProperty(property, null);
+                        }
+                    }
                 }
                 else
                 {
-                    if (selectExpandClause.AllSelected)
-                    {
-                        SelectedStructuralProperties = allStructuralProperties;
-                        SelectedComplexProperties = allComplexStructuralProperties;
-                        SelectedNavigationProperties = allNavigationProperties;
-                        SelectedActions = allActions;
-                        SelectedFunctions = allFunctions;
-                        SelectAllDynamicProperties = true;
-                    }
-                    else
-                    {
-                        // Explicitly set SelectAllDynamicProperties as false, while the BuildSelections method will set it as true
-                        // if it meets the select all condition.
-                        SelectAllDynamicProperties = false;
-                        BuildSelections(selectExpandClause, allStructuralProperties, allComplexStructuralProperties, allNavigationProperties, allActions, allFunctions);
-                    }
-
-                    selectItems = selectExpandClause.SelectedItems;
+                    BuildSelectExpand(selectExpandClause, structuralTypeInfo);
                 }
 
-                BuildExpansions(selectItems, allNavigationProperties);
-
-                // remove expanded navigation properties from the selected navigation properties.
-                SelectedNavigationProperties.ExceptWith(ExpandedProperties.Keys);
-
-                // remove referenced navigation properties from the selected navigation properties.
-                SelectedNavigationProperties.ExceptWith(ReferencedNavigationProperties);
+                AdjustSelectNavigationProperties();
             }
         }
 
         /// <summary>
-        /// Gets the list of EDM structural properties (primitive, enum or collection of them) to be included in the response.
+        /// Build $select and $expand clause
         /// </summary>
-        public ISet<IEdmStructuralProperty> SelectedStructuralProperties { get; private set; }
-
-        /// <summary>
-        /// Gets the list of EDM navigation properties to be included as links in the response. It is deprecated in favor of ExpandedProperties
-        /// </summary>
-        public ISet<IEdmNavigationProperty> SelectedNavigationProperties { get; private set; }
-
-        /// <summary>
-        /// Gets the list of EDM navigation properties to be expanded in the response.
-        /// </summary>
-        [Obsolete("This property is deprecated in favor of ExpandedProperties as this property only contains a subset of the information.")]
-        public IDictionary<IEdmNavigationProperty, SelectExpandClause> ExpandedNavigationProperties
+        /// <param name="selectExpandClause">The select expand clause</param>
+        /// <param name="structuralTypeInfo">The structural type properties.</param>
+        private void BuildSelectExpand(SelectExpandClause selectExpandClause, EdmStructuralTypeInfo structuralTypeInfo)
         {
-            get
+            Contract.Assert(selectExpandClause != null);
+            Contract.Assert(structuralTypeInfo != null);
+
+            var currentLevelPropertiesInclude = new Dictionary<IEdmStructuralProperty, SelectExpandIncludeProperty>();
+
+            // Explicitly set SelectAllDynamicProperties as false,
+            // Below will re-set it as true if it meets the select all condition.
+            SelectAllDynamicProperties = false;
+            foreach (SelectItem selectItem in selectExpandClause.SelectedItems)
             {
-                if (this.cachedExpandedClauses == null)
-                {
-                    this.cachedExpandedClauses = ExpandedProperties.ToDictionary(item => item.Key,
-                        item => item.Value != null ? item.Value.SelectAndExpand : null);
-                }
-
-                return this.cachedExpandedClauses;
-            }
-        }
-
-        /// <summary>
-        /// Gets the list of EDM navigation properties to be expanded in the response along with the nested query options embedded in the expand.
-        /// </summary>
-        public IDictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem> ExpandedProperties { get; private set; }
-
-        /// <summary>
-        /// Gets the list of EDM navigation properties to be expand referenced in the response.
-        /// </summary>
-        public ISet<IEdmNavigationProperty> ReferencedNavigationProperties { get; private set; }
-
-        /// <summary>
-        /// Gets the list of EDM navigation properties to be expanded on ComplexTypes in the response.
-        /// </summary>
-        internal IDictionary<IEdmStructuralProperty, ExpandedNavigationSelectItem> ExpandedPropertiesOnSubChildren { get; private set; }
-
-        /// <summary>
-        /// Gets the list of EDM nested properties (complex or collection of complex) to be included in the response.
-        /// </summary>
-        public ISet<IEdmStructuralProperty> SelectedComplexProperties { get; private set; }
-
-        /// <summary>
-        /// Gets the list of dynamic properties to select.
-        /// </summary>
-        public ISet<string> SelectedDynamicProperties { get; private set; }
-
-        /// <summary>
-        /// Gets the flag to indicate the dynamic property to be included in the response or not.
-        /// </summary>
-        public bool SelectAllDynamicProperties { get; private set; }
-
-        /// <summary>
-        /// Gets the list of OData actions to be included in the response.
-        /// </summary>
-        public ISet<IEdmAction> SelectedActions { get; private set; }
-
-        /// <summary>
-        /// Gets the list of OData functions to be included in the response.
-        /// </summary>
-        public ISet<IEdmFunction> SelectedFunctions { get; private set; }
-
-        /// <summary>
-        /// Gets the path to property corresponding to the SelectExpandNode. Null for a top-level select expand.
-        /// </summary>
-        internal Queue<IEdmProperty> PropertiesInPath { get; private set; }
-
-        /// <summary>
-        /// Gets the property corresponding to the SelectExpandNode. Null for a top-level select expand.
-        /// </summary>
-        internal IEdmProperty Property { get; private set; }
-
-        private void BuildExpansions(IEnumerable<SelectItem> selectedItems, HashSet<IEdmNavigationProperty> allNavigationProperties)
-        {
-            foreach (SelectItem selectItem in selectedItems)
-            {
+                // $expand=...
                 ExpandedReferenceSelectItem expandReferenceItem = selectItem as ExpandedReferenceSelectItem;
                 if (expandReferenceItem != null)
                 {
-                    ValidatePathIsSupportedForExpand(expandReferenceItem.PathToNavigationProperty);
-                    NavigationPropertySegment navigationSegment = (NavigationPropertySegment)expandReferenceItem.PathToNavigationProperty.LastSegment;
-                    IEdmNavigationProperty navigationProperty = navigationSegment.NavigationProperty;
-
-                    int propertyCountInPath =
-                        expandReferenceItem.PathToNavigationProperty.OfType<PropertySegment>().Count();
-
-                    bool numberOfPropertiesInPathMatch =
-                        (propertyCountInPath > 0 && PropertiesInPath != null &&
-                         PropertiesInPath.Count == propertyCountInPath) || propertyCountInPath < 1;
-
-                    if (numberOfPropertiesInPathMatch && allNavigationProperties.Contains(navigationProperty))
-                    {
-                        ExpandedNavigationSelectItem expandItem = selectItem as ExpandedNavigationSelectItem;
-                        if (expandItem != null)
-                        {
-                            if (!ExpandedProperties.ContainsKey(navigationProperty))
-                            {
-                                ExpandedProperties.Add(navigationProperty, expandItem);
-                            }
-                            else
-                            {
-                                ExpandedProperties[navigationProperty] = expandItem;
-                            }
-                        }
-                        else
-                        {
-                            ReferencedNavigationProperties.Add(navigationProperty);
-                        }
-                    }
-                    else
-                    {
-                        //This is the case where the navigation property is not on the current type. We need to propagate the expand item to deeper SelectExpandNode.
-                        IEdmStructuralProperty complexProperty = FindNextPropertySegment(expandReferenceItem.PathToNavigationProperty);
-
-                        if (complexProperty != null)
-                        {
-                            SelectExpandClause newClause;
-                            if (ExpandedPropertiesOnSubChildren.ContainsKey(complexProperty))
-                            {
-                                SelectExpandClause oldClause = ExpandedPropertiesOnSubChildren[complexProperty].SelectAndExpand;
-                                newClause = new SelectExpandClause(
-                                    oldClause.SelectedItems.Concat(new SelectItem[] { expandReferenceItem }), false);
-                                ExpandedNavigationSelectItem newItem = new ExpandedNavigationSelectItem(expandReferenceItem.PathToNavigationProperty, navigationSegment.NavigationSource, newClause);
-                                ExpandedPropertiesOnSubChildren[complexProperty] = newItem;
-                            }
-                            else
-                            {
-                                newClause = new SelectExpandClause(new SelectItem[] { expandReferenceItem }, false);
-                                ExpandedNavigationSelectItem newItem = new ExpandedNavigationSelectItem(expandReferenceItem.PathToNavigationProperty, navigationSegment.NavigationSource, newClause);
-                                ExpandedPropertiesOnSubChildren.Add(complexProperty, newItem);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Finds the appropriate property segment which should be responsible for propagating the expand item.
-        /// For instance, if we are creating the SelectExpandNode for property p2 for the query ~/EnitySet/Key/p1/p2/p3?$expand=NP, we want to return property p3 here.
-        /// </summary>
-        private IEdmStructuralProperty FindNextPropertySegment(ODataPath path)
-        {
-            IEdmStructuralProperty complexProperty = null;
-            // If the current SelectExpandNode is not top-level and has a property associated with it then return the next property segment from the path.
-            if (Property != null)
-            {
-                Debug.Assert(PropertiesInPath != null, "PropertiesInPath should not be null if Property is not null");
-                Queue<IEdmProperty> propertyQueue = new Queue<IEdmProperty>(PropertiesInPath);
-
-                foreach (ODataPathSegment segment in path)
-                {
-                    PropertySegment propertySegment = segment as PropertySegment;
-                    if (propertySegment != null)
-                    {
-                        complexProperty = propertySegment.Property;
-                        if (propertyQueue.Count == 0)
-                        {
-                            break;
-                        }
-
-                        if (propertyQueue.Peek().Name == complexProperty.Name)
-                        {
-                            propertyQueue.Dequeue();
-                        }
-                        else
-                        {
-                            return null;
-                        }
-                    }
-                }
-            }
-            else
-            {
-                // Return the first property if top-level resource
-                PropertySegment segment = path.OfType<PropertySegment>().FirstOrDefault();
-                if (segment != null)
-                {
-                    complexProperty = segment.Property;
-                }
-            }
-
-            return complexProperty;
-        }
-
-        private void BuildSelections(
-            SelectExpandClause selectExpandClause,
-            HashSet<IEdmStructuralProperty> allStructuralProperties,
-            HashSet<IEdmStructuralProperty> allNestedProperties,
-            HashSet<IEdmNavigationProperty> allNavigationProperties,
-            HashSet<IEdmAction> allActions,
-            HashSet<IEdmFunction> allFunctions)
-        {
-            foreach (SelectItem selectItem in selectExpandClause.SelectedItems)
-            {
-                if (selectItem is ExpandedNavigationSelectItem)
-                {
+                    BuildExpandItem(expandReferenceItem, currentLevelPropertiesInclude, structuralTypeInfo);
                     continue;
                 }
 
                 PathSelectItem pathSelectItem = selectItem as PathSelectItem;
                 if (pathSelectItem != null)
                 {
-                    ValidatePathIsSupportedForSelect(pathSelectItem.SelectedPath);
-                    ODataPathSegment segment = pathSelectItem.SelectedPath.LastSegment;
-
-                    NavigationPropertySegment navigationPropertySegment = segment as NavigationPropertySegment;
-                    if (navigationPropertySegment != null)
-                    {
-                        IEdmNavigationProperty navigationProperty = navigationPropertySegment.NavigationProperty;
-                        if (allNavigationProperties.Contains(navigationProperty))
-                        {
-                            SelectedNavigationProperties.Add(navigationProperty);
-                        }
-                        continue;
-                    }
-
-                    PropertySegment structuralPropertySegment = segment as PropertySegment;
-                    if (structuralPropertySegment != null)
-                    {
-                        IEdmStructuralProperty structuralProperty = structuralPropertySegment.Property;
-                        if (allStructuralProperties.Contains(structuralProperty))
-                        {
-                            SelectedStructuralProperties.Add(structuralProperty);
-                        }
-                        else if (allNestedProperties.Contains(structuralProperty))
-                        {
-                            SelectedComplexProperties.Add(structuralProperty);
-                        }
-                        continue;
-                    }
-
-                    OperationSegment operationSegment = segment as OperationSegment;
-                    if (operationSegment != null)
-                    {
-                        AddOperations(allActions, allFunctions, operationSegment);
-                        continue;
-                    }
-
-                    DynamicPathSegment dynamicPathSegment = segment as DynamicPathSegment;
-                    if (dynamicPathSegment != null)
-                    {
-                        SelectedDynamicProperties.Add(dynamicPathSegment.Identifier);
-                        continue;
-                    }
-                    throw new ODataException(Error.Format(SRResources.SelectionTypeNotSupported, segment.GetType().Name));
+                    // $select=abc/.../xyz
+                    BuildSelectItem(pathSelectItem, currentLevelPropertiesInclude, structuralTypeInfo);
+                    continue;
                 }
 
                 WildcardSelectItem wildCardSelectItem = selectItem as WildcardSelectItem;
                 if (wildCardSelectItem != null)
                 {
-                    SelectedStructuralProperties = allStructuralProperties;
-                    SelectedComplexProperties = allNestedProperties;
-                    SelectedNavigationProperties = allNavigationProperties;
+                    // $select=*
+                    MergeAllStructuralProperties(structuralTypeInfo.AllStructuralProperties, currentLevelPropertiesInclude);
+                    MergeSelectedNavigationProperties(structuralTypeInfo.AllNavigationProperties);
                     SelectAllDynamicProperties = true;
                     continue;
                 }
@@ -468,79 +281,392 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 NamespaceQualifiedWildcardSelectItem wildCardActionSelection = selectItem as NamespaceQualifiedWildcardSelectItem;
                 if (wildCardActionSelection != null)
                 {
-                    SelectedActions = allActions;
-                    SelectedFunctions = allFunctions;
+                    // $select=NS.*
+                    AddNamespaceWildcardOperation(wildCardActionSelection, structuralTypeInfo.AllActions, structuralTypeInfo.AllFunctions);
                     continue;
                 }
 
                 throw new ODataException(Error.Format(SRResources.SelectionTypeNotSupported, selectItem.GetType().Name));
             }
+
+            if (selectExpandClause.AllSelected)
+            {
+                MergeAllStructuralProperties(structuralTypeInfo.AllStructuralProperties, currentLevelPropertiesInclude);
+                MergeSelectedNavigationProperties(structuralTypeInfo.AllNavigationProperties);
+                MergeSelectedAction(structuralTypeInfo.AllActions);
+                MergeSelectedFunction(structuralTypeInfo.AllFunctions);
+                SelectAllDynamicProperties = true;
+            }
+
+            // at least to make sure the structural properties are in the same order of the order defined in the type.
+            foreach (var structuralProperty in structuralTypeInfo.AllStructuralProperties)
+            {
+                SelectExpandIncludeProperty includeProperty;
+                if (!currentLevelPropertiesInclude.TryGetValue(structuralProperty, out includeProperty))
+                {
+                    continue;
+                }
+
+                PathSelectItem pathSelectItem = includeProperty == null ? null : includeProperty.ToPathSelectItem();
+                AddStructuralProperty(structuralProperty, pathSelectItem);
+            }
         }
 
-        private void AddOperations(HashSet<IEdmAction> allActions, HashSet<IEdmFunction> allFunctions, OperationSegment operationSegment)
+        /// <summary>
+        /// Build the $expand item, it maybe $expand=nav, $expand=complex/nav, $expand=nav/$ref, etc.
+        /// </summary>
+        /// <param name="expandReferenceItem">The expanded reference select item.</param>
+        /// <param name="currentLevelPropertiesInclude">The current properties to include at current level.</param>
+        /// <param name="structuralTypeInfo">The structural type properties.</param>
+        private void BuildExpandItem(ExpandedReferenceSelectItem expandReferenceItem,
+            IDictionary<IEdmStructuralProperty, SelectExpandIncludeProperty> currentLevelPropertiesInclude,
+            EdmStructuralTypeInfo structuralTypeInfo)
+        {
+            Contract.Assert(expandReferenceItem != null && expandReferenceItem.PathToNavigationProperty != null);
+            Contract.Assert(currentLevelPropertiesInclude != null);
+            Contract.Assert(structuralTypeInfo != null);
+
+            // Verify and process the $expand=abc/xyz/nav.
+            ODataExpandPath expandPath = expandReferenceItem.PathToNavigationProperty;
+            IList<ODataPathSegment> remainingSegments;
+            ODataPathSegment segment = expandPath.GetFirstNonTypeCastSegment(out remainingSegments);
+
+            PropertySegment firstPropertySegment = segment as PropertySegment;
+            if (firstPropertySegment != null)
+            {
+                // for example: $expand=abc/xyz/nav, the remaining segment can't be null
+                // because at least the last navigation property segment is there.
+                Contract.Assert(remainingSegments != null);
+
+                if (structuralTypeInfo.IsStructuralPropertyDefined(firstPropertySegment.Property))
+                {
+                    SelectExpandIncludeProperty newPropertySelectItem;
+                    if (!currentLevelPropertiesInclude.TryGetValue(firstPropertySegment.Property, out newPropertySelectItem))
+                    {
+                        newPropertySelectItem = new SelectExpandIncludeProperty(firstPropertySegment);
+                        currentLevelPropertiesInclude[firstPropertySegment.Property] = newPropertySelectItem;
+                    }
+
+                    newPropertySelectItem.AddSubExpandItem(remainingSegments, expandReferenceItem);
+                }
+            }
+            else
+            {
+                // for example: $expand=nav, or $expand=NS.SubType/nav, the navigation property segment should be the last segment.
+                // So, the remaining segments should be null.
+                Contract.Assert(remainingSegments == null);
+
+                NavigationPropertySegment firstNavigationSegment = segment as NavigationPropertySegment;
+                Contract.Assert(firstNavigationSegment != null);
+
+                if (structuralTypeInfo.IsNavigationPropertyDefined(firstNavigationSegment.NavigationProperty))
+                {
+                    // It's not allowed to have mulitple navigation expanded or referenced.
+                    // for example: "$expand=nav($top=2),nav($skip=3)" is not allowed and will be merged (or throw exception) at ODL side.
+                    ExpandedNavigationSelectItem expanded = expandReferenceItem as ExpandedNavigationSelectItem;
+                    if (expanded != null)
+                    {
+                        if (ExpandedProperties == null)
+                        {
+                            ExpandedProperties = new Dictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem>();
+                        }
+
+                        ExpandedProperties[firstNavigationSegment.NavigationProperty] = expanded;
+                    }
+                    else
+                    {
+                        // $expand=..../nav/$ref
+                        if (ReferencedProperties == null)
+                        {
+                            ReferencedProperties = new Dictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem>();
+                        }
+
+                        ReferencedProperties[firstNavigationSegment.NavigationProperty] = expandReferenceItem;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Build the $select item, it maybe $select=complex/abc, $select=abc, $select=nav, etc.
+        /// </summary>
+        /// <param name="pathSelectItem">The expanded reference select item.</param>
+        /// <param name="currentLevelPropertiesInclude">The current properties to include at current level.</param>
+        /// <param name="structuralTypeInfo">The structural type properties.</param>
+        private void BuildSelectItem(PathSelectItem pathSelectItem,
+            IDictionary<IEdmStructuralProperty, SelectExpandIncludeProperty> currentLevelPropertiesInclude,
+            EdmStructuralTypeInfo structuralTypeInfo)
+        {
+            Contract.Assert(pathSelectItem != null && pathSelectItem.SelectedPath != null);
+            Contract.Assert(currentLevelPropertiesInclude != null);
+            Contract.Assert(structuralTypeInfo != null);
+
+            // Verify and process the $select=abc/xyz/....
+            ODataSelectPath selectPath = pathSelectItem.SelectedPath;
+            IList<ODataPathSegment> remainingSegments;
+            ODataPathSegment segment = selectPath.GetFirstNonTypeCastSegment(out remainingSegments);
+
+            PropertySegment firstPropertySegment = segment as PropertySegment;
+            if (firstPropertySegment != null)
+            {
+                if (structuralTypeInfo.IsStructuralPropertyDefined(firstPropertySegment.Property))
+                {
+                    // $select=abc/xyz/...
+                    SelectExpandIncludeProperty newPropertySelectItem;
+                    if (!currentLevelPropertiesInclude.TryGetValue(firstPropertySegment.Property, out newPropertySelectItem))
+                    {
+                        newPropertySelectItem = new SelectExpandIncludeProperty(firstPropertySegment);
+                        currentLevelPropertiesInclude[firstPropertySegment.Property] = newPropertySelectItem;
+                    }
+
+                    newPropertySelectItem.AddSubSelectItem(remainingSegments, pathSelectItem);
+                }
+
+                return;
+            }
+
+            // If the first segment is not a property segment,
+            // that segment must be the last segment, so the remainging segments should be null.
+            Contract.Assert(remainingSegments == null);
+
+            NavigationPropertySegment navigationSegment = segment as NavigationPropertySegment;
+            if (navigationSegment != null)
+            {
+                // for example: $select=NavigationProperty or $select=NS.VipCustomer/VipNav
+                if (structuralTypeInfo.IsNavigationPropertyDefined(navigationSegment.NavigationProperty))
+                {
+                    if (SelectedNavigationProperties == null)
+                    {
+                        SelectedNavigationProperties = new HashSet<IEdmNavigationProperty>();
+                    }
+
+                    SelectedNavigationProperties.Add(navigationSegment.NavigationProperty);
+                }
+
+                return;
+            }
+
+            OperationSegment operationSegment = segment as OperationSegment;
+            if (operationSegment != null)
+            {
+                // for example: $select=NS.Operation, or, $select=NS.VipCustomer/NS.Operation
+                AddOperations(operationSegment, structuralTypeInfo.AllActions, structuralTypeInfo.AllFunctions);
+                return;
+            }
+
+            DynamicPathSegment dynamicPathSegment = segment as DynamicPathSegment;
+            if (dynamicPathSegment != null)
+            {
+                if (SelectedDynamicProperties == null)
+                {
+                    SelectedDynamicProperties = new HashSet<string>();
+                }
+
+                SelectedDynamicProperties.Add(dynamicPathSegment.Identifier);
+                return;
+            }
+
+            // In fact, we should never be here, because it's verified above
+            throw new ODataException(Error.Format(SRResources.SelectionTypeNotSupported, segment.GetType().Name));
+        }
+
+        private static void MergeAllStructuralProperties(ISet<IEdmStructuralProperty> allStructuralProperties,
+            IDictionary<IEdmStructuralProperty, SelectExpandIncludeProperty> currentLevelPropertiesInclude)
+        {
+            if (allStructuralProperties == null)
+            {
+                return;
+            }
+
+            Contract.Assert(currentLevelPropertiesInclude != null);
+
+            foreach (var property in allStructuralProperties)
+            {
+                if (!currentLevelPropertiesInclude.ContainsKey(property))
+                {
+                    // Set the value as null is safe, because this property should not further process.
+                    // Besides, if there's "WildcardSelectItem", there's no other property selection items.
+                    currentLevelPropertiesInclude[property] = null;
+                }
+            }
+        }
+
+        private void MergeSelectedNavigationProperties(ISet<IEdmNavigationProperty> allNavigationProperties)
+        {
+            if (allNavigationProperties == null)
+            {
+                return;
+            }
+
+            if (SelectedNavigationProperties == null)
+            {
+                SelectedNavigationProperties = allNavigationProperties;
+            }
+            else
+            {
+                SelectedNavigationProperties.UnionWith(allNavigationProperties);
+            }
+        }
+
+        private void MergeSelectedAction(ISet<IEdmAction> allActions)
+        {
+            if (allActions == null)
+            {
+                return;
+            }
+
+            if (SelectedActions == null)
+            {
+                SelectedActions = allActions;
+            }
+            else
+            {
+                SelectedActions.UnionWith(allActions);
+            }
+        }
+
+        private void MergeSelectedFunction(ISet<IEdmFunction> allFunctions)
+        {
+            if (allFunctions == null)
+            {
+                return;
+            }
+
+            if (SelectedFunctions == null)
+            {
+                SelectedFunctions = allFunctions;
+            }
+            else
+            {
+                SelectedFunctions.UnionWith(allFunctions);
+            }
+        }
+
+        private void AddStructuralProperty(IEdmStructuralProperty structuralProperty, PathSelectItem pathSelectItem)
+        {
+            bool isComplexOrCollectComplex = IsComplexOrCollectionComplex(structuralProperty);
+
+            if (isComplexOrCollectComplex)
+            {
+                if (SelectedComplexes == null)
+                {
+                    SelectedComplexes = new Dictionary<IEdmStructuralProperty, PathSelectItem>();
+                }
+
+                SelectedComplexes[structuralProperty] = pathSelectItem;
+            }
+            else
+            {
+                if (SelectedStructuralProperties == null)
+                {
+                    SelectedStructuralProperties = new HashSet<IEdmStructuralProperty>();
+                }
+
+                // for primitive, enum and collection them, needn't care about the nested query options now.
+                // So, skip the path select item.
+                SelectedStructuralProperties.Add(structuralProperty);
+            }
+        }
+
+        private void AddNamespaceWildcardOperation(NamespaceQualifiedWildcardSelectItem namespaceSelectItem, ISet<IEdmAction> allActions,
+            ISet<IEdmFunction> allFunctions)
+        {
+            if (allActions == null)
+            {
+                SelectedActions = null;
+            }
+            else
+            {
+                SelectedActions = new HashSet<IEdmAction>(allActions.Where(a => a.Namespace == namespaceSelectItem.Namespace));
+            }
+
+            if (allFunctions == null)
+            {
+                SelectedFunctions = null;
+            }
+            else
+            {
+                SelectedFunctions = new HashSet<IEdmFunction>(allFunctions.Where(a => a.Namespace == namespaceSelectItem.Namespace));
+            }
+        }
+
+        private void AddOperations(OperationSegment operationSegment, ISet<IEdmAction> allActions, ISet<IEdmFunction> allFunctions)
         {
             foreach (IEdmOperation operation in operationSegment.Operations)
             {
                 IEdmAction action = operation as IEdmAction;
                 if (action != null && allActions.Contains(action))
                 {
+                    if (SelectedActions == null)
+                    {
+                        SelectedActions = new HashSet<IEdmAction>();
+                    }
+
                     SelectedActions.Add(action);
                 }
 
                 IEdmFunction function = operation as IEdmFunction;
                 if (function != null && allFunctions.Contains(function))
                 {
+                    if (SelectedFunctions == null)
+                    {
+                        SelectedFunctions = new HashSet<IEdmFunction>();
+                    }
+
                     SelectedFunctions.Add(function);
                 }
             }
         }
-        // we only support paths of type 'cast/structuralOrNavPropertyOrAction' and 'structuralOrNavPropertyOrAction'.
-        internal static void ValidatePathIsSupportedForSelect(ODataPath path)
+
+        private void AdjustSelectNavigationProperties()
         {
-            int segmentCount = path.Count();
-
-            if (segmentCount > 2)
+            if (SelectedNavigationProperties != null)
             {
-                throw new ODataException(SRResources.UnsupportedSelectExpandPath);
-            }
-
-            if (segmentCount == 2)
-            {
-                if (!(path.FirstSegment is TypeSegment))
+                // remove expanded navigation properties from the selected navigation properties.
+                if (ExpandedProperties != null)
                 {
-                    throw new ODataException(SRResources.UnsupportedSelectExpandPath);
+                    SelectedNavigationProperties.ExceptWith(ExpandedProperties.Keys);
+                }
+
+                // remove referenced navigation properties from the selected navigation properties.
+                if (ReferencedProperties != null)
+                {
+                    SelectedNavigationProperties.ExceptWith(ReferencedProperties.Keys);
                 }
             }
 
-            ODataPathSegment lastSegment = path.LastSegment;
-            if (!(lastSegment is NavigationPropertySegment
-                || lastSegment is PropertySegment
-                || lastSegment is OperationSegment
-                || lastSegment is DynamicPathSegment))
+            if (SelectedNavigationProperties != null && !SelectedNavigationProperties.Any())
             {
-                throw new ODataException(SRResources.UnsupportedSelectExpandPath);
+                SelectedNavigationProperties = null;
             }
         }
 
-        // we support paths of type 'cast/structuralOrNavPropertyOrAction', 'ComplexObject/cast/StructuralOrNavPropertyOnAction', 'ComplexObject/structuralOrNavPropertyOnAction' and 'structuralOrNavPropertyOrAction'.
-        internal static void ValidatePathIsSupportedForExpand(ODataPath path)
+        /// <summary>
+        /// Test whether the input structural property is complex property or collection of complex property.
+        /// </summary>
+        /// <param name="structuralProperty">The test structural property.</param>
+        /// <returns>True/false.</returns>
+        internal static bool IsComplexOrCollectionComplex(IEdmStructuralProperty structuralProperty)
         {
-            ODataPathSegment lastSegment = path.LastSegment;
-            foreach (ODataPathSegment segment in path)
+            if (structuralProperty == null)
             {
-                if (!(segment is TypeSegment || segment is PropertySegment || (segment == lastSegment)))
+                return false;
+            }
+
+            if (structuralProperty.Type.IsComplex())
+            {
+                return true;
+            }
+
+            if (structuralProperty.Type.IsCollection())
+            {
+                if (structuralProperty.Type.AsCollection().ElementType().IsComplex())
                 {
-                    throw new ODataException(SRResources.UnsupportedSelectExpandPath);
+                    return true;
                 }
             }
 
-            if (!(lastSegment is NavigationPropertySegment
-                  || lastSegment is PropertySegment
-                  || lastSegment is OperationSegment
-                  || lastSegment is DynamicPathSegment))
-            {
-                throw new ODataException(SRResources.UnsupportedSelectExpandPath);
-            }
+            return false;
         }
 
         /// <summary>
@@ -554,6 +680,9 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         public static void GetStructuralProperties(IEdmStructuredType structuredType, HashSet<IEdmStructuralProperty> structuralProperties,
             HashSet<IEdmStructuralProperty> nestedStructuralProperties)
         {
+            // Be noted: this method is not used anymore. Keeping it unremoved is only for non-breaking changes.
+            // If any new requirement for such method, it's better to move to "EdmLibHelpers" class.
+
             if (structuredType == null)
             {
                 throw Error.ArgumentNull("structuredType");
@@ -590,6 +719,98 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 {
                     structuralProperties.Add(edmStructuralProperty);
                 }
+            }
+        }
+
+        /// <summary>
+        /// An internal cache class used to provide the propert, operations
+        /// and do verification on the given <see cref="IEdmStructuredType"/>.
+        /// </summary>
+        internal class EdmStructuralTypeInfo
+        {
+            /// <summary>
+            /// Gets all structural properties defined on the structure type.
+            /// </summary>
+            public ISet<IEdmStructuralProperty> AllStructuralProperties { get; }
+
+            /// <summary>
+            /// Gets all navigation properties defined on the structure type.
+            /// </summary>
+            public ISet<IEdmNavigationProperty> AllNavigationProperties { get; }
+
+            /// <summary>
+            /// Gets all actions bonding to the structure type.
+            /// </summary>
+            public ISet<IEdmAction> AllActions { get; }
+
+            /// <summary>
+            /// Gets all function bonding to the structure type.
+            /// </summary>
+            public ISet<IEdmFunction> AllFunctions { get; }
+
+            /// <summary>
+            /// Creates a new instance of the <see cref="EdmStructuralTypeInfo"/> class
+            /// </summary>
+            /// <param name="model">The Edm model.</param>
+            /// <param name="structuredType">The Edm structured Type.</param>
+            public EdmStructuralTypeInfo(IEdmModel model, IEdmStructuredType structuredType)
+            {
+                Contract.Assert(model != null);
+                Contract.Assert(structuredType != null);
+
+                foreach (var edmProperty in structuredType.Properties())
+                {
+                    switch (edmProperty.PropertyKind)
+                    {
+                        case EdmPropertyKind.Structural:
+                            if (AllStructuralProperties == null)
+                            {
+                                AllStructuralProperties = new HashSet<IEdmStructuralProperty>();
+                            }
+
+                            AllStructuralProperties.Add((IEdmStructuralProperty)edmProperty);
+                            break;
+
+                        case EdmPropertyKind.Navigation:
+                            if (AllNavigationProperties == null)
+                            {
+                                AllNavigationProperties = new HashSet<IEdmNavigationProperty>();
+                            }
+
+                            AllNavigationProperties.Add((IEdmNavigationProperty)edmProperty);
+                            break;
+                    }
+                }
+
+                IEdmEntityType entityType = structuredType as IEdmEntityType;
+                if (entityType != null)
+                {
+                    var actions = model.GetAvailableActions(entityType);
+                    AllActions = actions.Any() ? new HashSet<IEdmAction>(actions) : null;
+
+                    var functions = model.GetAvailableFunctions(entityType);
+                    AllFunctions = functions.Any() ? new HashSet<IEdmFunction>(functions) : null;
+                }
+            }
+
+            /// <summary>
+            /// Tests whether a <see cref="IEdmStructuralProperty"/> is defined on this type.
+            /// </summary>
+            /// <param name="property">The test property.</param>
+            /// <returns>True/false</returns>
+            public bool IsStructuralPropertyDefined(IEdmStructuralProperty property)
+            {
+                return AllStructuralProperties != null && AllStructuralProperties.Contains(property);
+            }
+
+            /// <summary>
+            /// Tests whether a <see cref="IEdmNavigationProperty"/> is defined on this type.
+            /// </summary>
+            /// <param name="property">The test property.</param>
+            /// <returns>True/false</returns>
+            public bool IsNavigationPropertyDefined(IEdmNavigationProperty property)
+            {
+                return AllNavigationProperties != null && AllNavigationProperties.Contains(property);
             }
         }
     }

--- a/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
+++ b/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
@@ -235,6 +235,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\NamedPropertyExpression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\PropertyContainer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandBinder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandPathExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandIncludeProperty.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\ModelContainer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandWrapperConverter.cs" />

--- a/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
+++ b/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
@@ -236,7 +236,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\PropertyContainer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandBinder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandPathExtensions.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandIncludeProperty.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandIncludedProperty.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\ModelContainer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandWrapperConverter.cs" />

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -315,7 +315,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 ISet<IEdmStructuralProperty> autoSelectedProperties;
 
                 bool isContainDynamicPropertySelection = GetSelectExpandProperties(_model, structuredType, navigationSource, selectExpandClause,
-                    out propertiesToInclude, 
+                    out propertiesToInclude,
                     out propertiesToExpand,
                     out autoSelectedProperties);
 

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
@@ -11,7 +10,6 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Formatter;
-using Microsoft.AspNet.OData.Formatter.Serialization;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
@@ -21,77 +19,73 @@ namespace Microsoft.AspNet.OData.Query.Expressions
     /// <summary>
     /// Applies the given <see cref="SelectExpandQueryOption"/> to the given <see cref="IQueryable"/>.
     /// </summary>
-    [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling",
-        Justification = "Class coupling acceptable.")]
+    [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "Class coupling acceptable.")]
     internal class SelectExpandBinder
     {
-        private SelectExpandQueryOption _selectExpandQuery;
         private ODataQueryContext _context;
         private IEdmModel _model;
         private ODataQuerySettings _settings;
         private string _modelID;
 
-        public SelectExpandBinder(ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
+        public SelectExpandBinder(ODataQuerySettings settings, ODataQueryContext context)
         {
             Contract.Assert(settings != null);
-            Contract.Assert(selectExpandQuery != null);
-            Contract.Assert(selectExpandQuery.Context != null);
-            Contract.Assert(selectExpandQuery.Context.Model != null);
+            Contract.Assert(context != null);
+            Contract.Assert(context.Model != null);
             Contract.Assert(settings.HandleNullPropagation != HandleNullPropagationOption.Default);
 
-            _selectExpandQuery = selectExpandQuery;
-            _context = selectExpandQuery.Context;
+            _context = context;
             _model = _context.Model;
             _modelID = ModelContainer.GetModelID(_model);
             _settings = settings;
         }
 
-        public static IQueryable Bind(IQueryable queryable, ODataQuerySettings settings,
-            SelectExpandQueryOption selectExpandQuery)
+        public static IQueryable Bind(IQueryable queryable, ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
         {
             Contract.Assert(queryable != null);
+            Contract.Assert(selectExpandQuery != null);
 
-            SelectExpandBinder binder = new SelectExpandBinder(settings, selectExpandQuery);
-            return binder.Bind(queryable);
+            SelectExpandBinder binder = new SelectExpandBinder(settings, selectExpandQuery.Context);
+            return binder.Bind(queryable, selectExpandQuery);
         }
 
-        public static object Bind(object entity, ODataQuerySettings settings,
-            SelectExpandQueryOption selectExpandQuery)
+        public static object Bind(object entity, ODataQuerySettings settings, SelectExpandQueryOption selectExpandQuery)
         {
             Contract.Assert(entity != null);
+            Contract.Assert(selectExpandQuery != null);
 
-            SelectExpandBinder binder = new SelectExpandBinder(settings, selectExpandQuery);
-            return binder.Bind(entity);
+            SelectExpandBinder binder = new SelectExpandBinder(settings, selectExpandQuery.Context);
+            return binder.Bind(entity, selectExpandQuery);
         }
 
-        private object Bind(object entity)
+        private object Bind(object entity, SelectExpandQueryOption selectExpandQuery)
         {
-            Contract.Assert(entity != null);
-
-            LambdaExpression projectionLambda = GetProjectionLambda();
+            // Needn't to verify the input, that's done at upper level.
+            LambdaExpression projectionLambda = GetProjectionLambda(selectExpandQuery);
 
             // TODO: cache this ?
             return projectionLambda.Compile().DynamicInvoke(entity);
         }
 
-        private IQueryable Bind(IQueryable queryable)
+        private IQueryable Bind(IQueryable queryable, SelectExpandQueryOption selectExpandQuery)
         {
-            Type elementType = _selectExpandQuery.Context.ElementClrType;
+            // Needn't to verify the input, that's done at upper level.
+            Type elementType = selectExpandQuery.Context.ElementClrType;
 
-            LambdaExpression projectionLambda = GetProjectionLambda();
+            LambdaExpression projectionLambda = GetProjectionLambda(selectExpandQuery);
 
             MethodInfo selectMethod = ExpressionHelperMethods.QueryableSelectGeneric.MakeGenericMethod(elementType, projectionLambda.Body.Type);
             return selectMethod.Invoke(null, new object[] { queryable, projectionLambda }) as IQueryable;
         }
 
-        private LambdaExpression GetProjectionLambda()
+        private LambdaExpression GetProjectionLambda(SelectExpandQueryOption selectExpandQuery)
         {
-            Type elementType = _selectExpandQuery.Context.ElementClrType;
-            IEdmNavigationSource navigationSource = _selectExpandQuery.Context.NavigationSource;
+            Type elementType = selectExpandQuery.Context.ElementClrType;
+            IEdmNavigationSource navigationSource = selectExpandQuery.Context.NavigationSource;
             ParameterExpression source = Expression.Parameter(elementType);
 
             // expression looks like -> new Wrapper { Instance = source , Properties = "...", Container = new PropertyContainer { ... } }
-            Expression projectionExpression = ProjectElement(source, _selectExpandQuery.SelectExpandClause, _context.ElementType as IEdmStructuredType, navigationSource);
+            Expression projectionExpression = ProjectElement(source, selectExpandQuery.SelectExpandClause, _context.ElementType as IEdmStructuredType, navigationSource);
 
             // expression looks like -> source => new Wrapper { Instance = source .... }
             LambdaExpression projectionLambdaExpression = Expression.Lambda(projectionExpression, source);
@@ -100,20 +94,24 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         }
 
         internal Expression ProjectAsWrapper(Expression source, SelectExpandClause selectExpandClause,
-            IEdmEntityType entityType, IEdmNavigationSource navigationSource, ExpandedReferenceSelectItem expandedItem = null,
+            IEdmStructuredType structuredType, IEdmNavigationSource navigationSource, OrderByClause orderByClause = null,
+            long? topOption = null,
+            long? skipOption = null,
             int? modelBoundPageSize = null)
         {
             Type elementType;
             if (TypeHelper.IsCollection(source.Type, out elementType))
             {
                 // new CollectionWrapper<ElementType> { Instance = source.Select(s => new Wrapper { ... }) };
-                return ProjectCollection(source, elementType, selectExpandClause, entityType, navigationSource, expandedItem,
+                return ProjectCollection(source, elementType, selectExpandClause, structuredType, navigationSource, orderByClause,
+                    topOption,
+                    skipOption,
                     modelBoundPageSize);
             }
             else
             {
                 // new Wrapper { v1 = source.property ... }
-                return ProjectElement(source, selectExpandClause, entityType, navigationSource);
+                return ProjectElement(source, selectExpandClause, structuredType, navigationSource);
             }
         }
 
@@ -123,11 +121,9 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             Contract.Assert(property != null);
             Contract.Assert(source != null);
 
-            IEdmStructuredType declaringType = property.DeclaringType as IEdmStructuredType;
+            IEdmStructuredType declaringType = property.DeclaringType;
 
-            Contract.Assert(declaringType != null, "Unstructured types cannot be projected.");
-
-            // derived navigation property using cast
+            // derived property using cast
             if (elementType != declaringType)
             {
                 Type originalType = EdmLibHelpers.GetClrType(elementType, _model);
@@ -153,94 +149,25 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             return Expression.Constant(property.Name);
         }
 
-        internal Expression CreatePropertyValueExpression(IEdmStructuredType elementType, IEdmProperty property, Expression source)
+        internal Expression CreatePropertyValueExpression(IEdmStructuredType elementType, IEdmProperty property, Expression source, FilterClause filterClause)
         {
             Contract.Assert(elementType != null);
             Contract.Assert(property != null);
             Contract.Assert(source != null);
 
-            return CreatePropertyValueExpressionWithFilter(elementType, property, source, null);
-        }
-
-        internal Expression CreatePropertyValueExpressionWithFilter(IEdmStructuredType elementType, IEdmProperty property,
-    Expression source, ExpandedReferenceSelectItem expandItem)
-        {
-            Contract.Assert(elementType != null);
-            Contract.Assert(property != null);
-            Contract.Assert(source != null);
-
-            FilterClause filterClause = expandItem != null ? expandItem.FilterOption : null;
-
-            IEdmStructuredType declaringType;
-            IEdmStructuredType currentType = elementType;
-            if (expandItem != null)
-            {
-                foreach (ODataPathSegment segment in expandItem.PathToNavigationProperty)
-                {
-                    string currentProperty = String.Empty;
-                    PropertySegment propertyAccessPathSegment =
-                         segment as PropertySegment;
-                    if (propertyAccessPathSegment != null)
-                    {
-                        IEdmProperty propertyInPath = propertyAccessPathSegment.Property;
-                        currentProperty = EdmLibHelpers.GetClrPropertyName(propertyInPath, _model);
-                        declaringType = propertyInPath.DeclaringType;
-                        Contract.Assert(!String.IsNullOrEmpty(currentProperty), "Property name could not be found on the model.");
-                        if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
-                        {
-                            // create expression similar to: 'source == null ? null : propertyValue'
-                            if (declaringType != currentType)
-                            {
-                                Type castType = EdmLibHelpers.GetClrType(property.DeclaringType, _model);
-                                if (castType == null)
-                                {
-                                    throw new ODataException(Error.Format(SRResources.MappingDoesNotContainResourceType,
-                                        property.DeclaringType.FullTypeName()));
-                                }
-
-                                source = Expression.TypeAs(source, castType);
-                            }
-                            Expression propertyExpression = Expression.Property(source, currentProperty);
-                            Type nullablePropType = TypeHelper.ToNullable(propertyExpression.Type);
-
-                            source = Expression.Condition(
-                                test: Expression.Equal(propertyExpression, Expression.Constant(value: null)),
-                                ifTrue: Expression.Constant(value: null, type: nullablePropType),
-                                ifFalse: propertyExpression);
-                        }
-                        else
-                        {
-                            source = Expression.Property(source, currentProperty);
-                        }
-
-                        currentType = propertyInPath.Type.ToStructuredType();
-                    }
-                    else
-                    {
-                        TypeSegment typeSegment = segment as TypeSegment;
-                        if (typeSegment != null)
-                        {
-                            Type castType = EdmLibHelpers.GetClrType(typeSegment.EdmType, _model);
-                            source = Expression.TypeAs(source, castType);
-                            currentType = typeSegment.EdmType as IEdmStructuredType;
-                        }
-                    }
-                }
-            }
-
-            // derived property using cast
-            if (currentType != property.DeclaringType)
+            // Expression: source = source as propertyDeclaringType
+            if (elementType != property.DeclaringType)
             {
                 Type castType = EdmLibHelpers.GetClrType(property.DeclaringType, _model);
                 if (castType == null)
                 {
-                    throw new ODataException(Error.Format(SRResources.MappingDoesNotContainResourceType,
-                        property.DeclaringType.FullTypeName()));
+                    throw new ODataException(Error.Format(SRResources.MappingDoesNotContainResourceType, property.DeclaringType.FullTypeName()));
                 }
 
                 source = Expression.TypeAs(source, castType);
             }
 
+            // Expression:  source.Property
             string propertyName = EdmLibHelpers.GetClrPropertyName(property, _model);
             PropertyInfo propertyInfo = source.Type.GetProperty(propertyName);
             Expression propertyValue = Expression.Property(source, propertyInfo);
@@ -255,8 +182,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 Type clrElementType = EdmLibHelpers.GetClrType(edmElementType, _model);
                 if (clrElementType == null)
                 {
-                    throw new ODataException(Error.Format(SRResources.MappingDoesNotContainResourceType,
-                        edmElementType.FullName()));
+                    throw new ODataException(Error.Format(SRResources.MappingDoesNotContainResourceType, edmElementType.FullName()));
                 }
 
                 Expression filterResult = nullablePropertyValue;
@@ -284,8 +210,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                     LambdaExpression filterLambdaExpression = FilterBinder.Bind(null, filterClause, clrElementType, _context, querySettings) as LambdaExpression;
                     if (filterLambdaExpression == null)
                     {
-                        throw new ODataException(Error.Format(SRResources.ExpandFilterExpressionNotLambdaExpression,
-                            property.Name, "LambdaExpression"));
+                        throw new ODataException(Error.Format(SRResources.ExpandFilterExpressionNotLambdaExpression, property.Name, "LambdaExpression"));
                     }
 
                     ParameterExpression filterParameter = filterLambdaExpression.Parameters.First();
@@ -329,33 +254,17 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             return propertyValue;
         }
 
-        private class ReferenceNavigationPropertyExpandFilterVisitor : ExpressionVisitor
-        {
-            private Expression _source;
-            private ParameterExpression _parameterExpression;
-
-            public ReferenceNavigationPropertyExpandFilterVisitor(ParameterExpression parameterExpression, Expression source)
-            {
-                _source = source;
-                _parameterExpression = parameterExpression;
-            }
-
-            protected override Expression VisitParameter(ParameterExpression node)
-            {
-                if (node != _parameterExpression)
-                {
-                    throw new ODataException(Error.Format(SRResources.ReferenceNavigationPropertyExpandFilterVisitorUnexpectedParameter, node.Name));
-                }
-
-                return _source;
-            }
-        }
-
         // Generates the expression
         //      source => new Wrapper { Instance = source, Container = new PropertyContainer { ..expanded properties.. } }
-        private Expression ProjectElement(Expression source, SelectExpandClause selectExpandClause, IEdmStructuredType structuredType, IEdmNavigationSource navigationSource)
+        internal Expression ProjectElement(Expression source, SelectExpandClause selectExpandClause, IEdmStructuredType structuredType, IEdmNavigationSource navigationSource)
         {
             Contract.Assert(source != null);
+
+            // If it's not a structural type, just return the source.
+            if (structuredType == null)
+            {
+                return source;
+            }
 
             Type elementType = source.Type;
             Type wrapperType = typeof(SelectExpandWrapper<>).MakeGenericType(elementType);
@@ -401,16 +310,21 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             // source => new Wrapper { Container =  new PropertyContainer { .... } }
             if (selectExpandClause != null)
             {
-                Dictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand = GetPropertiesToExpandInQuery(selectExpandClause);
+                IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude;
+                IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand;
                 ISet<IEdmStructuralProperty> autoSelectedProperties;
 
-                ISet<IEdmStructuralProperty> propertiesToInclude = GetPropertiesToIncludeInQuery(selectExpandClause, structuredType, navigationSource, _model, out autoSelectedProperties);
-                bool isSelectingOpenTypeSegments = GetSelectsOpenTypeSegments(selectExpandClause, structuredType);
+                bool isContainDynamicPropertySelection = GetSelectExpandProperties(_model, structuredType, navigationSource, selectExpandClause,
+                    out propertiesToInclude, 
+                    out propertiesToExpand,
+                    out autoSelectedProperties);
 
-                if (propertiesToExpand.Count > 0 || propertiesToInclude.Count > 0 || autoSelectedProperties.Count > 0 || isSelectingOpenTypeSegments)
+                bool isSelectingOpenTypeSegments = isContainDynamicPropertySelection || IsSelectsOpenTypeSegments(selectExpandClause, structuredType);
+
+                if (propertiesToExpand != null || propertiesToInclude != null || autoSelectedProperties != null || isSelectingOpenTypeSegments)
                 {
                     Expression propertyContainerCreation =
-                        BuildPropertyContainer(structuredType, source, propertiesToExpand, propertiesToInclude, autoSelectedProperties, isSelectingOpenTypeSegments);
+                        BuildPropertyContainer(source, structuredType, propertiesToExpand, propertiesToInclude, autoSelectedProperties, isSelectingOpenTypeSegments);
 
                     if (propertyContainerCreation != null)
                     {
@@ -428,7 +342,223 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             return Expression.MemberInit(Expression.New(wrapperType), wrapperTypeMemberAssignments);
         }
 
-        private static bool GetSelectsOpenTypeSegments(SelectExpandClause selectExpandClause, IEdmStructuredType structuredType)
+        /// <summary>
+        /// Gets the $select and $expand properties from the given <see cref="SelectExpandClause"/>
+        /// </summary>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="structuredType">The current structural type.</param>
+        /// <param name="navigationSource">The current navigation source.</param>
+        /// <param name="selectExpandClause">The given select and expand clause.</param>
+        /// <param name="propertiesToInclude">The out properties to include at current level, could be null.</param>
+        /// <param name="propertiesToExpand">The out properties to expand at current level, could be null.</param>
+        /// <param name="autoSelectedProperties">The out auto selected properties to include at current level, could be null.</param>
+        /// <returns>true if the select contains dynamic property selection, false if it's not.</returns>
+        internal static bool GetSelectExpandProperties(IEdmModel model, IEdmStructuredType structuredType, IEdmNavigationSource navigationSource,
+            SelectExpandClause selectExpandClause,
+            out IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude,
+            out IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand,
+            out ISet<IEdmStructuralProperty> autoSelectedProperties)
+        {
+            Contract.Assert(selectExpandClause != null);
+
+            // Properties to be included includes all the properties selected or in the middle of a $select and $expand path.
+            // for example: "$expand=abc/xyz/nav", "abc" and "xyz" are the middle properties that should be included.
+            // meanwhile, "nav" is the property that should be expanded.
+            // If it's a type cast path, for example: $select=NS.TypeCast/abc, "abc" should be included also.
+            propertiesToInclude = null;
+            propertiesToExpand = null;
+            autoSelectedProperties = null;
+
+            bool isContainDynamicPropertySelect = false;
+            var currentLevelPropertiesInclude = new Dictionary<IEdmStructuralProperty, SelectExpandIncludeProperty>();
+            foreach (SelectItem selectItem in selectExpandClause.SelectedItems)
+            {
+                // $expand=...
+                ExpandedReferenceSelectItem expandedItem = selectItem as ExpandedReferenceSelectItem;
+                if (expandedItem != null)
+                {
+                    ProcessExpandedItem(expandedItem, navigationSource, currentLevelPropertiesInclude, ref propertiesToExpand);
+                    continue;
+                }
+
+                // $select=...
+                PathSelectItem pathItem = selectItem as PathSelectItem;
+                if (pathItem != null)
+                {
+                    if (ProcessSelectedItem(pathItem, navigationSource, currentLevelPropertiesInclude))
+                    {
+                        isContainDynamicPropertySelect = true;
+                    }
+                    continue;
+                }
+
+                // Skip processing the "WildcardSelectItem and NamespaceQualifiedWildcardSelectItem"
+                // ODL now doesn't support "$select=property/*" and "$select=property/NS.*"
+            }
+
+            if (!IsSelectAll(selectExpandClause))
+            {
+                // We should include the keys if it's an entity.
+                IEdmEntityType entityType = structuredType as IEdmEntityType;
+                if (entityType != null)
+                {
+                    foreach (IEdmStructuralProperty keyProperty in entityType.Key())
+                    {
+                        if (!currentLevelPropertiesInclude.Keys.Contains(keyProperty))
+                        {
+                            if (autoSelectedProperties == null)
+                            {
+                                autoSelectedProperties = new HashSet<IEdmStructuralProperty>();
+                            }
+
+                            autoSelectedProperties.Add(keyProperty);
+                        }
+                    }
+                }
+
+                // We should add concurrency properties, if not added
+                if (navigationSource != null && model != null)
+                {
+                    IEnumerable<IEdmStructuralProperty> concurrencyProperties = model.GetConcurrencyProperties(navigationSource);
+                    foreach (IEdmStructuralProperty concurrencyProperty in concurrencyProperties)
+                    {
+                        if (concurrencyProperty.DeclaringType == structuredType &&
+                            !currentLevelPropertiesInclude.Keys.Contains(concurrencyProperty))
+                        {
+                            if (autoSelectedProperties == null)
+                            {
+                                autoSelectedProperties = new HashSet<IEdmStructuralProperty>();
+                            }
+
+                            autoSelectedProperties.Add(concurrencyProperty);
+                        }
+                    }
+                }
+            }
+
+            if (currentLevelPropertiesInclude.Any())
+            {
+                propertiesToInclude = new Dictionary<IEdmStructuralProperty, PathSelectItem>();
+                foreach (var propertiesInclude in currentLevelPropertiesInclude)
+                {
+                    propertiesToInclude[propertiesInclude.Key] = propertiesInclude.Value == null ? null : propertiesInclude.Value.ToPathSelectItem();
+                }
+            }
+
+            return isContainDynamicPropertySelect;
+        }
+
+        /// <summary>
+        /// Process the <see cref="ExpandedReferenceSelectItem"/>.
+        /// </summary>
+        /// <param name="expandedItem">The expaned item.</param>
+        /// <param name="navigationSource">The navigation source.</param>
+        /// <param name="currentLevelPropertiesInclude">The current level properties included.</param>
+        /// <param name="propertiesToExpand">out/ref, the property expanded.</param>
+        private static void ProcessExpandedItem(ExpandedReferenceSelectItem expandedItem,
+            IEdmNavigationSource navigationSource,
+            IDictionary<IEdmStructuralProperty, SelectExpandIncludeProperty> currentLevelPropertiesInclude,
+            ref IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand)
+        {
+            Contract.Assert(expandedItem != null && expandedItem.PathToNavigationProperty != null);
+            Contract.Assert(currentLevelPropertiesInclude != null);
+
+            // Verify and process the $expand=... path.
+            IList<ODataPathSegment> remainingSegments;
+            ODataPathSegment firstNonTypeSegment = expandedItem.PathToNavigationProperty.GetFirstNonTypeCastSegment(out remainingSegments);
+
+            // for $expand=NS.SubType/Nav, we don't care about the leading type segment, because with or without the type segment
+            // the "nav" property value expression should be built into the property container.
+
+            PropertySegment firstStructuralPropertySegment = firstNonTypeSegment as PropertySegment;
+            if (firstStructuralPropertySegment != null)
+            {
+                // for example: $expand=abc/nav, the remaining segments should never be null because at least the last navigation segment is there.
+                Contract.Assert(remainingSegments != null);
+
+                SelectExpandIncludeProperty newPropertySelectItem;
+                if (!currentLevelPropertiesInclude.TryGetValue(firstStructuralPropertySegment.Property, out newPropertySelectItem))
+                {
+                    newPropertySelectItem = new SelectExpandIncludeProperty(firstStructuralPropertySegment, navigationSource);
+                    currentLevelPropertiesInclude[firstStructuralPropertySegment.Property] = newPropertySelectItem;
+                }
+
+                newPropertySelectItem.AddSubExpandItem(remainingSegments, expandedItem);
+            }
+            else
+            {
+                // for example: $expand=nav, if we couldn't find a structural property in the path, it means we get the last navigation segment.
+                // So, the remaing segments should be null and the last segment should be "NavigationPropertySegment".
+                Contract.Assert(remainingSegments == null);
+
+                NavigationPropertySegment firstNavigationPropertySegment = firstNonTypeSegment as NavigationPropertySegment;
+                Contract.Assert(firstNavigationPropertySegment != null);
+
+                // Needn't add this navigation property into the include property.
+                // Because this navigation property will be included separately.
+                if (propertiesToExpand == null)
+                {
+                    propertiesToExpand = new Dictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem>();
+                }
+
+                propertiesToExpand[firstNavigationPropertySegment.NavigationProperty] = expandedItem;
+            }
+        }
+
+        /// <summary>
+        /// Process the <see cref="PathSelectItem"/>.
+        /// </summary>
+        /// <param name="pathSelectItem">The selected item.</param>
+        /// <param name="navigationSource">The navigation source.</param>
+        /// <param name="currentLevelPropertiesInclude">The current level properties included.</param>
+        /// <returns>true if it's dynamic property selection, false if it's not.</returns>
+        private static bool ProcessSelectedItem(PathSelectItem pathSelectItem,
+            IEdmNavigationSource navigationSource,
+            IDictionary<IEdmStructuralProperty, SelectExpandIncludeProperty> currentLevelPropertiesInclude)
+        {
+            Contract.Assert(pathSelectItem != null && pathSelectItem.SelectedPath != null);
+            Contract.Assert(currentLevelPropertiesInclude != null);
+
+            // Verify and process the $select path
+            IList<ODataPathSegment> remainingSegments;
+            ODataPathSegment firstNonTypeSegment = pathSelectItem.SelectedPath.GetFirstNonTypeCastSegment(out remainingSegments);
+
+            // for $select=NS.SubType/Property, we don't care about the leading type segment, because with or without the type segment
+            // the "Property" property value expression should be built into the property container.
+
+            PropertySegment firstSturucturalPropertySegment = firstNonTypeSegment as PropertySegment;
+            if (firstSturucturalPropertySegment != null)
+            {
+                // $select=abc/..../xyz
+                SelectExpandIncludeProperty newPropertySelectItem;
+                if (!currentLevelPropertiesInclude.TryGetValue(firstSturucturalPropertySegment.Property, out newPropertySelectItem))
+                {
+                    newPropertySelectItem = new SelectExpandIncludeProperty(firstSturucturalPropertySegment, navigationSource);
+                    currentLevelPropertiesInclude[firstSturucturalPropertySegment.Property] = newPropertySelectItem;
+                }
+
+                newPropertySelectItem.AddSubSelectItem(remainingSegments, pathSelectItem);
+            }
+            else
+            {
+                // If we can't find a PropertySegment, the $select path maybe selecting an operation, a navigation or dynamic property.
+                // And the remaing segments should be null.
+                Contract.Assert(remainingSegments == null);
+
+                // For operation (action/function), needn't process it.
+                // For navigation property, needn't process it here.
+
+                // For dynamic property, let's test the last segment for this path select item.
+                if (firstNonTypeSegment is DynamicPathSegment)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsSelectsOpenTypeSegments(SelectExpandClause selectExpandClause, IEdmStructuredType structuredType)
         {
             if (structuredType == null || !structuredType.IsOpen)
             {
@@ -440,13 +570,13 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 return true;
             }
 
-            return selectExpandClause.SelectedItems.OfType<PathSelectItem>().Any(x => x.SelectedPath.LastSegment is DynamicPathSegment);
+            return false;
         }
 
-        private Expression CreateTotalCountExpression(Expression source, ExpandedReferenceSelectItem expandItem)
+        private Expression CreateTotalCountExpression(Expression source, bool? countOption)
         {
             Expression countExpression = Expression.Constant(null, typeof(long?));
-            if (expandItem.CountOption == null || !expandItem.CountOption.Value)
+            if (countOption == null || !countOption.Value)
             {
                 return countExpression;
             }
@@ -484,123 +614,268 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             }
         }
 
-        [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "Class coupling acceptable")]
-        private Expression BuildPropertyContainer(IEdmStructuredType elementType, Expression source,
-            Dictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand,
-            ISet<IEdmStructuralProperty> propertiesToInclude, ISet<IEdmStructuralProperty> autoSelectedProperties, bool isSelectingOpenTypeSegments)
+        private Expression BuildPropertyContainer(Expression source, IEdmStructuredType structuredType,
+            IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand,
+            IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude,
+            ISet<IEdmStructuralProperty> autoSelectedProperties,
+            bool isSelectingOpenTypeSegments)
         {
             IList<NamedPropertyExpression> includedProperties = new List<NamedPropertyExpression>();
 
-            foreach (KeyValuePair<IEdmNavigationProperty, ExpandedReferenceSelectItem> kvp in propertiesToExpand)
+            if (propertiesToExpand != null)
             {
-                IEdmNavigationProperty propertyToExpand = kvp.Key;
-                ExpandedReferenceSelectItem expandItem = kvp.Value;
-
-                SelectExpandClause projection = GetOrCreateSelectExpandClause(kvp);
-
-                ModelBoundQuerySettings querySettings = EdmLibHelpers.GetModelBoundQuerySettings(propertyToExpand,
-                    propertyToExpand.ToEntityType(),
-                    _context.Model);
-
-                Expression propertyName = CreatePropertyNameExpression(elementType, propertyToExpand, source);
-                Expression propertyValue = CreatePropertyValueExpressionWithFilter(elementType, propertyToExpand, source,
-                    expandItem);
-                Expression nullCheck = GetNullCheckExpression(propertyToExpand, propertyValue, projection);
-
-                Expression countExpression = CreateTotalCountExpression(propertyValue, expandItem);
-
-                // projection can be null if the expanded navigation property is not further projected or expanded.
-                if (projection != null)
+                foreach (var propertyToExpand in propertiesToExpand)
                 {
-                    int? modelBoundPageSize = querySettings == null ? null : querySettings.PageSize;
-                    propertyValue = ProjectAsWrapper(propertyValue, projection, propertyToExpand.ToEntityType(), expandItem.NavigationSource, expandItem, modelBoundPageSize);
+                    // $expand=abc or $expand=abc/$ref
+                    BuildExpandedProperty(source, structuredType, propertyToExpand.Key, propertyToExpand.Value, includedProperties);
                 }
-
-                NamedPropertyExpression propertyExpression = new NamedPropertyExpression(propertyName, propertyValue);
-                if (projection != null)
-                {
-                    if (!propertyToExpand.Type.IsCollection())
-                    {
-                        propertyExpression.NullCheck = nullCheck;
-                    }
-                    else if (_settings.PageSize.HasValue)
-                    {
-                        propertyExpression.PageSize = _settings.PageSize.Value;
-                    }
-                    else
-                    {
-                        if (querySettings != null && querySettings.PageSize.HasValue)
-                        {
-                            propertyExpression.PageSize = querySettings.PageSize.Value;
-                        }
-                    }
-
-                    propertyExpression.TotalCount = countExpression;
-                    propertyExpression.CountOption = expandItem.CountOption;
-                }
-
-                includedProperties.Add(propertyExpression);
             }
 
-            foreach (IEdmStructuralProperty propertyToInclude in propertiesToInclude)
+            if (propertiesToInclude != null)
             {
-                Expression propertyName = CreatePropertyNameExpression(elementType, propertyToInclude, source);
-                Expression propertyValue = CreatePropertyValueExpression(elementType, propertyToInclude, source);
-                includedProperties.Add(new NamedPropertyExpression(propertyName, propertyValue));
+                foreach (var propertyToInclude in propertiesToInclude)
+                {
+                    // $select=abc($select=...,$filter=...,$compute=...)....
+                    BuildSelectedProperty(source, structuredType, propertyToInclude.Key, propertyToInclude.Value, includedProperties);
+                }
             }
 
-            foreach (IEdmStructuralProperty propertyToInclude in autoSelectedProperties)
+            if (autoSelectedProperties != null)
             {
-                Expression propertyName = CreatePropertyNameExpression(elementType, propertyToInclude, source);
-                Expression propertyValue = CreatePropertyValueExpression(elementType, propertyToInclude, source);
-                includedProperties.Add(new NamedPropertyExpression(propertyName, propertyValue) { AutoSelected = true });
+                foreach (IEdmStructuralProperty propertyToInclude in autoSelectedProperties)
+                {
+                    Expression propertyName = CreatePropertyNameExpression(structuredType, propertyToInclude, source);
+                    Expression propertyValue = CreatePropertyValueExpression(structuredType, propertyToInclude, source, filterClause: null);
+                    includedProperties.Add(new NamedPropertyExpression(propertyName, propertyValue)
+                    {
+                        AutoSelected = true
+                    });
+                }
             }
 
             if (isSelectingOpenTypeSegments)
             {
-                var dynamicPropertyDictionary = EdmLibHelpers.GetDynamicPropertyDictionary(elementType, _model);
-                if (dynamicPropertyDictionary != null)
-                {
-                    Expression propertyName = Expression.Constant(dynamicPropertyDictionary.Name);
-                    Expression propertyValue = Expression.Property(source, dynamicPropertyDictionary.Name);
-                    Expression nullablePropertyValue = ExpressionHelpers.ToNullable(propertyValue);
-                    if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
-                    {
-                        // source == null ? null : propertyValue
-                        propertyValue = Expression.Condition(
-                            test: Expression.Equal(source, Expression.Constant(value: null)),
-                            ifTrue: Expression.Constant(value: null, type: TypeHelper.ToNullable(propertyValue.Type)),
-                            ifFalse: nullablePropertyValue);
-                    }
-                    else
-                    {
-                        propertyValue = nullablePropertyValue;
-                    }
-
-                    includedProperties.Add(new NamedPropertyExpression(propertyName, propertyValue));
-                }
+                BuildDynamicProperty(source, structuredType, includedProperties);
             }
 
             // create a property container that holds all these property names and values.
             return PropertyContainer.CreatePropertyContainer(includedProperties);
         }
 
-        private static SelectExpandClause GetOrCreateSelectExpandClause(KeyValuePair<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertyToExpand)
+        /// <summary>
+        /// Build the navigation property <see cref="IEdmNavigationProperty"/> into the included properties.
+        /// The property name is the navigation property name.
+        /// The property value is the navigation property value from the source and applied the nested query options.
+        /// </summary>
+        /// <param name="source">The source contains the navigation property.</param>
+        /// <param name="structuredType">The structured type or its derived type contains the navigation property.</param>
+        /// <param name="navigationProperty">The expanded navigation property.</param>
+        /// <param name="expandedItem">The expanded navigation select item. It may contain the neste query options.</param>
+        /// <param name="includedProperties">The container to hold the created property.</param>
+        internal void BuildExpandedProperty(Expression source, IEdmStructuredType structuredType,
+            IEdmNavigationProperty navigationProperty, ExpandedReferenceSelectItem expandedItem,
+            IList<NamedPropertyExpression> includedProperties)
+        {
+            Contract.Assert(source != null);
+            Contract.Assert(structuredType != null);
+            Contract.Assert(navigationProperty != null);
+            Contract.Assert(expandedItem != null);
+            Contract.Assert(includedProperties != null);
+
+            IEdmEntityType edmEntityType = navigationProperty.ToEntityType();
+
+            ModelBoundQuerySettings querySettings = EdmLibHelpers.GetModelBoundQuerySettings(navigationProperty, edmEntityType, _model);
+
+            // TODO: Process $apply and $compute in the $expand here, will support later.
+            // $apply=...; $compute=...
+
+            // Expression:
+            //       "navigation property name"
+            Expression propertyName = CreatePropertyNameExpression(structuredType, navigationProperty, source);
+
+            // Expression:
+            //        source.NavigationProperty
+            Expression propertyValue = CreatePropertyValueExpression(structuredType, navigationProperty, source, expandedItem.FilterOption);
+
+            // Sub select and expand could be null if the expanded navigation property is not further projected or expanded.
+            SelectExpandClause subSelectExpandClause = GetOrCreateSelectExpandClause(navigationProperty, expandedItem);
+
+            Expression nullCheck = GetNullCheckExpression(navigationProperty, propertyValue, subSelectExpandClause);
+
+            Expression countExpression = CreateTotalCountExpression(propertyValue, expandedItem.CountOption);
+
+            int? modelBoundPageSize = querySettings == null ? null : querySettings.PageSize;
+            propertyValue = ProjectAsWrapper(propertyValue, subSelectExpandClause, edmEntityType, expandedItem.NavigationSource,
+                expandedItem.OrderByOption, // $orderby=...
+                expandedItem.TopOption, // $top=...
+                expandedItem.SkipOption, // $skip=...
+                modelBoundPageSize);
+
+            NamedPropertyExpression propertyExpression = new NamedPropertyExpression(propertyName, propertyValue);
+            if (subSelectExpandClause != null)
+            {
+                if (!navigationProperty.Type.IsCollection())
+                {
+                    propertyExpression.NullCheck = nullCheck;
+                }
+                else if (_settings.PageSize.HasValue)
+                {
+                    propertyExpression.PageSize = _settings.PageSize.Value;
+                }
+                else
+                {
+                    if (querySettings != null && querySettings.PageSize.HasValue)
+                    {
+                        propertyExpression.PageSize = querySettings.PageSize.Value;
+                    }
+                }
+
+                propertyExpression.TotalCount = countExpression;
+                propertyExpression.CountOption = expandedItem.CountOption;
+            }
+
+            includedProperties.Add(propertyExpression);
+        }
+
+        /// <summary>
+        /// Build the structural property <see cref="IEdmStructuralProperty"/> into the included properties.
+        /// The property name is the structural property name.
+        /// The property value is the structural property value from the source and applied the nested query options.
+        /// </summary>
+        /// <param name="source">The source contains the structural property.</param>
+        /// <param name="structuredType">The structured type or its derived type contains the structural property.</param>
+        /// <param name="structuralProperty">The selected structural property.</param>
+        /// <param name="pathSelectItem">The selected item. It may contain the neste query options and could be null.</param>
+        /// <param name="includedProperties">The container to hold the created property.</param>
+        internal void BuildSelectedProperty(Expression source, IEdmStructuredType structuredType,
+            IEdmStructuralProperty structuralProperty, PathSelectItem pathSelectItem,
+            IList<NamedPropertyExpression> includedProperties)
+        {
+            Contract.Assert(source != null);
+            Contract.Assert(structuredType != null);
+            Contract.Assert(structuralProperty != null);
+            Contract.Assert(includedProperties != null);
+
+            // // Expression:
+            //       "navigation property name"
+            Expression propertyName = CreatePropertyNameExpression(structuredType, structuralProperty, source);
+
+            // Expression:
+            //        source.NavigationProperty
+            Expression propertyValue;
+            if (pathSelectItem == null)
+            {
+                propertyValue = CreatePropertyValueExpression(structuredType, structuralProperty, source, filterClause: null);
+                includedProperties.Add(new NamedPropertyExpression(propertyName, propertyValue));
+                return;
+            }
+
+            SelectExpandClause subSelectExpandClause = pathSelectItem.SelectAndExpand;
+
+            // TODO: Process $compute in the $select ahead.
+            // $compute=...
+
+            propertyValue = CreatePropertyValueExpression(structuredType, structuralProperty, source, pathSelectItem.FilterOption);
+
+            Expression nullCheck = GetNullCheckExpression(structuralProperty, propertyValue, subSelectExpandClause);
+
+            Expression countExpression = CreateTotalCountExpression(propertyValue, pathSelectItem.CountOption);
+
+            // be noted: the property structured type could be null, because the property maybe not a complex property.
+            IEdmStructuredType propertyStructuredType = structuralProperty.Type.ToStructuredType();
+            ModelBoundQuerySettings querySettings = null;
+            if (propertyStructuredType != null)
+            {
+                querySettings = EdmLibHelpers.GetModelBoundQuerySettings(structuralProperty, propertyStructuredType, _context.Model);
+            }
+
+            int? modelBoundPageSize = querySettings == null ? null : querySettings.PageSize;
+            propertyValue = ProjectAsWrapper(propertyValue, subSelectExpandClause, structuralProperty.Type.ToStructuredType(), pathSelectItem.NavigationSource,
+                pathSelectItem.OrderByOption, // $orderby=...
+                pathSelectItem.TopOption, // $top=...
+                pathSelectItem.SkipOption, // $skip=...
+                modelBoundPageSize);
+
+            NamedPropertyExpression propertyExpression = new NamedPropertyExpression(propertyName, propertyValue);
+            if (subSelectExpandClause != null)
+            {
+                if (!structuralProperty.Type.IsCollection())
+                {
+                     propertyExpression.NullCheck = nullCheck;
+                }
+                else if (_settings.PageSize.HasValue)
+                {
+                    propertyExpression.PageSize = _settings.PageSize.Value;
+                }
+                else
+                {
+                    if (querySettings != null && querySettings.PageSize.HasValue)
+                    {
+                        propertyExpression.PageSize = querySettings.PageSize.Value;
+                    }
+                }
+
+                propertyExpression.TotalCount = countExpression;
+                propertyExpression.CountOption = pathSelectItem.CountOption;
+            }
+
+            includedProperties.Add(propertyExpression);
+        }
+
+        /// <summary>
+        /// Build the dynamic properties into the included properties.
+        /// </summary>
+        /// <param name="source">The source contains the dynamic property.</param>
+        /// <param name="structuredType">The structured type contains the dynamic property.</param>
+        /// <param name="includedProperties">The container to hold the created property.</param>
+        internal void BuildDynamicProperty(Expression source, IEdmStructuredType structuredType,
+            IList<NamedPropertyExpression> includedProperties)
+        {
+            Contract.Assert(source != null);
+            Contract.Assert(structuredType != null);
+            Contract.Assert(includedProperties != null);
+
+            PropertyInfo dynamicPropertyDictionary = EdmLibHelpers.GetDynamicPropertyDictionary(structuredType, _model);
+            if (dynamicPropertyDictionary != null)
+            {
+                Expression propertyName = Expression.Constant(dynamicPropertyDictionary.Name);
+                Expression propertyValue = Expression.Property(source, dynamicPropertyDictionary.Name);
+                Expression nullablePropertyValue = ExpressionHelpers.ToNullable(propertyValue);
+                if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
+                {
+                    // source == null ? null : propertyValue
+                    propertyValue = Expression.Condition(
+                        test: Expression.Equal(source, Expression.Constant(value: null)),
+                        ifTrue: Expression.Constant(value: null, type: TypeHelper.ToNullable(propertyValue.Type)),
+                        ifFalse: nullablePropertyValue);
+                }
+                else
+                {
+                    propertyValue = nullablePropertyValue;
+                }
+
+                includedProperties.Add(new NamedPropertyExpression(propertyName, propertyValue));
+            }
+        }
+
+        private static SelectExpandClause GetOrCreateSelectExpandClause(IEdmNavigationProperty navigationProperty, ExpandedReferenceSelectItem expandedItem)
         {
             // for normal $expand=....
-            ExpandedNavigationSelectItem expandNavigationSelectItem = propertyToExpand.Value as ExpandedNavigationSelectItem;
+            ExpandedNavigationSelectItem expandNavigationSelectItem = expandedItem as ExpandedNavigationSelectItem;
             if (expandNavigationSelectItem != null)
             {
                 return expandNavigationSelectItem.SelectAndExpand;
             }
 
-            // for $expand=..../$ref, just includes the keys properties.
+            // for $expand=..../$ref, just includes the keys properties
             IList<SelectItem> selectItems = new List<SelectItem>();
-            foreach (IEdmStructuralProperty keyProperty in propertyToExpand.Key.ToEntityType().Key())
+            foreach (IEdmStructuralProperty keyProperty in navigationProperty.ToEntityType().Key())
             {
                 selectItems.Add(new PathSelectItem(new ODataSelectPath(new PropertySegment(keyProperty))));
             }
 
+            // TODO: Sam, it seems we can only create a "SelectAll==false" and leave the "SelectItems as empty",
+            // because the keys will be included auto-selected.
             return new SelectExpandClause(selectItems, false);
         }
 
@@ -622,6 +897,23 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             return source;
         }
 
+        private static Expression GetNullCheckExpression(IEdmStructuralProperty propertyToInclude, Expression propertyValue,
+            SelectExpandClause projection)
+        {
+            if (projection == null || propertyToInclude.Type.IsCollection())
+            {
+                return null;
+            }
+
+            if (IsSelectAll(projection) && propertyToInclude.Type.IsComplex())
+            {
+                // for Collections (Primitive, Enum, Complex collection), that's check above.
+                return Expression.Equal(propertyValue, Expression.Constant(null));
+            }
+
+            return null;
+        }
+
         private Expression GetNullCheckExpression(IEdmNavigationProperty propertyToExpand, Expression propertyValue,
             SelectExpandClause projection)
         {
@@ -638,7 +930,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             Expression keysNullCheckExpression = null;
             foreach (var key in propertyToExpand.ToEntityType().Key())
             {
-                var propertyValueExpression = CreatePropertyValueExpressionWithFilter(propertyToExpand.ToEntityType(), key, propertyValue, null);
+                var propertyValueExpression = CreatePropertyValueExpression(propertyToExpand.ToEntityType(), key, propertyValue, filterClause: null);
                 var keyExpression = Expression.Equal(
                     propertyValueExpression,
                     Expression.Constant(null, propertyValueExpression.Type));
@@ -652,77 +944,98 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         }
 
         // new CollectionWrapper<ElementType> { Instance = source.Select((ElementType element) => new Wrapper { }) }
-        private Expression ProjectCollection(Expression source, Type elementType, SelectExpandClause selectExpandClause, IEdmEntityType entityType, IEdmNavigationSource navigationSource, ExpandedReferenceSelectItem expandedItem, int? modelBoundPageSize)
+        private Expression ProjectCollection(Expression source, Type elementType,
+            SelectExpandClause selectExpandClause, IEdmStructuredType structuredType, IEdmNavigationSource navigationSource,
+            OrderByClause orderByClause,
+            long? topOption,
+            long? skipOption,
+            int? modelBoundPageSize)
         {
+            // structuralType could be null, because it can be primitive collection.
+
             ParameterExpression element = Expression.Parameter(elementType);
 
+            Expression projection;
             // expression
             //      new Wrapper { }
-            Expression projection = ProjectElement(element, selectExpandClause, entityType, navigationSource);
+            if (structuredType != null)
+            {
+                projection = ProjectElement(element, selectExpandClause, structuredType, navigationSource);
+            }
+            else
+            {
+                projection = element;
+            }
 
             // expression
             //      (ElementType element) => new Wrapper { }
             LambdaExpression selector = Expression.Lambda(projection, element);
 
-            if (expandedItem != null)
+            if (orderByClause != null)
             {
-                source = AddOrderByQueryForSource(source, expandedItem.OrderByOption, elementType);
+                source = AddOrderByQueryForSource(source, orderByClause, elementType);
             }
 
-            if (_settings.PageSize.HasValue || modelBoundPageSize.HasValue ||
-                (expandedItem != null && (expandedItem.TopOption.HasValue || expandedItem.SkipOption.HasValue)))
-            {
-                // nested paging. Need to apply order by first, and take one more than page size as we need to know
-                // whether the collection was truncated or not while generating next page links.
-                IEnumerable<IEdmStructuralProperty> properties =
-                    entityType.Key().Any()
-                        ? entityType.Key()
-                        : entityType
-                            .StructuralProperties()
-                            .Where(property => property.Type.IsPrimitive() && !property.Type.IsStream())
-                            .OrderBy(property => property.Name);
+            bool hasTopValue = topOption != null && topOption.HasValue;
+            bool hasSkipvalue = skipOption != null && skipOption.HasValue;
 
-                if (expandedItem == null || expandedItem.OrderByOption == null)
+            IEdmEntityType entityType = structuredType as IEdmEntityType;
+            if (entityType != null)
+            {
+                if (_settings.PageSize.HasValue || modelBoundPageSize.HasValue || hasTopValue || hasSkipvalue)
                 {
-                    bool alreadyOrdered = false;
-                    foreach (var prop in properties)
+                    // nested paging. Need to apply order by first, and take one more than page size as we need to know
+                    // whether the collection was truncated or not while generating next page links.
+                    IEnumerable<IEdmStructuralProperty> properties =
+                        entityType.Key().Any()
+                            ? entityType.Key()
+                            : entityType
+                                .StructuralProperties()
+                                .Where(property => property.Type.IsPrimitive() && !property.Type.IsStream())
+                                .OrderBy(property => property.Name);
+
+                    if (orderByClause == null)
                     {
-                        source = ExpressionHelpers.OrderByPropertyExpression(source, prop.Name, elementType,
-                            alreadyOrdered);
-                        if (!alreadyOrdered)
+                        bool alreadyOrdered = false;
+                        foreach (var prop in properties)
                         {
-                            alreadyOrdered = true;
+                            source = ExpressionHelpers.OrderByPropertyExpression(source, prop.Name, elementType,
+                                alreadyOrdered);
+                            if (!alreadyOrdered)
+                            {
+                                alreadyOrdered = true;
+                            }
                         }
                     }
                 }
+            }
 
-                if (expandedItem != null && expandedItem.SkipOption.HasValue)
+            if (hasSkipvalue)
+            {
+                Contract.Assert(skipOption.Value <= Int32.MaxValue);
+                source = ExpressionHelpers.Skip(source, (int)skipOption.Value, elementType,
+                    _settings.EnableConstantParameterization);
+            }
+
+            if (hasTopValue)
+            {
+                Contract.Assert(topOption.Value <= Int32.MaxValue);
+                source = ExpressionHelpers.Take(source, (int)topOption.Value, elementType,
+                    _settings.EnableConstantParameterization);
+            }
+
+            // don't page nested collections if EnableCorrelatedSubqueryBuffering is enabled
+            if (!_settings.EnableCorrelatedSubqueryBuffering)
+            {
+                if (_settings.PageSize.HasValue)
                 {
-                    Contract.Assert(expandedItem.SkipOption.Value <= Int32.MaxValue);
-                    source = ExpressionHelpers.Skip(source, (int)expandedItem.SkipOption.Value, elementType,
+                    source = ExpressionHelpers.Take(source, _settings.PageSize.Value + 1, elementType,
                         _settings.EnableConstantParameterization);
                 }
-
-                if (expandedItem != null && expandedItem.TopOption.HasValue)
+                else if (_settings.ModelBoundPageSize.HasValue)
                 {
-                    Contract.Assert(expandedItem.TopOption.Value <= Int32.MaxValue);
-                    source = ExpressionHelpers.Take(source, (int)expandedItem.TopOption.Value, elementType,
+                    source = ExpressionHelpers.Take(source, modelBoundPageSize.Value + 1, elementType,
                         _settings.EnableConstantParameterization);
-                }
-
-                // don't page nested collections if EnableCorrelatedSubqueryBuffering is enabled
-                if (expandedItem == null || !_settings.EnableCorrelatedSubqueryBuffering)
-                {
-                    if (_settings.PageSize.HasValue)
-                    {
-                        source = ExpressionHelpers.Take(source, _settings.PageSize.Value + 1, elementType,
-                            _settings.EnableConstantParameterization);
-                    }
-                    else if (_settings.ModelBoundPageSize.HasValue)
-                    {
-                        source = ExpressionHelpers.Take(source, modelBoundPageSize.Value + 1, elementType,
-                            _settings.EnableConstantParameterization);
-                    }
                 }
             }
 
@@ -776,9 +1089,9 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                     }
 
                     expression = Expression.Condition(
-                                    test: Expression.TypeIs(source, clrType),
-                                    ifTrue: Expression.Constant(derivedTypes[i].FullTypeName()),
-                                    ifFalse: expression);
+                        test: Expression.TypeIs(source, clrType),
+                        ifTrue: Expression.Constant(derivedTypes[i].FullTypeName()),
+                        ifFalse: expression);
                 }
 
                 return expression;
@@ -828,94 +1141,6 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             return ExpressionHelperMethods.EnumerableSelectGeneric.MakeGenericMethod(elementType, resultType);
         }
 
-        private static Dictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> GetPropertiesToExpandInQuery(SelectExpandClause selectExpandClause)
-        {
-            Dictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> properties = new Dictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem>();
-
-            foreach (SelectItem selectItem in selectExpandClause.SelectedItems)
-            {
-                ExpandedReferenceSelectItem expandItem = selectItem as ExpandedReferenceSelectItem;
-                if (expandItem != null)
-                {
-                    SelectExpandNode.ValidatePathIsSupportedForExpand(expandItem.PathToNavigationProperty);
-                    NavigationPropertySegment navigationSegment = expandItem.PathToNavigationProperty.LastSegment as NavigationPropertySegment;
-                    if (navigationSegment == null)
-                    {
-                        throw new ODataException(SRResources.UnsupportedSelectExpandPath);
-                    }
-
-                    properties[navigationSegment.NavigationProperty] = expandItem;
-                }
-            }
-
-            return properties;
-        }
-
-        private static ISet<IEdmStructuralProperty> GetPropertiesToIncludeInQuery(
-            SelectExpandClause selectExpandClause, IEdmStructuredType structuredType, IEdmNavigationSource navigationSource, IEdmModel model, out ISet<IEdmStructuralProperty> autoSelectedProperties)
-        {
-            IEdmEntityType entityType = structuredType as IEdmEntityType;
-
-            autoSelectedProperties = new HashSet<IEdmStructuralProperty>();
-            HashSet<IEdmStructuralProperty> propertiesToInclude = new HashSet<IEdmStructuralProperty>();
-
-            IEnumerable<SelectItem> selectedItems = selectExpandClause.SelectedItems;
-            if (!IsSelectAll(selectExpandClause))
-            {
-                // only select requested properties and keys.
-                foreach (PathSelectItem pathSelectItem in selectedItems.OfType<PathSelectItem>())
-                {
-                    SelectExpandNode.ValidatePathIsSupportedForSelect(pathSelectItem.SelectedPath);
-                    PropertySegment structuralPropertySegment = pathSelectItem.SelectedPath.LastSegment as PropertySegment;
-                    if (structuralPropertySegment != null)
-                    {
-                        propertiesToInclude.Add(structuralPropertySegment.Property);
-                    }
-                }
-
-                foreach (ExpandedNavigationSelectItem expandedNavigationSelectItem in selectedItems.OfType<ExpandedNavigationSelectItem>())
-                {
-                    foreach (var segment in expandedNavigationSelectItem.PathToNavigationProperty)
-                    {
-                        PropertySegment propertySegment = segment as PropertySegment;
-                        if (propertySegment != null &&
-                            structuredType.Properties().Contains(propertySegment.Property))
-                        {
-                            propertiesToInclude.Add(propertySegment.Property);
-                            break;
-                        }
-                    }
-                }
-
-                if (entityType != null)
-                {
-                    // add keys
-                    foreach (IEdmStructuralProperty keyProperty in entityType.Key())
-                    {
-                        if (!propertiesToInclude.Contains(keyProperty))
-                        {
-                            autoSelectedProperties.Add(keyProperty);
-                        }
-                    }
-                }
-
-                // add concurrency properties, if not added
-                if (navigationSource != null && model != null)
-                {
-                    IEnumerable<IEdmStructuralProperty> concurrencyProperties = model.GetConcurrencyProperties(navigationSource);
-                    foreach (IEdmStructuralProperty concurrencyProperty in concurrencyProperties)
-                    {
-                        if (!propertiesToInclude.Contains(concurrencyProperty))
-                        {
-                            autoSelectedProperties.Add(concurrencyProperty);
-                        }
-                    }
-                }
-            }
-
-            return propertiesToInclude;
-        }
-
         private static bool IsSelectAll(SelectExpandClause selectExpandClause)
         {
             if (selectExpandClause == null)
@@ -945,6 +1170,28 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 Contract.Assert(isContainerPropertySet, "if it is not select all, container should hold something");
 
                 return isTypeNamePropertySet ? typeof(SelectSomeAndInheritance<>) : typeof(SelectSome<>);
+            }
+        }
+
+        private class ReferenceNavigationPropertyExpandFilterVisitor : ExpressionVisitor
+        {
+            private Expression _source;
+            private ParameterExpression _parameterExpression;
+
+            public ReferenceNavigationPropertyExpandFilterVisitor(ParameterExpression parameterExpression, Expression source)
+            {
+                _source = source;
+                _parameterExpression = parameterExpression;
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                if (node != _parameterExpression)
+                {
+                    throw new ODataException(Error.Format(SRResources.ReferenceNavigationPropertyExpandFilterVisitorUnexpectedParameter, node.Name));
+                }
+
+                return _source;
             }
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -422,15 +422,17 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                     IEnumerable<IEdmStructuralProperty> concurrencyProperties = model.GetConcurrencyProperties(navigationSource);
                     foreach (IEdmStructuralProperty concurrencyProperty in concurrencyProperties)
                     {
-                        if (concurrencyProperty.DeclaringType == structuredType &&
-                            !currentLevelPropertiesInclude.Keys.Contains(concurrencyProperty))
+                        if (structuredType.Properties().Any(p => p == concurrencyProperty))
                         {
-                            if (autoSelectedProperties == null)
+                            if (!currentLevelPropertiesInclude.Keys.Contains(concurrencyProperty))
                             {
-                                autoSelectedProperties = new HashSet<IEdmStructuralProperty>();
-                            }
+                                if (autoSelectedProperties == null)
+                                {
+                                    autoSelectedProperties = new HashSet<IEdmStructuralProperty>();
+                                }
 
-                            autoSelectedProperties.Add(concurrencyProperty);
+                                autoSelectedProperties.Add(concurrencyProperty);
+                            }
                         }
                     }
                 }
@@ -1024,18 +1026,21 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                     _settings.EnableConstantParameterization);
             }
 
-            // don't page nested collections if EnableCorrelatedSubqueryBuffering is enabled
-            if (!_settings.EnableCorrelatedSubqueryBuffering)
+            if (_settings.PageSize.HasValue || modelBoundPageSize.HasValue || hasTopValue || hasSkipvalue)
             {
-                if (_settings.PageSize.HasValue)
+                // don't page nested collections if EnableCorrelatedSubqueryBuffering is enabled
+                if (!_settings.EnableCorrelatedSubqueryBuffering)
                 {
-                    source = ExpressionHelpers.Take(source, _settings.PageSize.Value + 1, elementType,
-                        _settings.EnableConstantParameterization);
-                }
-                else if (_settings.ModelBoundPageSize.HasValue)
-                {
-                    source = ExpressionHelpers.Take(source, modelBoundPageSize.Value + 1, elementType,
-                        _settings.EnableConstantParameterization);
+                    if (_settings.PageSize.HasValue)
+                    {
+                        source = ExpressionHelpers.Take(source, _settings.PageSize.Value + 1, elementType,
+                            _settings.EnableConstantParameterization);
+                    }
+                    else if (_settings.ModelBoundPageSize.HasValue)
+                    {
+                        source = ExpressionHelpers.Take(source, modelBoundPageSize.Value + 1, elementType,
+                            _settings.EnableConstantParameterization);
+                    }
                 }
             }
 

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -945,6 +945,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         }
 
         // new CollectionWrapper<ElementType> { Instance = source.Select((ElementType element) => new Wrapper { }) }
+        [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "These are simple conversion function and cannot be split up.")]
         private Expression ProjectCollection(Expression source, Type elementType,
             SelectExpandClause selectExpandClause, IEdmStructuredType structuredType, IEdmNavigationSource navigationSource,
             OrderByClause orderByClause,

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -369,7 +369,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             propertiesToExpand = null;
             autoSelectedProperties = null;
 
-            bool isContainDynamicPropertySelect = false;
+            bool isSelectContainsDynamicProperty = false;
             var currentLevelPropertiesInclude = new Dictionary<IEdmStructuralProperty, SelectExpandIncludedProperty>();
             foreach (SelectItem selectItem in selectExpandClause.SelectedItems)
             {
@@ -387,7 +387,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 {
                     if (ProcessSelectedItem(pathItem, navigationSource, currentLevelPropertiesInclude))
                     {
-                        isContainDynamicPropertySelect = true;
+                        isSelectContainsDynamicProperty = true;
                     }
                     continue;
                 }
@@ -447,7 +447,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 }
             }
 
-            return isContainDynamicPropertySelect;
+            return isSelectContainsDynamicProperty;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandIncludeProperty.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandIncludeProperty.cs
@@ -1,0 +1,215 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+
+namespace Microsoft.AspNet.OData.Query.Expressions
+{
+    internal class SelectExpandIncludeProperty
+    {
+        /// <summary>
+        /// the corresponding property segment.
+        /// </summary>
+        private PropertySegment _propertySegment;
+
+        /// <summary>
+        /// the corresponding navigation source. maybe useless
+        /// </summary>
+        private IEdmNavigationSource _navigationSource;
+
+        /// <summary>
+        /// the path select item for this property.
+        /// for example: $select=abc or $select=NS.Type/abc
+        /// </summary>
+        private PathSelectItem _propertySelectItem;
+
+        /// <summary>
+        /// the sub $select and $expand for this property.
+        /// </summary>
+        private IList<SelectItem> _subSelectItems;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="SelectExpandIncludeProperty"/> class.
+        /// </summary>
+        /// <param name="propertySegment">The property segment that has this select expand item.</param>
+        public SelectExpandIncludeProperty(PropertySegment propertySegment)
+            : this(propertySegment, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="SelectExpandIncludeProperty"/> class.
+        /// </summary>
+        /// <param name="propertySegment">The property segment that has this select expand item.</param>
+        /// <param name="navigationSource">The targe navigation source of this property segment.</param>
+        public SelectExpandIncludeProperty(PropertySegment propertySegment, IEdmNavigationSource navigationSource)
+        {
+            if (propertySegment == null)
+            {
+                throw Error.ArgumentNull("propertySegment");
+            }
+
+            _propertySegment = propertySegment;
+            _navigationSource = navigationSource;
+        }
+
+        /// <summary>
+        /// Gets the merged path select item for this property, <see cref="PathSelectItem"/>.
+        /// </summary>
+        /// <returns>Null or the created <see cref="PathSelectItem"/>.</returns>
+        public PathSelectItem ToPathSelectItem()
+        {
+            if (_subSelectItems == null)
+            {
+                return _propertySelectItem;
+            }
+
+            // so, _subSelectItems is not null, merge the select and expand from the property into the _subSelectItems
+            bool isSelectAll = false;
+            if (_propertySelectItem != null && _propertySelectItem.SelectAndExpand != null)
+            {
+                // Retrieve the "IsSelectAll" from the property sub selectexpand clause.
+                isSelectAll = this._propertySelectItem.SelectAndExpand.AllSelected;
+                foreach (var selectItem in this._propertySelectItem.SelectAndExpand.SelectedItems)
+                {
+                    _subSelectItems.Add(selectItem);
+                }
+            }
+
+            if (isSelectAll)
+            {
+                // We do nothing here, because the property itself tells us to select all.
+                // Meanwhile, ODL doesn't allow $select=abc,abc(...), so it's safe to use "SelectAll".
+            }
+            else
+            {
+                // Mark selectall equals "true" if only include $expand
+                // So, if only "$expand=abc/nav", it means to select all for "abc" then expand "nav".
+                isSelectAll = true;
+                foreach (var item in _subSelectItems)
+                {
+                    // only include $expand=...., means selectAll as true
+                    if (!(item is ExpandedNavigationSelectItem || item is ExpandedReferenceSelectItem))
+                    {
+                        isSelectAll = false;
+                        break;
+                    }
+                }
+            }
+
+            SelectExpandClause subSelectExpandClause = new SelectExpandClause(_subSelectItems, isSelectAll);
+
+            if (_propertySelectItem == null && subSelectExpandClause == null)
+            {
+                return null;
+            }
+            else if (_propertySelectItem == null)
+            {
+                return new PathSelectItem(new ODataSelectPath(_propertySegment), _navigationSource, subSelectExpandClause,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null);
+            }
+            else
+            {
+                return new PathSelectItem(new ODataSelectPath(_propertySegment), _navigationSource, subSelectExpandClause,
+                    _propertySelectItem.FilterOption,
+                    _propertySelectItem.OrderByOption,
+                    _propertySelectItem.TopOption,
+                    _propertySelectItem.SkipOption,
+                    _propertySelectItem.CountOption,
+                    _propertySelectItem.SearchOption,
+                    _propertySelectItem.ComputeOption);
+            }
+        }
+
+        /// <summary>
+        /// Add sub $select item for this include property.
+        /// </summary>
+        /// <param name="remainingSegments">The remaining segments star from this include property.</param>
+        /// <param name="oldSelectItem">The old $select item.</param>
+        public void AddSubSelectItem(IList<ODataPathSegment> remainingSegments, PathSelectItem oldSelectItem)
+        {
+            if (remainingSegments == null)
+            {
+                // Be noted: In ODL v7.6.1, it's not allowed duplicated properties in $select.
+                // for example: "$select=abc($top=2),abc($skip=2)" is not allowed in ODL library.
+                // So, don't worry about the previous setting overrided by other same path.
+                // However, it's possibility in later ODL version (>=7.6.2) to allow duplicated properties in $select.
+                // It that case, please update the codes here otherwise the latter will win.
+                
+                // Besides, $select=abc,abc($top=2) is not allowed in ODL 7.6.1.
+                Contract.Assert(_propertySelectItem == null);
+                _propertySelectItem = oldSelectItem;
+            }
+            else
+            {
+                if (_subSelectItems == null)
+                {
+                    _subSelectItems = new List<SelectItem>();
+                }
+
+                _subSelectItems.Add(new PathSelectItem(new ODataSelectPath(remainingSegments), oldSelectItem.NavigationSource,
+                    oldSelectItem.SelectAndExpand, oldSelectItem.FilterOption,
+                    oldSelectItem.OrderByOption, oldSelectItem.TopOption,
+                    oldSelectItem.SkipOption, oldSelectItem.CountOption,
+                    oldSelectItem.SearchOption, oldSelectItem.ComputeOption));
+            }
+        }
+
+        /// <summary>
+        /// Add sub $expand item for this include property.
+        /// </summary>
+        /// <param name="remainingSegments">The remaining segments star from this include property.</param>
+        /// <param name="oldRefItem">The old $expand item.</param>
+        public void AddSubExpandItem(IList<ODataPathSegment> remainingSegments, ExpandedReferenceSelectItem oldRefItem)
+        {
+            // remainingSegments should never be null, because at least a navigation property segment in it.
+            Contract.Assert(remainingSegments != null);
+
+            if (_subSelectItems == null)
+            {
+                _subSelectItems = new List<SelectItem>();
+            }
+
+            ODataExpandPath newPath = new ODataExpandPath(remainingSegments);
+            ExpandedNavigationSelectItem expandedNav = oldRefItem as ExpandedNavigationSelectItem;
+            if (expandedNav != null)
+            {
+                _subSelectItems.Add(new ExpandedNavigationSelectItem(newPath,
+                    expandedNav.NavigationSource,
+                    expandedNav.SelectAndExpand,
+                    expandedNav.FilterOption,
+                    expandedNav.OrderByOption,
+                    expandedNav.TopOption,
+                    expandedNav.SkipOption,
+                    expandedNav.CountOption,
+                    expandedNav.SearchOption,
+                    expandedNav.LevelsOption,
+                    expandedNav.ComputeOption,
+                    expandedNav.ApplyOption));
+            }
+            else
+            {
+                _subSelectItems.Add(new ExpandedReferenceSelectItem(newPath,
+                    oldRefItem.NavigationSource,
+                    oldRefItem.FilterOption,
+                    oldRefItem.OrderByOption,
+                    oldRefItem.TopOption,
+                    oldRefItem.SkipOption,
+                    oldRefItem.CountOption,
+                    oldRefItem.SearchOption,
+                    oldRefItem.ComputeOption,
+                    oldRefItem.ApplyOption));
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandIncludedProperty.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandIncludedProperty.cs
@@ -9,7 +9,7 @@ using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNet.OData.Query.Expressions
 {
-    internal class SelectExpandIncludeProperty
+    internal class SelectExpandIncludedProperty
     {
         /// <summary>
         /// the corresponding property segment.
@@ -33,20 +33,20 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         private IList<SelectItem> _subSelectItems;
 
         /// <summary>
-        /// Creates a new instance of the <see cref="SelectExpandIncludeProperty"/> class.
+        /// Creates a new instance of the <see cref="SelectExpandIncludedProperty"/> class.
         /// </summary>
         /// <param name="propertySegment">The property segment that has this select expand item.</param>
-        public SelectExpandIncludeProperty(PropertySegment propertySegment)
+        public SelectExpandIncludedProperty(PropertySegment propertySegment)
             : this(propertySegment, null)
         {
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="SelectExpandIncludeProperty"/> class.
+        /// Creates a new instance of the <see cref="SelectExpandIncludedProperty"/> class.
         /// </summary>
         /// <param name="propertySegment">The property segment that has this select expand item.</param>
         /// <param name="navigationSource">The targe navigation source of this property segment.</param>
-        public SelectExpandIncludeProperty(PropertySegment propertySegment, IEdmNavigationSource navigationSource)
+        public SelectExpandIncludedProperty(PropertySegment propertySegment, IEdmNavigationSource navigationSource)
         {
             if (propertySegment == null)
             {
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         }
 
         /// <summary>
-        /// Gets the merged path select item for this property, <see cref="PathSelectItem"/>.
+        /// Gets the merged <see cref="PathSelectItem"/> for this property.
         /// </summary>
         /// <returns>Null or the created <see cref="PathSelectItem"/>.</returns>
         public PathSelectItem ToPathSelectItem()
@@ -73,8 +73,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             if (_propertySelectItem != null && _propertySelectItem.SelectAndExpand != null)
             {
                 // Retrieve the "IsSelectAll" from the property sub selectexpand clause.
-                isSelectAll = this._propertySelectItem.SelectAndExpand.AllSelected;
-                foreach (var selectItem in this._propertySelectItem.SelectAndExpand.SelectedItems)
+                isSelectAll = _propertySelectItem.SelectAndExpand.AllSelected;
+                foreach (var selectItem in _propertySelectItem.SelectAndExpand.SelectedItems)
                 {
                     _subSelectItems.Add(selectItem);
                 }

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandPathExtensions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandPathExtensions.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.OData;
+using Microsoft.OData.UriParser;
+
+namespace Microsoft.AspNet.OData.Query.Expressions
+{
+    internal static class SelectExpandPathExtensions
+    {
+        /// <summary>
+        /// Verify the $select path and gets the first non type cast segment in a select path.
+        /// For example: $select=NS.SubType1/abc/NS.SubType2/xyz
+        /// => firstPropertySegment: "abc"
+        /// => remainingSegments:  NS.SubType2/xyz
+        /// </summary>
+        /// <param name="selectPath">The input $select path.</param>
+        /// <param name="remainingSegments">The remaining segments after the first non type segment.</param>
+        /// <returns>First non-type cast segment.</returns>
+        public static ODataPathSegment GetFirstNonTypeCastSegment(this ODataSelectPath selectPath, out IList<ODataPathSegment> remainingSegments)
+        {
+            if (selectPath == null)
+            {
+                throw new ArgumentNullException("selectPath");
+            }
+
+            // In fact, ODataSelectPath constructor verifies the supporting segments, we add the verification here for double check.
+            return GetFirstNonTypeCastSegment(selectPath,
+                //The middle segment should be "TypeSegment" or "PropertySegment".
+                m => m is PropertySegment || m is TypeSegment,
+                // The last segment could be "NavigationPropertySegment, PropertySegment, OperationSegment, DynamicPathSegment"
+                s => s is NavigationPropertySegment || s is PropertySegment || s is OperationSegment || s is DynamicPathSegment,
+                out remainingSegments);
+        }
+
+        /// <summary>
+        /// Verify the $expand path and gets the first non type cast segment in this expand path.
+        /// For example: $expand=NS.SubType1/abc/NS.SubType2/nav
+        /// => firstPropertySegment: "abc"
+        /// => remainingSegments:  NS.SubType2/nav
+        /// => leadingTypeSegment: NS.SubType1
+        /// </summary>
+        /// <param name="expandPath">The input $expand path.</param>
+        /// <param name="remainingSegments">The remaining segments after the first non type segment.</param>
+        /// <returns>First non-type cast segment.</returns>
+        public static ODataPathSegment GetFirstNonTypeCastSegment(this ODataExpandPath expandPath,
+            out IList<ODataPathSegment> remainingSegments)
+        {
+            if (expandPath == null)
+            {
+                throw new ArgumentNullException("expandPath");
+            }
+
+            // In fact, ODataExpandPath constructor verifies the supporting segments, we add the verification here for double check.
+            return GetFirstNonTypeCastSegment(expandPath,
+                //The middle segment should be "TypeSegment" or "PropertySegment".
+                m => m is PropertySegment || m is TypeSegment,
+                // The last segment could be "NavigationPropertySegment"
+                s => s is NavigationPropertySegment,
+                out remainingSegments);
+        }
+
+        private static ODataPathSegment GetFirstNonTypeCastSegment(ODataPath path,
+            Func<ODataPathSegment, bool> middleSegmentPredict,
+            Func<ODataPathSegment, bool> lastSegmentPredict,
+            out IList<ODataPathSegment> remainingSegments) // could be null
+        {
+            Contract.Assert(path != null);
+
+            remainingSegments = null;
+            ODataPathSegment firstNonTypeSegment = null;
+            int lastIndex = path.Count() - 1;
+            int index = 0;
+            foreach (var segment in path)
+            {
+                if (index == lastIndex)
+                {
+                    // Last segment
+                    if (!lastSegmentPredict(segment))
+                    {
+                        throw new ODataException(Error.Format(SRResources.InvalidLastSegmentInSelectExpandPath, segment.GetType().Name));
+                    }
+                }
+                else
+                {
+                    // middle segment
+                    if (!middleSegmentPredict(segment))
+                    {
+                        throw new ODataException(Error.Format(SRResources.InvalidSegmentInSelectExpandPath, segment.GetType().Name));
+                    }
+                }
+
+                index++;
+
+                if (firstNonTypeSegment != null)
+                {
+                    if (remainingSegments == null)
+                    {
+                        remainingSegments = new List<ODataPathSegment>();
+                    }
+
+                    remainingSegments.Add(segment);
+                    continue;
+                }
+
+                // Theorically, a path like:  "~/NS.BaseType/NS.SubType1/NS.SubType2/PropertyOnSubType2" is valid(?) but not allowed.
+                // However, the functionality of above path is same as "~/NS.SubType2/PropertyOnSubType2".
+                // So, Let's only care about the last segment in the leading segments.
+                // if we have the leading segments, and the last segment must be the type segment and it's verified.
+                if (segment is TypeSegment)
+                {
+                    // do nothing here, just skip the leading type segment
+                }
+                else
+                {
+                    firstNonTypeSegment = segment;
+                }
+            }
+
+            return firstNonTypeSegment;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandPathExtensions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandPathExtensions.cs
@@ -66,22 +66,22 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         }
 
         private static ODataPathSegment GetFirstNonTypeCastSegment(ODataPath path,
-            Func<ODataPathSegment, bool> middleSegmentPredict,
-            Func<ODataPathSegment, bool> lastSegmentPredict,
+            Func<ODataPathSegment, bool> middleSegmentPredicte,
+            Func<ODataPathSegment, bool> lastSegmentPredicte,
             out IList<ODataPathSegment> remainingSegments) // could be null
         {
             Contract.Assert(path != null);
 
             remainingSegments = null;
             ODataPathSegment firstNonTypeSegment = null;
-            int lastIndex = path.Count() - 1;
+            int lastIndex = path.Count - 1;
             int index = 0;
             foreach (var segment in path)
             {
                 if (index == lastIndex)
                 {
                     // Last segment
-                    if (!lastSegmentPredict(segment))
+                    if (!lastSegmentPredicte(segment))
                     {
                         throw new ODataException(Error.Format(SRResources.InvalidLastSegmentInSelectExpandPath, segment.GetType().Name));
                     }
@@ -89,7 +89,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 else
                 {
                     // middle segment
-                    if (!middleSegmentPredict(segment))
+                    if (!middleSegmentPredicte(segment))
                     {
                         throw new ODataException(Error.Format(SRResources.InvalidSegmentInSelectExpandPath, segment.GetType().Name));
                     }
@@ -103,6 +103,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                     {
                         remainingSegments = new List<ODataPathSegment>();
                     }
+
+                    Contract.Assert(remainingSegments != null);
 
                     remainingSegments.Add(segment);
                     continue;

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandPathExtensions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandPathExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using System.Linq;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.OData;
 using Microsoft.OData.UriParser;
@@ -22,7 +21,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         /// <param name="selectPath">The input $select path.</param>
         /// <param name="remainingSegments">The remaining segments after the first non type segment.</param>
         /// <returns>First non-type cast segment.</returns>
-        public static ODataPathSegment GetFirstNonTypeCastSegment(this ODataSelectPath selectPath, out IList<ODataPathSegment> remainingSegments)
+        public static ODataPathSegment GetFirstNonTypeCastSegment(this ODataSelectPath selectPath,
+            out IList<ODataPathSegment> remainingSegments)
         {
             if (selectPath == null)
             {
@@ -104,14 +104,12 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                         remainingSegments = new List<ODataPathSegment>();
                     }
 
-                    Contract.Assert(remainingSegments != null);
-
                     remainingSegments.Add(segment);
                     continue;
                 }
 
-                // Theorically, a path like:  "~/NS.BaseType/NS.SubType1/NS.SubType2/PropertyOnSubType2" is valid(?) but not allowed.
-                // However, the functionality of above path is same as "~/NS.SubType2/PropertyOnSubType2".
+                // Theoretically, a path like:  "~/NS.BaseType/NS.SubType1/NS.SubType2/PropertyOnSubType2" is valid(?) but not allowed.
+                // However, the functionality of the above path is same as "~/NS.SubType2/PropertyOnSubType2" (omit the middle type cast).
                 // So, Let's only care about the last segment in the leading segments.
                 // if we have the leading segments, and the last segment must be the type segment and it's verified.
                 if (segment is TypeSegment)

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -1462,6 +1462,9 @@
     <Compile Include="..\NavigationPropertyOnComplexType\PeopleRepository.cs">
       <Link>NavigationPropertyOnComplexType\PeopleRepository.cs</Link>
     </Compile>
+    <Compile Include="..\NavigationPropertyOnComplexType\SelectImprovementOnComplexTypeTests.cs">
+      <Link>NavigationPropertyOnComplexType\SelectImprovementOnComplexTypeTests.cs</Link>
+    </Compile>
     <Compile Include="..\ODataCountTest\CountController.cs">
       <Link>ODataCountTest\CountController.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -90,6 +90,9 @@
     <Compile Include="..\NavigationPropertyOnComplexType\PeopleRepository.cs">
       <Link>NavigationPropertyOnComplexType\PeopleRepository.cs</Link>
     </Compile>
+    <Compile Include="..\NavigationPropertyOnComplexType\SelectImprovementOnComplexTypeTests.cs">
+      <Link>NavigationPropertyOnComplexType\SelectImprovementOnComplexTypeTests.cs</Link>
+    </Compile>
     <Compile Include="..\QueryComposition\EFWideCustomer.cs">
       <Link>QueryComposition\EFWideCustomer.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/NavigationPropertyOnComplexTypeModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/NavigationPropertyOnComplexTypeModel.cs
@@ -84,6 +84,14 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
         public ZipCode Area { get; set; }
     }
 
+    // with the same propert name in different derived type.
+    public class GeometryLocation : Address
+    {
+        public string Latitude { get; set; }
+
+        public string Longitude { get; set; }
+    }
+
     public class ModelGenerator
     {
         // Builds the EDM model for the OData service.

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/NavigationPropertyOnComplexTypeModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/NavigationPropertyOnComplexTypeModel.cs
@@ -5,52 +5,82 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNet.OData.Builder;
 using Microsoft.OData.Edm;
-using Microsoft.Test.E2E.AspNet.OData.Aggregation;
 
 namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
 {
     public class Person
     {
         public int Id { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
+
+        public string Name { get; set; }
 
         public int Age { get; set; }
-        public Address Location { get; set; }
 
-        public Address Home { get; set; }
+        public IList<int> Taxes { get; set; }
+
+        public Address HomeLocation { get; set; }
+
+        public IList<Address> RepoLocations { get; set; }
 
         public GeoLocation PreciseLocation { get; set; }
 
-        public Orders Order { get; set; }
+        public OrderInfo OrderInfo { get; set; }
     }
 
-    public class Orders
+    public class VipPerson : Person
     {
-        public Address Zip { get; set; }
-        public Orders Order { get; set; }
-        public IDictionary<string, object> propertybag { get; set; }
+        public int Bonus { get; set; }
     }
 
     public class Address
     {
         public string Street { get; set; }
+
+        public int TaxNo { get; set; }
+
+        public IList<string> Emails { get; set; }
+
+        public AddressInfo RelatedInfo { get; set; }
+
+        public IList<AddressInfo> AdditionInfos { get; set; }
+
         public ZipCode ZipCode { get; set; }
+
+        public IList<ZipCode> DetailCodes { get; set; }
+    }
+
+    public class AddressInfo
+    {
+        public int AreaSize { get; set; }
+
+        public string CountyName { get; set; }
+    }
+
+    public class OrderInfo
+    {
+        public Address BillLocation { get; set; }
+
+        public OrderInfo SubInfo { get; set; }
+
+        public IDictionary<string, object> propertybag { get; set; }
     }
 
     public class ZipCode
     {
         [Key]
         public int Zip { get; set; }
-        public string City { get; set; }
-        public string State { get; set; }
 
+        public string City { get; set; }
+
+        public string State { get; set; }
     }
 
     public class GeoLocation : Address
     {
         public string Latitude { get; set; }
+
         public string Longitude { get; set; }
+
         public ZipCode Area { get; set; }
     }
 
@@ -60,12 +90,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
         public static IEdmModel GetConventionalEdmModel()
         {
             var modelBuilder = new ODataConventionModelBuilder();
-            var peopleEntitySet = modelBuilder.EntitySet<Person>("People");
-            var zipcodes = modelBuilder.EntitySet<ZipCode>("ZipCodes");
+            modelBuilder.EntitySet<Person>("People");
+            modelBuilder.EntitySet<ZipCode>("ZipCodes");
 
             modelBuilder.Namespace = typeof(Person).Namespace;
             return modelBuilder.GetEdmModel();
         }
-
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/NavigationPropertyOnComplexTypeTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/NavigationPropertyOnComplexTypeTests.cs
@@ -38,10 +38,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             // Arrange : GET ~/People(1)/HomeLocation/ZipCode
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)/HomeLocation/ZipCode";
 
-            string expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#ZipCodes/$entity\"," +
+            string equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#ZipCodes/$entity\"," +
                 "\"Zip\":98052,\"City\":\"Redmond\",\"State\":\"Washington\"}";
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, contains: null, equals: equals);
@@ -53,11 +51,9 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             // Arrange
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)/HomeLocation?$select=Street&$expand=ZipCode";
 
-            string expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(1)/HomeLocation(Street,ZipCode())\"," +
+            string equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(1)/HomeLocation(Street,ZipCode())\"," +
                 "\"Street\":\"110th\"," +
                 "\"ZipCode\":{\"Zip\":98052,\"City\":\"Redmond\",\"State\":\"Washington\"}}";
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, contains: null, equals: equals);
@@ -74,8 +70,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
 
             // Assert
             JObject jObj = JObject.Parse(result);
-            Assert.Equal("BASE_ADDRESS/odata/$metadata#People(1)/RepoLocations(Street,ZipCode())".Replace("BASE_ADDRESS", BaseAddress),
-                jObj["@odata.context"]);
+            Assert.Equal("BASE_ADDRESS/odata/$metadata#People(1)/RepoLocations(Street,ZipCode())", jObj["@odata.context"]);
 
             var array = jObj["value"] as JArray;
             Assert.Equal(3, array.Count);
@@ -135,10 +130,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             // Arrange
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$expand=HomeLocation/ZipCode&$select=HomeLocation/Street";
 
-            string expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Street,HomeLocation/ZipCode())/$entity\"," +
+            string equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Street,HomeLocation/ZipCode())/$entity\"," +
                 "\"HomeLocation\":{\"Street\":\"110th\",\"ZipCode\":{\"Zip\":98052,\"City\":\"Redmond\",\"State\":\"Washington\"}}}";
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, contains: null, equals: equals);
@@ -175,8 +168,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                       "\"ZipCode\":{\"Zip\":35816,\"City\":\"Huntsville\",\"State\":\"Alabama\"}}}";
             }
 
-            equals = equals.Replace("BASE_ADDRESS", BaseAddress);
-
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, null, equals);
         }
@@ -211,22 +202,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
         public void QueryEntityWithReferenceOnNavigationPropertiesOfComplexProperty()
         {
             // Arrange
-            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(2)?$expand=HomeLocation/ZipCode/$ref&$select=HomeLocation/Street";
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$expand=HomeLocation/ZipCode/$ref&$select=HomeLocation/Street";
 
-            string contains = "odata/$metadata#People(OrderInfo,OrderInfo/BillLocation/ZipCode())/$entity\"," +
-              "\"OrderInfo\":{" +
-                "\"BillLocation\":{" +
+            string contains = "odata/$metadata#People(HomeLocation/Street,HomeLocation/ZipCode,HomeLocation/ZipCode/$ref())/$entity\"," +
+              "\"HomeLocation\":{" +
                   "\"Street\":\"110th\"," +
-                  "\"TaxNo\":0," +
-                  "\"Emails\":[]," +
-                  "\"RelatedInfo\":null,\"AdditionInfos\":[]," +
                   "\"ZipCode\":{" +
-                    "\"Zip\":98052," +
-                    "\"City\":\"Redmond\"," +
-                    "\"State\":\"Washington\"" +
+                    "\"@odata.id\":\"ZipCodes(98052)\"" +
                   "}" +
-                "}," +
-                "\"SubInfo\":null" +
+                "}" +
               "}";
 
             // Act & Assert
@@ -237,22 +221,23 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
         public void QueryEntityWithReferenceOnCollectionNavigationPropertiesOfComplexProperty()
         {
             // Arrange
-            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(2)?$expand=HomeLocation/DetailCodes/$ref&$select=HomeLocation/Street";
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$expand=HomeLocation/DetailCodes/$ref&$select=HomeLocation/Street";
 
-            string contains = "odata/$metadata#People(OrderInfo,OrderInfo/BillLocation/ZipCode())/$entity\"," +
-              "\"OrderInfo\":{" +
-                "\"BillLocation\":{" +
+            string contains = "odata/$metadata#People(HomeLocation/Street,HomeLocation/DetailCodes,HomeLocation/DetailCodes/$ref())/$entity\"," +
+              "\"HomeLocation\":{" +
                   "\"Street\":\"110th\"," +
-                  "\"TaxNo\":0," +
-                  "\"Emails\":[]," +
-                  "\"RelatedInfo\":null,\"AdditionInfos\":[]," +
-                  "\"ZipCode\":{" +
-                    "\"Zip\":98052," +
-                    "\"City\":\"Redmond\"," +
-                    "\"State\":\"Washington\"" +
-                  "}" +
-                "}," +
-                "\"SubInfo\":null" +
+                  "\"DetailCodes\":[" +
+                    "{" +
+                       "\"@odata.id\":\"ZipCodes(98052)\"" +
+                    "}," +
+                    "{" +
+                       "\"@odata.id\":\"ZipCodes(35816)\"" +
+                    "}," +
+                    "{" +
+                       "\"@odata.id\":\"ZipCodes(10048)\"" +
+                    "}" +
+                  "]" +
+                "}" +
               "}";
 
             // Act & Assert
@@ -265,21 +250,16 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             // Arrange
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(2)?$expand=OrderInfo/BillLocation/ZipCode/$ref&$select=OrderInfo/BillLocation/Street";
 
-            string contains = "odata/$metadata#People(OrderInfo,OrderInfo/BillLocation/ZipCode())/$entity\"," +
+            string contains = "odata/$metadata#People(OrderInfo/BillLocation/Street,OrderInfo/BillLocation/ZipCode,OrderInfo/BillLocation/ZipCode/$ref())/$entity\"," +
               "\"OrderInfo\":{" +
                 "\"BillLocation\":{" +
                   "\"Street\":\"110th\"," +
-                  "\"TaxNo\":0," +
-                  "\"Emails\":[]," +
-                  "\"RelatedInfo\":null,\"AdditionInfos\":[]," +
                   "\"ZipCode\":{" +
-                    "\"Zip\":98052," +
-                    "\"City\":\"Redmond\"," +
-                    "\"State\":\"Washington\"" +
+                    "\"@odata.id\":\"ZipCodes(98052)\"" +
                   "}" +
-                "}," +
-                "\"SubInfo\":null" +
-              "}";
+                "}" +
+              "}" +
+            "}";
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, contains);
@@ -319,8 +299,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             string contains = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(4)/HomeLocation(Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Area())\"," +
                 "\"Street\":\"120th\",\"TaxNo\":17,\"Emails\":[\"E7\",\"E4\",\"E5\"],\"Latitude\":\"12.8\",\"Longitude\":\"22.9\",\"Rela";
 
-            contains = contains.Replace("BASE_ADDRESS", BaseAddress);
-
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, contains: contains, equals: null);
         }
@@ -334,8 +312,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             string contains = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(4)/HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation(Area())\"," +
                 "\"Street\":\"120th\",\"TaxNo\":17,\"Emails\":[\"E7\",\"E4\",\"E5\"],\"Latitude\":\"12.8\",\"Longitude\":\"22.9\",\"Rela";
 
-            contains = contains.Replace("BASE_ADDRESS", BaseAddress);
-
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, contains: contains, equals: null);
         }
@@ -348,8 +324,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
 
             string contains = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Area())/$entity\"," +
                 "\"Id\":4,\"Name\":\"Jones\",\"Age\":9,";
-
-            contains = contains.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             var result = ExecuteAndVerifyQueryRequest(requestUri, contains: contains, equals: null);
@@ -370,8 +344,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                         "\"Street\":\"110th\"," +
                         "\"ZipCode\":{\"Zip\":35816,\"City\":\"Huntsville\",\"State\":\"Alabama\"}}}}}";
 
-            equals = equals.Replace("BASE_ADDRESS", BaseAddress);
-
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, contains: null, equals: equals);
         }
@@ -390,6 +362,13 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             string result = response.Content.ReadAsStringAsync().Result;
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // replace the real address using "BASE_ADDRESS"
+            string odataContext = "\"@odata.context\":\"";
+            int start = result.IndexOf(odataContext) + odataContext.Length;
+            int end = result.IndexOf("/odata/$metadata");
+            string uri = result.Substring(start, end - start);
+            result = result.Replace(uri, "BASE_ADDRESS");
 
             if (contains != null)
             {

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/PeopleController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/PeopleController.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
         [EnableQuery]
         public IEnumerable<Person> Get()
         {
-            return _repo.Get();
+            return _repo.People;
         }
 
         [HttpGet]
         [EnableQuery]
         public ITestActionResult Get([FromODataUri]int key)
         {
-            Person person = _repo.people.FirstOrDefault(p => p.Id == key);
+            Person person = _repo.People.FirstOrDefault(p => p.Id == key);
             if (person == null)
             {
                 return NotFound();
@@ -34,16 +34,28 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
         }
 
         [EnableQuery]
-        public ITestActionResult GetLocationFromPerson([FromODataUri]int key)
+        public ITestActionResult GetHomeLocationFromPerson([FromODataUri]int key)
         {
-            Person person = _repo.people.FirstOrDefault(p => p.Id == key);
+            Person person = _repo.People.FirstOrDefault(p => p.Id == key);
             if (person == null)
             {
                 return NotFound();
             }
-            return Ok(person.Location);
+            return Ok(person.HomeLocation);
         }
 
+        [EnableQuery]
+        public ITestActionResult GetRepoLocationsFromPerson([FromODataUri]int key)
+        {
+            Person person = _repo.People.FirstOrDefault(p => p.Id == key);
+            if (person == null)
+            {
+                return NotFound();
+            }
+            return Ok(person.RepoLocations);
+        }
+
+        /*
         [EnableQuery]
         public ITestActionResult GetLocationOfAddress([FromODataUri]int key)
         {
@@ -53,33 +65,40 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                 return NotFound();
             }
             return Ok(person.Location as Address);
-        }
+        }*/
 
         [EnableQuery]
-        public ITestActionResult GetLocationOfGeolocation([FromODataUri]int key)
+        public ITestActionResult GetHomeLocationOfGeolocation([FromODataUri]int key)
         {
-            Person person = _repo.people.FirstOrDefault(p => p.Id == key);
+            Person person = _repo.People.FirstOrDefault(p => p.Id == key);
             if (person == null)
             {
                 return NotFound();
             }
-            return Ok(person.Location as GeoLocation);
+
+            return Ok(person.HomeLocation as GeoLocation);
         }
 
         [EnableQuery]
-        [ODataRoute("people({id})/Order")]
-        public ITestActionResult GetOrdeFromPerson([FromODataUri]int id)
+        [ODataRoute("People({id})/OrderInfo")]
+        public ITestActionResult GetOrdeInfoFromPerson([FromODataUri]int id)
         {
-            return Ok(_repo.people.FirstOrDefault(p => p.Id == id).Order);
+            return Ok(_repo.People.FirstOrDefault(p => p.Id == id).OrderInfo);
         }
 
-        [ODataRoute("people({id})/Location/ZipCode")]
+        [ODataRoute("People({id})/HomeLocation/ZipCode")]
         public ITestActionResult GetZipCode([FromODataUri]int id)
         {
-            return Ok(_repo.people.FirstOrDefault().Location.ZipCode);
+            Person person = _repo.People.FirstOrDefault(p => p.Id == id);
+            if (person == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(person.HomeLocation.ZipCode);
         }
 
-        [ODataRoute("people({id})/Location/ZipCode/$ref")]
+        [ODataRoute("People({id})/HomeLocation/ZipCode/$ref")]
         public ITestActionResult CreateRefToZipCode([FromODataUri] int id, [FromBody] ZipCode zip)
         {
             return Ok(zip);

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/PeopleRepository.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/PeopleRepository.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                     Id = 6,
                     Name = "Sam",
                     Age = 40,
-                    HomeLocation = new Address
+                    HomeLocation = new GeometryLocation
                     {
                         Street = "130th",
                         TaxNo = 18,
@@ -169,7 +169,9 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                             CountyName = "King" + e
                         }).ToList(),
                         ZipCode = zipCodes[2],
-                        DetailCodes = zipCodes
+                        DetailCodes = zipCodes,
+                        Latitude = "101.1",
+                        Longitude = "202.2"
                     },
                     Bonus = 99
                 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/PeopleRepository.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/PeopleRepository.cs
@@ -8,50 +8,172 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
 {
     public class PeopleRepository
     {
-        public List<Person> people { get; set; }
-        public List<ZipCode> zipCodes;
-        public IDictionary<string, object> propertyBag = new Dictionary<string, object>();
+        public List<Person> People { get; private set; }
 
         public PeopleRepository()
         {
-            zipCodes = new List<ZipCode>
+            var zipCodes = new List<ZipCode>
             {
                 new ZipCode { Zip = 98052, City = "Redmond", State="Washington"},
-                new ZipCode {Zip = 98030, City = "Kent", State = "Washington"},
-                new ZipCode {Zip = 98004, City = "Bellevue", State = "Washington"}
+                new ZipCode { Zip = 35816, City = "Huntsville", State = "Alabama"},
+                new ZipCode { Zip = 10048, City = "New York", State = "New York"}
             };
 
-            propertyBag.Add("key", zipCodes[1]);
-
-            people = new List<Person> { 
-                new Person { Id=1, FirstName = "Kate", LastName = "Jones", Age = 5, Location = new Address{ ZipCode = zipCodes[1], Street = "110th" }, Home = new Address{ ZipCode = zipCodes[0], Street = "110th" }, Order = new Orders{ Zip = new Address{ ZipCode = zipCodes[0], Street = "110th" }}},
-                new Person { Id =2, FirstName = "Lewis", LastName = "James", Age = 6 , Location = new GeoLocation{ ZipCode = zipCodes[1], Street = "110th", Latitude = "12.211", Longitude ="231.131" }, Home = new Address{ ZipCode = zipCodes[0], Street = "110th" }, Order = new Orders{ Zip = new Address{ ZipCode = zipCodes[0], Street = "110th" }}},
-                new Person { Id = 3, FirstName = "Carlos", LastName = "Park", Age = 7, Location = new Address{ ZipCode = zipCodes[2], Street = "110th" }, Home = new Address{ ZipCode = zipCodes[0], Street = "110th" }, Order = new Orders{ Zip = new Address{ ZipCode = zipCodes[0], Street = "110th" }}, PreciseLocation = new GeoLocation{Area = zipCodes[2], Latitude = "12", Longitude = "22", Street = "50th", ZipCode = zipCodes[1]}},
-                new Person { Id = 4, FirstName = "Carlos", LastName = "Park", Age = 7, Location = new Address{ ZipCode = zipCodes[2], Street = "110th" }, Home = new Address{ ZipCode = zipCodes[0], Street = "110th" }, Order = new Orders{ Zip = new Address{ ZipCode = zipCodes[0], Street = "110th" }, Order = new Orders{ Zip = new Address{ ZipCode = zipCodes[1], Street = "110th" }}}, PreciseLocation = new GeoLocation{Area = zipCodes[2], Latitude = "12", Longitude = "22", Street = "50th", ZipCode = zipCodes[1]}},
-                new Person { Id = 5, FirstName = "Carlos", LastName = "Park", Age = 7, Order = new Orders() {propertybag = propertyBag} }
-            };
-        }
-
-        public IEnumerable<Person> Get()
-        {
-            return people;
-        }
-
-        public Person Get(string firstName, string lastName)
-        {
-            return people.Where(p => p.FirstName == firstName && p.LastName == lastName).FirstOrDefault();
-        }
-
-        public Person Remove(string firstName, string lastName)
-        {
-            var p = Get(firstName, lastName);
-            if (p == null)
+            IDictionary<string, object> propertyBag = new Dictionary<string, object>
             {
-                return null;
-            }
+                { "DynamicInt", 9 },
+                {
+                    "DynamicAddress",
+                    new Address
+                    {
+                        Street = "",
+                        Emails = new List<string>
+                        {
+                            "abc@1.com",
+                            "xyz@2.com"
+                        }
+                    }
+                }
+            };
 
-            people.Remove(p);
-            return p;
+            var repoLocations = new Address[]
+            {
+                new Address
+                {
+                    Street = "110th",
+                    TaxNo = 19,
+                    Emails = new [] { "E1", "E3", "E2" },
+                    RelatedInfo = new AddressInfo { AreaSize = 101, CountyName = "King" },
+                    AdditionInfos = Enumerable.Range(1, 3).Select(e => new AddressInfo
+                    {
+                        AreaSize = 101 + e,
+                        CountyName = "King" + e
+                    }).ToList(),
+                    ZipCode = zipCodes[0],
+                    DetailCodes = zipCodes
+                },
+                new GeoLocation
+                {
+                    Street = "120th",
+                    TaxNo = 17,
+                    Emails = new [] { "E7", "E4", "E5" },
+                    RelatedInfo = null,
+                    AdditionInfos = Enumerable.Range(1, 3).Select(e => new AddressInfo
+                    {
+                        AreaSize = 101 + e,
+                        CountyName = "King" + e
+                    }).ToList(),
+                    Latitude = "12.8",
+                    Longitude = "22.9",
+                    ZipCode = zipCodes[1],
+                    DetailCodes = zipCodes,
+                    Area = zipCodes[2]
+                },
+                new Address
+                {
+                    Street = "130th",
+                    TaxNo = 18,
+                    Emails = new [] { "E9", "E6", "E8" },
+                    RelatedInfo = new AddressInfo { AreaSize = 201, CountyName = "Queue" },
+                    AdditionInfos = new AddressInfo[0],
+                    ZipCode = zipCodes[2],
+                    DetailCodes = zipCodes
+                },
+
+            };
+
+            People = new List<Person>
+            {
+                new Person
+                {
+                    Id = 1,
+                    Name = "Kate",
+                    Age = 5,
+                    Taxes = new [] { 7, 5, 9 },
+                    HomeLocation = repoLocations[0],
+                    RepoLocations = repoLocations,
+                    PreciseLocation = null, // by design
+                    OrderInfo = new OrderInfo
+                    {
+                        BillLocation = repoLocations[0],
+                        SubInfo = null
+                    }
+                },
+                new Person
+                {
+                    Id = 2,
+                    Name = "Lewis",
+                    Age = 6 ,
+                    Taxes = new [] { 1, 5, 2 },
+                    HomeLocation = new GeoLocation{ ZipCode = zipCodes[1], Street = "110th", Latitude = "12.211", Longitude ="231.131" },
+                    RepoLocations = repoLocations,
+                    PreciseLocation = null, // by design
+                    OrderInfo = new OrderInfo
+                    {
+                        BillLocation = new Address{ ZipCode = zipCodes[0], Street = "110th" }
+                    }
+                },
+                new Person
+                {
+                    Id = 3,
+                    Name = "Carlos",
+                    Age = 7,
+                    HomeLocation = null, // by design
+                    RepoLocations = repoLocations,
+                    OrderInfo = new OrderInfo
+                    {
+                        BillLocation = new Address{ ZipCode = zipCodes[0], Street = "110th" }
+                    },
+                    PreciseLocation = new GeoLocation{Area = zipCodes[2], Latitude = "12", Longitude = "22", Street = "50th", ZipCode = zipCodes[1]}
+                },
+                new Person
+                {
+                    Id = 4,
+                    Name = "Jones",
+                    Age = 9,
+                    HomeLocation = repoLocations[1],
+                    RepoLocations = repoLocations.Take(2).ToList(),
+                    PreciseLocation = new GeoLocation{Area = zipCodes[2], Latitude = "12", Longitude = "22", Street = "50th", ZipCode = zipCodes[1]},
+                    OrderInfo = new OrderInfo
+                    {
+                        BillLocation = new Address{ ZipCode = zipCodes[0], Street = "110th" },
+                        SubInfo = new OrderInfo{ BillLocation = new Address{ ZipCode = zipCodes[1], Street = "110th" }}
+                    }
+                },
+                new Person
+                {
+                    Id = 5,
+                    Name = "Park",
+                    Age = 17,
+                    HomeLocation = repoLocations[2],
+                    RepoLocations = repoLocations.Take(1).ToList(),
+                    OrderInfo = new OrderInfo()
+                    {
+                        propertybag = propertyBag
+                    }
+                },
+                new VipPerson
+                {
+                    Id = 6,
+                    Name = "Sam",
+                    Age = 40,
+                    HomeLocation = new Address
+                    {
+                        Street = "130th",
+                        TaxNo = 18,
+                        Emails = new [] { "A9", "A6", "A8" },
+                        RelatedInfo = new AddressInfo { AreaSize = 101, CountyName = "King" },
+                        AdditionInfos = Enumerable.Range(1, 3).Select(e => new AddressInfo
+                        {
+                            AreaSize = 101 + e,
+                            CountyName = "King" + e
+                        }).ToList(),
+                        ZipCode = zipCodes[2],
+                        DetailCodes = zipCodes
+                    },
+                    Bonus = 99
+                }
+            };
         }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/SelectImprovementOnComplexTypeTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/SelectImprovementOnComplexTypeTests.cs
@@ -1,0 +1,585 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Xunit;
+
+namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
+{
+    public class SelectImprovementOnComplexTypeTests : WebHostTestBase
+    {
+        private const string PeopleBaseUrl = "{0}/odata/People";
+
+        public SelectImprovementOnComplexTypeTests(WebHostTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            configuration.AddControllers(typeof(PeopleController));
+            configuration.JsonReferenceLoopHandling =
+                Newtonsoft.Json.ReferenceLoopHandling.Ignore;
+            configuration.MaxTop(2).Expand().Select().OrderBy().Filter();
+            configuration.MapODataServiceRoute("odata", "odata", ModelGenerator.GetConventionalEdmModel());
+        }
+
+        #region SubProperty on Single ComplexProperty
+        [Theory]
+        [InlineData("HomeLocation/Street,HomeLocation/TaxNo")]
+        [InlineData("HomeLocation($select=Street,TaxNo)")]
+        public void QueryEntityWithSelectOnSubPrimitivePropertyOfComplexProperty(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
+
+            string value = "\"HomeLocation\":{\"Street\":\"110th\",\"TaxNo\":19}";
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Street,HomeLocation/TaxNo)/$entity\"," + value + "}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("HomeLocation/Emails")]
+        [InlineData("HomeLocation($select=Emails)")]
+        public void QueryEntityWithSelectOnSubCollectionPrimitivePropertyOfComplexTypeProperty(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
+
+            string value = "\"HomeLocation\":{\"Emails\":[\"E1\",\"E3\",\"E2\"]}";
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Emails)/$entity\"," + value + "}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("HomeLocation/RelatedInfo,HomeLocation/AdditionInfos")]
+        [InlineData("HomeLocation($select=RelatedInfo,AdditionInfos)")]
+        public void QueryEntityWithSelectOnSubComplexPropertyOfComplexProperty(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
+
+            string value = "\"HomeLocation\":{\"RelatedInfo\":{\"AreaSize\":101,\"CountyName\":\"King\"}," +
+                "\"AdditionInfos\":[" +
+                  "{\"AreaSize\":102,\"CountyName\":\"King1\"}," +
+                  "{\"AreaSize\":103,\"CountyName\":\"King2\"}," +
+                  "{\"AreaSize\":104,\"CountyName\":\"King3\"}" +
+                "]}";
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/RelatedInfo,HomeLocation/AdditionInfos)/$entity\"," + value + "}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory(Skip = "Has problem in SelectExpandNode, need to skip the PathSelectItem for Nav?")]
+        [InlineData("HomeLocation/ZipCode,HomeLocation/Street")]
+        [InlineData("HomeLocation($select=ZipCode,Street)")]
+        public void QueryEntityWithSelectOnSubNavigationPropertyOfComplexTypeProperty(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select + "&$format=application/json;odata.metadata=full";
+
+            string value = "\"HomeLocation\":{\"Emails\":[\"E1\",\"E3\",\"E2\"]}";
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Emails)/$entity\"," + value + "}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude,HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Longitude")]
+        [InlineData("HomeLocation($select=Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude,Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Longitude)")]
+        public void QueryEntityWithSelectOnDerivedSubPropertyOfComplexTypeProperty(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(2)?$select=" + select;
+
+            string value = "\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Latitude\":\"12.211\",\"Longitude\":\"231.131\"}";
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude,HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Longitude)/$entity\"," + value + "}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("OrderInfo/DynamicAddress,OrderInfo/DynamicInt")]
+        [InlineData("OrderInfo($select=DynamicAddress,DynamicInt)")]
+        public void QueryEntityWithSelectOnSubDynamicPropertyOfComplexTypeProperty(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(5)?$select=" + select;
+
+            string value = "\"OrderInfo\":{" +
+                "\"DynamicInt\":9," +
+                "\"DynamicAddress\":{" +
+                  "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.Address\"," +
+                  "\"Street\":\"\"," +
+                  "\"TaxNo\":0," +
+                  "\"Emails\":[\"abc@1.com\",\"xyz@2.com\"]," +
+                  "\"RelatedInfo\":null," +
+                  "\"AdditionInfos\":[]" +
+                "}}";
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(OrderInfo)/$entity\"," + value + "}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(OrderInfo/DynamicAddress,OrderInfo/DynamicInt)/$entity\"," + value + "}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+        #endregion
+
+        #region SubProperty On Collection ComplexProperty
+        [Theory]
+        [InlineData("RepoLocations/Street,RepoLocations/TaxNo,RepoLocations/RelatedInfo")]
+        [InlineData("RepoLocations($select=Street,TaxNo,RelatedInfo)")]
+        public void QueryEntityWithSelectOnSubPropertyOfCollectionComplexProperty(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
+
+            string value = "\"RepoLocations\":[" +
+                "{\"Street\":\"110th\",\"TaxNo\":19,\"RelatedInfo\":{\"AreaSize\":101,\"CountyName\":\"King\"}}," +
+                "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Street\":\"120th\",\"TaxNo\":17,\"RelatedInfo\":null}," +
+                "{\"Street\":\"130th\",\"TaxNo\":18,\"RelatedInfo\":{\"AreaSize\":201,\"CountyName\":\"Queue\"}}" +
+              "]";
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Street,RepoLocations/TaxNo,RepoLocations/RelatedInfo)/$entity\"," + value + "}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("RepoLocations/Emails")]
+        [InlineData("RepoLocations($select=Emails)")]
+        public void QueryEntityWithSelectOnSubCollectionPrimitivePropertyOfCollectionComplexProperty(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(4)?$select=" + select;
+
+            string value = "\"RepoLocations\":[" +
+                "{\"Emails\":[\"E1\",\"E3\",\"E2\"]}," +
+                "{" +
+                  "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\"," +
+                  "\"Emails\":[\"E7\",\"E4\",\"E5\"]" +
+                "}" +
+              "]";
+
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Emails)/$entity\"," + value + "}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("RepoLocations/RelatedInfo,RepoLocations/AdditionInfos")]
+        [InlineData("RepoLocations($select=RelatedInfo,AdditionInfos)")]
+        public void QueryEntityWithSelectOnSubComplexPropertyOfCollectionComplexProperty(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(5)?$select=" + select;
+
+            string value = "\"RepoLocations\":[{\"RelatedInfo\":{\"AreaSize\":101,\"CountyName\":\"King\"}," +
+                "\"AdditionInfos\":[" +
+                  "{\"AreaSize\":102,\"CountyName\":\"King1\"}," +
+                  "{\"AreaSize\":103,\"CountyName\":\"King2\"}," +
+                  "{\"AreaSize\":104,\"CountyName\":\"King3\"}" +
+                "]}]";
+
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/RelatedInfo,RepoLocations/AdditionInfos)/$entity\"," + value + "}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("RepoLocations/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude")]
+        [InlineData("RepoLocations($select=Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude)")]
+        public void QueryEntityWithSelectOnDerivedSubPropertyOfCollectionComplexTypeProperty(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(4)?$select=" + select;
+
+            string value = "\"RepoLocations\":[" +
+                  "{}," + // Be noted, this is correct.
+                  "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Latitude\":\"12.8\"}" +
+                "]";
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude)/$entity\"," + value + "}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+        #endregion
+
+        #region Nested query option on select
+        [Theory]
+        [InlineData("Taxes", "\"Taxes\":[7,5,9]")]
+        [InlineData("Taxes($filter=$it eq 5)", "\"Taxes\":[5]")]
+        [InlineData("Taxes($filter=$it le 8)", "\"Taxes\":[7,5]")]
+        public void QueryEntityWithSelectOnCollectionPrimitivePropertyWithNestedFilter(string select, string value)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
+            string equals = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata#People(Taxes)/$entity\",{1}}}", BaseAddress, value);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("Taxes($orderby=$it)", "\"Taxes\":[5,7,9]")]
+        [InlineData("Taxes($orderby =$it desc)", "\"Taxes\":[9,7,5]")]
+        public void QueryEntityWithSelectOnCollectionPrimitivePropertyWithNestedOrderby(string select, string value)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
+            string equals = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata#People(Taxes)/$entity\",{1}}}", BaseAddress, value);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("Taxes($top=1;$skip=1)", "\"Taxes\":[5]")]
+        [InlineData("Taxes($top=2)", "\"Taxes\":[7,5]")]
+        [InlineData("Taxes($top=2;$skip=1)", "\"Taxes\":[5,9]")]
+        public void QueryEntityWithSelectOnCollectionPrimitivePropertyWithNestedTopAndSkip(string select, string value)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
+            string equals = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata#People(Taxes)/$entity\",{1}}}", BaseAddress, value);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("HomeLocation/Emails($filter=$it eq 'E3')")]
+        [InlineData("HomeLocation($select=Emails($filter=$it eq 'E3'))")]
+        public void QueryEntityWithSelectOnSubCollectionPrimitivePropertyOfComplexTypePropertyWithNestedFilter(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
+
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," +
+                    "\"HomeLocation\":{\"Emails\":[\"E3\"]}}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Emails)/$entity\"," +
+                    "\"HomeLocation\":{\"Emails\":[\"E3\"]}}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("HomeLocation/Emails($orderby=$it)")]
+        [InlineData("HomeLocation($select=Emails($orderby=$it desc))")]
+        public void QueryEntityWithSelectOnCollectionPrimitivePropertyOfComplexPropertyWithNestedOrderby(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(5)?$select=" + select;
+
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," +
+                    "\"HomeLocation\":{\"Emails\":[\"E9\",\"E8\",\"E6\"]}}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Emails)/$entity\"," +
+                    "\"HomeLocation\":{\"Emails\":[\"E6\",\"E8\",\"E9\"]}}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("HomeLocation/Emails($top=1;$skip=1)", "\"Emails\":[\"E6\"]")]
+        [InlineData("HomeLocation/Emails($top=2)", "\"Emails\":[\"E9\",\"E6\"]")]
+        [InlineData("HomeLocation/Emails($top=2;$skip=1)", "\"Emails\":[\"E6\",\"E8\"]")]
+        public void QueryEntityWithSelectOnCollectionPrimitivePropertyOfComplexPropertyWithNestedTopAndSkip(string select, string value)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(5)?$select=" + select;
+            string equals = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata#People(HomeLocation/Emails)/$entity\",\"HomeLocation\":{{{1}}}}}", BaseAddress, value);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("RepoLocations/Emails($filter=$it eq 'E3')")]
+        [InlineData("RepoLocations($select=Emails($filter=$it eq 'E3'))")]
+        public void QueryEntityWithSelectOnSubCollectionPrimitivePropertyOfCollectionComplexTypePropertyWithFilter(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
+
+            string value = "\"RepoLocations\":[" +
+                "{\"Emails\":[\"E3\"]}," +
+                "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Emails\":[]}," +
+                "{\"Emails\":[]}" +
+              "]";
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Emails)/$entity\"," + value + "}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("RepoLocations/Emails($orderby=$it;$top=1;$skip=2)")]
+        [InlineData("RepoLocations($select=Emails($orderby=$it;$top=1;$skip=2))")]
+        public void QueryEntityWithSelectOnSubCollectionPrimitivePropertyOfCollectionComplexTypePropertyWithOrderByTopSkip(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
+
+            string value = "\"RepoLocations\":[" +
+                "{\"Emails\":[\"E3\"]}," +
+                "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Emails\":[\"E7\"]}," +
+                "{\"Emails\":[\"E9\"]}" +
+              "]";
+            string expects;
+            if (select.Contains("$select="))
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
+            }
+            else
+            {
+                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Emails)/$entity\"," + value + "}";
+            }
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("RepoLocations($filter=TaxNo eq 17;$select=AdditionInfos($filter=AreaSize eq 102))")]
+        public void QueryEntityWithSelectOnSubCollectionComplexPropertyOfCollectionComplexTypePropertyWithNestedFilter(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
+
+            string expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," +
+                "\"RepoLocations\":[" +
+                  "{" +
+                    "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\"," +
+                    "\"AdditionInfos\":[" +
+                      "{\"AreaSize\":102,\"CountyName\":\"King1\"}" +
+                    "]" +
+                  "}" +
+                "]}";
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+        #endregion
+
+        [Theory]
+        [InlineData("HomeLocation/Street")]
+        [InlineData("HomeLocation($select=Street)")]
+        public void QueryEntitySetWithSelectOnSubPropertyOfComplexTypeProperty(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "?$select=" + select;
+
+            string value = "\"value\":[" +
+                "{\"HomeLocation\":{\"Street\":\"110th\"}}," +
+                "{\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Street\":\"110th\"}}," +
+                "{\"HomeLocation\":{\"Street\":null}}," +
+                "{\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Street\":\"120th\"}}," +
+                "{\"HomeLocation\":{\"Street\":\"130th\"}}," +
+                "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson\",\"HomeLocation\":{\"Street\":\"130th\"}}]";
+
+            string expect;
+            if (select.Contains("$select="))
+            {
+                expect = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)\"," + value + "}";
+            }
+            else
+            {
+                expect = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Street)\"," + value + "}";
+            }
+
+            string equals = expect.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Fact]
+        public void QueryEntitySetWithSelectOnDerivedProperty()
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) +
+                "?$select=Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson/Bonus";
+
+            string expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson/Bonus)\"," +
+                "\"value\":[" +
+                "{}," +
+                "{}," +
+                "{}," +
+                "{}," +
+                "{}," +
+                "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson\",\"Bonus\":99}" +
+              "]}";
+
+            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        private static string ExecuteAndVerifyQueryRequest(string requestUri, string equals)
+        {
+            // Arrange
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            HttpClient client = new HttpClient();
+
+            // Act
+            HttpResponseMessage response = client.SendAsync(request).Result;
+
+            // Assert
+            string result = response.Content.ReadAsStringAsync().Result;
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(equals, result);
+
+            return result;
+        }
+    }
+}
+

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/SelectImprovementOnComplexTypeTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/SelectImprovementOnComplexTypeTests.cs
@@ -39,17 +39,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
 
             string value = "\"HomeLocation\":{\"Street\":\"110th\",\"TaxNo\":19}";
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Street,HomeLocation/TaxNo)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Street,HomeLocation/TaxNo)/$entity\"," + value + "}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -64,17 +62,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
 
             string value = "\"HomeLocation\":{\"Emails\":[\"E1\",\"E3\",\"E2\"]}";
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Emails)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Emails)/$entity\"," + value + "}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -94,42 +90,46 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                   "{\"AreaSize\":103,\"CountyName\":\"King2\"}," +
                   "{\"AreaSize\":104,\"CountyName\":\"King3\"}" +
                 "]}";
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/RelatedInfo,HomeLocation/AdditionInfos)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/RelatedInfo,HomeLocation/AdditionInfos)/$entity\"," + value + "}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
         }
 
-        [Theory(Skip = "Has problem in SelectExpandNode, need to skip the PathSelectItem for Nav?")]
+        [Theory]
         [InlineData("HomeLocation/ZipCode,HomeLocation/Street")]
-        [InlineData("HomeLocation($select=ZipCode,Street)")]
+        // [InlineData("HomeLocation($select=ZipCode,Street)")] See https://github.com/OData/odata.net/issues/1574#issuecomment-547570980
         public void QueryEntityWithSelectOnSubNavigationPropertyOfComplexTypeProperty(string select)
         {
             // Arrange
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select + "&$format=application/json;odata.metadata=full";
 
-            string value = "\"HomeLocation\":{\"Emails\":[\"E1\",\"E3\",\"E2\"]}";
-            string expects;
+            string value = "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.Person\"," +
+                "\"@odata.id\":\"BASE_ADDRESS/odata/People(1)\"," +
+                "\"@odata.editLink\":\"BASE_ADDRESS/odata/People(1)\"," +
+                "\"HomeLocation\":{" +
+                    "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.Address\"," +
+                    "\"Street\":\"110th\"," +
+                    "\"ZipCode@odata.associationLink\":\"BASE_ADDRESS/odata/People(1)/HomeLocation/ZipCode/$ref\"," +
+                    "\"ZipCode@odata.navigationLink\":\"BASE_ADDRESS/odata/People(1)/HomeLocation/ZipCode\"" +
+                "}";
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Emails)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/ZipCode,HomeLocation/Street)/$entity\"," + value + "}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -144,17 +144,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(2)?$select=" + select;
 
             string value = "\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Latitude\":\"12.211\",\"Longitude\":\"231.131\"}";
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," + value + "}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude,HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Longitude)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude,HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Longitude)/$entity\"," + value + "}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -178,17 +176,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                   "\"RelatedInfo\":null," +
                   "\"AdditionInfos\":[]" +
                 "}}";
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(OrderInfo)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(OrderInfo)/$entity\"," + value + "}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(OrderInfo/DynamicAddress,OrderInfo/DynamicInt)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(OrderInfo/DynamicAddress,OrderInfo/DynamicInt)/$entity\"," + value + "}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -209,17 +205,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                 "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Street\":\"120th\",\"TaxNo\":17,\"RelatedInfo\":null}," +
                 "{\"Street\":\"130th\",\"TaxNo\":18,\"RelatedInfo\":{\"AreaSize\":201,\"CountyName\":\"Queue\"}}" +
               "]";
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Street,RepoLocations/TaxNo,RepoLocations/RelatedInfo)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Street,RepoLocations/TaxNo,RepoLocations/RelatedInfo)/$entity\"," + value + "}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -241,17 +235,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                 "}" +
               "]";
 
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Emails)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Emails)/$entity\"," + value + "}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -272,17 +264,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                   "{\"AreaSize\":104,\"CountyName\":\"King3\"}" +
                 "]}]";
 
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/RelatedInfo,RepoLocations/AdditionInfos)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/RelatedInfo,RepoLocations/AdditionInfos)/$entity\"," + value + "}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -300,17 +290,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                   "{}," + // Be noted, this is correct.
                   "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Latitude\":\"12.8\"}" +
                 "]";
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude)/$entity\"," + value + "}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -326,7 +314,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
         {
             // Arrange
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
-            string equals = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata#People(Taxes)/$entity\",{1}}}", BaseAddress, value);
+            string equals = string.Format("{{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(Taxes)/$entity\",{0}}}", value);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -339,7 +327,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
         {
             // Arrange
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
-            string equals = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata#People(Taxes)/$entity\",{1}}}", BaseAddress, value);
+            string equals = string.Format("{{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(Taxes)/$entity\",{0}}}", value);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -353,7 +341,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
         {
             // Arrange
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
-            string equals = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata#People(Taxes)/$entity\",{1}}}", BaseAddress, value);
+            string equals = string.Format("{{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(Taxes)/$entity\",{0}}}", value);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -367,19 +355,17 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             // Arrange
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
 
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," +
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," +
                     "\"HomeLocation\":{\"Emails\":[\"E3\"]}}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Emails)/$entity\"," +
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Emails)/$entity\"," +
                     "\"HomeLocation\":{\"Emails\":[\"E3\"]}}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -393,19 +379,17 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             // Arrange
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(5)?$select=" + select;
 
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," +
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)/$entity\"," +
                     "\"HomeLocation\":{\"Emails\":[\"E9\",\"E8\",\"E6\"]}}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Emails)/$entity\"," +
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Emails)/$entity\"," +
                     "\"HomeLocation\":{\"Emails\":[\"E6\",\"E8\",\"E9\"]}}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -419,7 +403,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
         {
             // Arrange
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(5)?$select=" + select;
-            string equals = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata#People(HomeLocation/Emails)/$entity\",\"HomeLocation\":{{{1}}}}}", BaseAddress, value);
+            string equals = string.Format("{{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Emails)/$entity\",\"HomeLocation\":{{{0}}}}}", value);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -438,17 +422,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                 "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Emails\":[]}," +
                 "{\"Emails\":[]}" +
               "]";
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Emails)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Emails)/$entity\"," + value + "}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -467,17 +449,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                 "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Emails\":[\"E7\"]}," +
                 "{\"Emails\":[\"E9\"]}" +
               "]";
-            string expects;
+            string equals;
             if (select.Contains("$select="))
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," + value + "}";
             }
             else
             {
-                expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Emails)/$entity\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations/Emails)/$entity\"," + value + "}";
             }
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -490,7 +470,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             // Arrange
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "(1)?$select=" + select;
 
-            string expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," +
+            string equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(RepoLocations)/$entity\"," +
                 "\"RepoLocations\":[" +
                   "{" +
                     "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\"," +
@@ -499,8 +479,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                     "]" +
                   "}" +
                 "]}";
-
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -521,19 +499,17 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                 "{\"HomeLocation\":{\"Street\":null}}," +
                 "{\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Street\":\"120th\"}}," +
                 "{\"HomeLocation\":{\"Street\":\"130th\"}}," +
-                "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson\",\"HomeLocation\":{\"Street\":\"130th\"}}]";
+                "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson\",\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeometryLocation\",\"Street\":\"130th\"}}]";
 
-            string expect;
+            string equals;
             if (select.Contains("$select="))
             {
-                expect = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)\"," + value + "}";
             }
             else
             {
-                expect = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Street)\"," + value + "}";
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Street)\"," + value + "}";
             }
-
-            string equals = expect.Replace("BASE_ADDRESS", BaseAddress);
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -546,7 +522,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             string requestUri = string.Format(PeopleBaseUrl, BaseAddress) +
                 "?$select=Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson/Bonus";
 
-            string expects = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson/Bonus)\"," +
+            string equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson/Bonus)\"," +
                 "\"value\":[" +
                 "{}," +
                 "{}," +
@@ -556,7 +532,95 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                 "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson\",\"Bonus\":99}" +
               "]}";
 
-            string equals = expects.Replace("BASE_ADDRESS", BaseAddress);
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Fact]
+        public void QueryEntitySetWithSelectOnDerivedPropertyWithFullMetadata()
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) +
+                "?$select=Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson/Bonus&$format=application/json;odata.metadata=full";
+
+            string equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson/Bonus)\"," +
+                "\"value\":[" +
+                "{" +
+                   "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.Person\"," +
+                   "\"@odata.id\":\"BASE_ADDRESS/odata/People(1)\"," +
+                   "\"@odata.editLink\":\"BASE_ADDRESS/odata/People(1)\"" +
+                "}," +
+                "{" +
+                   "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.Person\"," +
+                   "\"@odata.id\":\"BASE_ADDRESS/odata/People(2)\"," +
+                   "\"@odata.editLink\":\"BASE_ADDRESS/odata/People(2)\"" +
+                "}," +
+                "{" +
+                   "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.Person\"," +
+                   "\"@odata.id\":\"BASE_ADDRESS/odata/People(3)\"," +
+                   "\"@odata.editLink\":\"BASE_ADDRESS/odata/People(3)\"" +
+                "}," +
+                "{" +
+                   "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.Person\"," +
+                   "\"@odata.id\":\"BASE_ADDRESS/odata/People(4)\"," +
+                   "\"@odata.editLink\":\"BASE_ADDRESS/odata/People(4)\"" +
+                "}," +
+                "{" +
+                   "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.Person\"," +
+                   "\"@odata.id\":\"BASE_ADDRESS/odata/People(5)\"," +
+                   "\"@odata.editLink\":\"BASE_ADDRESS/odata/People(5)\"" +
+                "}," +
+                "{" +
+                   "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson\"," +
+                   "\"@odata.id\":\"BASE_ADDRESS/odata/People(6)\"," +
+                   "\"@odata.editLink\":\"BASE_ADDRESS/odata/People(6)\"," +
+                   "\"Bonus\":99" +
+                "}" +
+              "]}";
+
+            // Act & Assert
+            ExecuteAndVerifyQueryRequest(requestUri, equals);
+        }
+
+        [Theory]
+        [InlineData("HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude,HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeometryLocation/Latitude")]
+        [InlineData("HomeLocation($select=Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude,Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeometryLocation/Latitude)")]
+        public void QueryEntitySetWithSelectOnSameNameDerivedPropertyOfComplexPropertyWithTypeCast(string select)
+        {
+            // Arrange
+            string requestUri = string.Format(PeopleBaseUrl, BaseAddress) + "?$select=" + select;
+
+            string value = "\"value\":[" +
+                "{" +
+                    "\"HomeLocation\":{}" +
+                "}," +
+                "{" +
+                    "\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Latitude\":\"12.211\"}" +
+                "}," +
+                "{" +
+                    "\"HomeLocation\":{}" +
+                "}," +
+                "{" +
+                    "\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Latitude\":\"12.8\"}" +
+                "}," +
+                "{" +
+                    "\"HomeLocation\":{}" +
+                "}," +
+                "{" +
+                    "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson\"," +
+                    "\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeometryLocation\",\"Latitude\":\"101.1\"}" +
+                "}" +
+             "]";
+
+            string equals;
+            if (select.Contains("$select="))
+            {
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation)\"," + value + "}";
+            }
+            else
+            {
+                equals = "{\"@odata.context\":\"BASE_ADDRESS/odata/$metadata#People(HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation/Latitude,HomeLocation/Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeometryLocation/Latitude)\"," + value + "}";
+            }
 
             // Act & Assert
             ExecuteAndVerifyQueryRequest(requestUri, equals);
@@ -574,6 +638,13 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
 
             // Assert
             string result = response.Content.ReadAsStringAsync().Result;
+
+            // replace the real address using "BASE_ADDRESS"
+            string odataContext = "\"@odata.context\":\"";
+            int start = result.IndexOf(odataContext) + odataContext.Length;
+            int end = result.IndexOf("/odata/$metadata");
+            string uri = result.Substring(start, end - start);
+            result = result.Replace(uri, "BASE_ADDRESS");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(equals, result);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/ODataResourceSerializerTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/ODataResourceSerializerTests.cs
@@ -210,7 +210,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             // Arrange
             SelectExpandNode selectExpandNode = new SelectExpandNode
             {
-                SelectedNavigationProperties =
+                SelectedNavigationProperties = new HashSet<IEdmNavigationProperty>
                 {
                     new Mock<IEdmNavigationProperty>().Object,
                     new Mock<IEdmNavigationProperty>().Object
@@ -237,7 +237,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             // Arrange
             SelectExpandNode selectExpandNode = new SelectExpandNode
             {
-                SelectedNavigationProperties =
+                SelectedNavigationProperties = new HashSet<IEdmNavigationProperty>
                 {
                     new Mock<IEdmNavigationProperty>().Object,
                     new Mock<IEdmNavigationProperty>().Object
@@ -275,7 +275,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             // Arrange
             SelectExpandNode selectExpandNode = new SelectExpandNode
             {
-                ExpandedProperties =
+                ExpandedProperties = new Dictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem>
                 {
                     { new Mock<IEdmNavigationProperty>().Object, null },
                     { new Mock<IEdmNavigationProperty>().Object, null }
@@ -284,12 +284,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             Mock<ODataWriter> writer = new Mock<ODataWriter>();
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(_serializerProvider);
             serializer.Setup(s => s.CreateSelectExpandNode(It.IsAny<ResourceContext>())).Returns(selectExpandNode);
-#pragma warning disable CS0618 // Type or member is obsolete
-            var expandedNavigationProperties = selectExpandNode.ExpandedNavigationProperties.ToList();
-#pragma warning restore CS0618 // Type or member is obsolete
+            var expandedNavigationProperties = selectExpandNode.ExpandedProperties.Keys;
 
-            serializer.Setup(s => s.CreateNavigationLink(expandedNavigationProperties[0].Key, It.IsAny<ResourceContext>())).Verifiable();
-            serializer.Setup(s => s.CreateNavigationLink(expandedNavigationProperties[1].Key, It.IsAny<ResourceContext>())).Verifiable();
+            serializer.Setup(s => s.CreateNavigationLink(expandedNavigationProperties.First(), It.IsAny<ResourceContext>())).Verifiable();
+            serializer.Setup(s => s.CreateNavigationLink(expandedNavigationProperties.Last(), It.IsAny<ResourceContext>())).Verifiable();
             serializer.CallBase = true;
 
             // Act
@@ -312,7 +310,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
 
             SelectExpandNode selectExpandNode = new SelectExpandNode
             {
-                ExpandedProperties =
+                ExpandedProperties = new Dictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem>
                 {
                     { ordersProperty, selectExpandClause.SelectedItems.OfType<ExpandedNavigationSelectItem>().Single() }
                 },
@@ -325,9 +323,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
                 .Callback((object o, IEdmTypeReference t, ODataWriter w, ODataSerializerContext context) =>
                     {
                         Assert.Same(context.NavigationSource.Name, "Orders");
-#pragma warning disable CS0618 // Type or member is obsolete
-                        Assert.Same(context.SelectExpandClause, selectExpandNode.ExpandedNavigationProperties.Single().Value);
-#pragma warning restore CS0618 // Type or member is obsolete
+                        Assert.Same(context.SelectExpandClause, selectExpandNode.ExpandedProperties.Single().Value.SelectAndExpand);
                     })
                 .Verifiable();
 
@@ -368,7 +364,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
                 new Dictionary<string, string> { { "$select", "Orders" }, { "$expand", "Orders" } });
             SelectExpandClause selectExpandClause = parser.ParseSelectAndExpand();
 
-            SelectExpandNode selectExpandNode = new SelectExpandNode();
+            SelectExpandNode selectExpandNode = new SelectExpandNode
+            {
+                ExpandedProperties = new Dictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem>()
+            };
             selectExpandNode.ExpandedProperties[ordersProperty] = selectExpandClause.SelectedItems.OfType<ExpandedNavigationSelectItem>().Single();
 
             Mock<ODataWriter> writer = new Mock<ODataWriter>();
@@ -406,7 +405,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
                 new Dictionary<string, string> { { "$select", "Orders" }, { "$expand", "Orders" } });
             SelectExpandClause selectExpandClause = parser.ParseSelectAndExpand();
 
-            SelectExpandNode selectExpandNode = new SelectExpandNode();
+            SelectExpandNode selectExpandNode = new SelectExpandNode
+            {
+                ExpandedProperties = new Dictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem>()
+            };
             selectExpandNode.ExpandedProperties[ordersProperty] =
                 selectExpandClause.SelectedItems.OfType<ExpandedNavigationSelectItem>().Single();
 
@@ -451,7 +453,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
                 new Dictionary<string, string> { { "$select", "Customer" }, { "$expand", "Customer" } });
             SelectExpandClause selectExpandClause = parser.ParseSelectAndExpand();
 
-            SelectExpandNode selectExpandNode = new SelectExpandNode();
+            SelectExpandNode selectExpandNode = new SelectExpandNode
+            {
+                ExpandedProperties = new Dictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem>()
+            };
             selectExpandNode.ExpandedProperties[customerProperty] =
                 selectExpandClause.SelectedItems.OfType<ExpandedNavigationSelectItem>().Single();
 
@@ -499,7 +504,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
                 });
             SelectExpandClause selectExpandClause = parser.ParseSelectAndExpand();
 
-            SelectExpandNode selectExpandNode = new SelectExpandNode();
+            SelectExpandNode selectExpandNode = new SelectExpandNode
+            {
+                ExpandedProperties = new Dictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem>()
+            };
             selectExpandNode.ExpandedProperties[specialOrdersProperty] =
                 selectExpandClause.SelectedItems.OfType<ExpandedNavigationSelectItem>().Single();
 
@@ -554,7 +562,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
                 });
             SelectExpandClause selectExpandClause = parser.ParseSelectAndExpand();
 
-            SelectExpandNode selectExpandNode = new SelectExpandNode();
+            SelectExpandNode selectExpandNode = new SelectExpandNode
+            {
+                ExpandedProperties = new Dictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem>()
+            };
             selectExpandNode.ExpandedProperties[customerProperty] =
                 selectExpandClause.SelectedItems.OfType<ExpandedNavigationSelectItem>().Single();
 
@@ -599,7 +610,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             // Arrange
             SelectExpandNode selectExpandNode = new SelectExpandNode
             {
-                SelectedStructuralProperties = { new Mock<IEdmStructuralProperty>().Object, new Mock<IEdmStructuralProperty>().Object }
+                SelectedStructuralProperties = new HashSet<IEdmStructuralProperty>
+                {
+                    new Mock<IEdmStructuralProperty>().Object, new Mock<IEdmStructuralProperty>().Object
+                }
             };
             ODataProperty[] properties = new ODataProperty[] { new ODataProperty(), new ODataProperty() };
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(_serializerProvider);
@@ -628,7 +642,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             // Arrange
             SelectExpandNode selectExpandNode = new SelectExpandNode
             {
-                SelectedStructuralProperties = { new Mock<IEdmStructuralProperty>().Object, new Mock<IEdmStructuralProperty>().Object }
+                SelectedStructuralProperties = new HashSet<IEdmStructuralProperty>
+                {
+                    new Mock<IEdmStructuralProperty>().Object, new Mock<IEdmStructuralProperty>().Object
+                }
             };
             ODataProperty[] properties = new[] { new ODataProperty(), new ODataProperty() };
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(_serializerProvider);
@@ -665,7 +682,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
 
             SelectExpandNode selectExpandNode = new SelectExpandNode
             {
-                SelectedStructuralProperties = { new Mock<IEdmStructuralProperty>().Object, new Mock<IEdmStructuralProperty>().Object }
+                SelectedStructuralProperties = new HashSet<IEdmStructuralProperty>
+                {
+                    new Mock<IEdmStructuralProperty>().Object, new Mock<IEdmStructuralProperty>().Object
+                }
             };
             ODataProperty[] properties = new[] { new ODataProperty(), new ODataProperty() };
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(_serializerProvider);
@@ -697,7 +717,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             mockConcurrencyProperty.SetupGet(s => s.Name).Returns("City");
             SelectExpandNode selectExpandNode = new SelectExpandNode
             {
-                SelectedStructuralProperties = { new Mock<IEdmStructuralProperty>().Object, mockConcurrencyProperty.Object }
+                SelectedStructuralProperties = new HashSet<IEdmStructuralProperty> { new Mock<IEdmStructuralProperty>().Object, mockConcurrencyProperty.Object }
             };
             ODataProperty[] properties = new[] { new ODataProperty(), new ODataProperty() };
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(_serializerProvider);
@@ -741,7 +761,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             // Arrange
             SelectExpandNode selectExpandNode = new SelectExpandNode
             {
-                SelectedStructuralProperties = { new Mock<IEdmStructuralProperty>().Object }
+                SelectedStructuralProperties = new HashSet<IEdmStructuralProperty> { new Mock<IEdmStructuralProperty>().Object }
             };
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(_serializerProvider);
             serializer.CallBase = true;
@@ -765,7 +785,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             ODataAction[] actions = new ODataAction[] { new ODataAction(), new ODataAction() };
             SelectExpandNode selectExpandNode = new SelectExpandNode
             {
-                SelectedActions = { new Mock<IEdmAction>().Object, new Mock<IEdmAction>().Object }
+                SelectedActions = new HashSet<IEdmAction> { new Mock<IEdmAction>().Object, new Mock<IEdmAction>().Object }
             };
             Mock<ODataResourceSerializer> serializer = new Mock<ODataResourceSerializer>(_serializerProvider);
             serializer.CallBase = true;
@@ -1752,13 +1772,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
 
             SelectExpandNode selectExpandNode = new SelectExpandNode
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                ExpandedNavigationProperties =
-#pragma warning restore CS0618 // Type or member is obsolete
-                {
-                     { ordersProperty, new SelectExpandClause(new SelectItem[0], allSelected: true) }
-                },
-                ExpandedProperties =
+                ExpandedProperties = new Dictionary<IEdmNavigationProperty, ExpandedNavigationSelectItem>
                 {
                     {ordersProperty, null }
                 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/SelectExpandNodeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/SelectExpandNodeTest.cs
@@ -19,21 +19,20 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
         private CustomersModelWithInheritance _model = new CustomersModelWithInheritance();
 
         [Fact]
-        public void Ctor_ThrowsArgumentNull_EntityType()
+        public void Ctor_ThrowsArgumentNull_StructuredType()
         {
+            // Arrange & Act & Assert
             ExceptionAssert.ThrowsArgumentNull(
                 () => new SelectExpandNode(selectExpandClause: null, structuredType: null, model: EdmCoreModel.Instance),
                 "structuredType");
         }
 
         [Fact]
-        public void Ctor_ThrowsArgumentNull_Model()
+        public void Ctor_ThrowsArgumentNull_EdmModel()
         {
+            // Arrange & Act & Assert
             ExceptionAssert.ThrowsArgumentNull(
-                () => new SelectExpandNode(
-                    selectExpandClause: null,
-                    structuredType: new Mock<IEdmEntityType>().Object,
-                    model: null),
+                () => new SelectExpandNode(selectExpandClause: null, structuredType: new Mock<IEdmEntityType>().Object, model: null),
                 "model");
         }
 
@@ -57,41 +56,52 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
         [Theory]
         [InlineData(null, null, false, "City,ID,Name,SimpleEnum", "Account,Address,OtherAccounts")] // no select and expand -> select all
         [InlineData(null, null, true, "City,ID,Name,SimpleEnum,SpecialCustomerProperty", "Account,Address,OtherAccounts,SpecialAddress")] // no select and expand on derived type -> select all
-        [InlineData("ID", null, false, "ID", "")] // simple select -> select requested
-        [InlineData("ID", null, true, "ID", "")] // simple select on derived type -> select requested
+        [InlineData("ID", null, false, "ID", null)] // simple select -> select requested
+        [InlineData("ID", null, true, "ID", null)] // simple select on derived type -> select requested
         [InlineData("*", null, false, "City,ID,Name,SimpleEnum", "Account,Address,OtherAccounts")] // simple select with wild card -> select all, no duplication
         [InlineData("*", null, true, "City,ID,Name,SimpleEnum,SpecialCustomerProperty", "Account,Address,OtherAccounts,SpecialAddress")] // simple select with wild card on derived type -> select all, no duplication
         [InlineData("ID,*", null, false, "City,ID,Name,SimpleEnum", "Account,Address,OtherAccounts")] // simple select with wild card and duplicate -> select all, no duplicates
         [InlineData("ID,*", null, true, "City,ID,Name,SimpleEnum,SpecialCustomerProperty", "Account,Address,OtherAccounts,SpecialAddress")] // simple select with wild card and duplicate -> select all, no duplicates
-        [InlineData("ID,Name", null, false, "ID,Name", "")] // multiple select -> select requested
-        [InlineData("ID,Name", null, true, "ID,Name", "")] // multiple select on derived type -> select requested
-        [InlineData("Orders", "Orders", false, "", "")] // only expand -> select no structural property
-        [InlineData("Orders", "Orders", true, "", "")] // only expand -> select no structural property
+        [InlineData("ID,Name", null, false, "ID,Name", null)] // multiple select -> select requested
+        [InlineData("ID,Name", null, true, "ID,Name", null)] // multiple select on derived type -> select requested
+        [InlineData("Orders", "Orders", false, null, null)] // only expand -> select no structural property
+        [InlineData("Orders", "Orders", true, null, null)] // only expand -> select no structural property
         [InlineData(null, "Orders", false, "City,ID,Name,SimpleEnum", "Account,Address,OtherAccounts")] // simple expand -> select all
         [InlineData(null, "Orders", true, "City,ID,Name,SimpleEnum,SpecialCustomerProperty", "Account,Address,OtherAccounts,SpecialAddress")] // simple expand on derived type -> select all
-        [InlineData("ID,Name,Orders", "Orders", false, "ID,Name", "")] // expand and select -> select requested
-        [InlineData("ID,Name,Orders", "Orders", true, "ID,Name", "")] // expand and select on derived type -> select requested
-        [InlineData("NS.SpecialCustomer/SpecialCustomerProperty", "", false, "", "")] // select derived type properties -> select none
-        [InlineData("NS.SpecialCustomer/SpecialCustomerProperty", "", true, "SpecialCustomerProperty", "")] // select derived type properties on derived type -> select requested
-        [InlineData("ID", "Orders($select=ID),Orders($expand=Customer($select=ID))", true, "ID", "")] // deep expand and selects
-        public void GetPropertiesToBeSelected_Selects_ExpectedProperties_OnCustomer(
-            string select, string expand, bool specialCustomer, string structuralPropertiesToSelect, string nestedProperteisToSelect)
+        [InlineData("ID,Name,Orders", "Orders", false, "ID,Name", null)] // expand and select -> select requested
+        [InlineData("ID,Name,Orders", "Orders", true, "ID,Name", null)] // expand and select on derived type -> select requested
+        [InlineData("NS.SpecialCustomer/SpecialCustomerProperty", null, false, null, null)] // select derived type properties -> select none
+        [InlineData("NS.SpecialCustomer/SpecialCustomerProperty", null, true, "SpecialCustomerProperty", null)] // select derived type properties on derived type -> select requested
+        [InlineData("ID", "Orders($select=ID),Orders($expand=Customer($select=ID))", true, "ID", null)] // deep expand and selects
+        public void SelectProperties_SelectsExpectedProperties_OnCustomer(
+            string select, string expand, bool specialCustomer, string structuralsToSelect, string complexesToSelect)
         {
             // Arrange
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(_model.Model, _model.Customer, _model.Customers,
-                new Dictionary<string, string> { { "$select", select }, { "$expand", expand } });
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, expand);
 
-            SelectExpandClause selectExpandClause = parser.ParseSelectAndExpand();
-            IEdmEntityType entityType = specialCustomer ? _model.SpecialCustomer : _model.Customer;
+            IEdmStructuredType structuralType = specialCustomer ? _model.SpecialCustomer : _model.Customer;
 
             // Act
-            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, entityType, _model.Model);
-            var result = selectExpandNode.SelectedStructuralProperties;
+            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, structuralType, _model.Model);
 
             // Assert
-            Assert.Equal(structuralPropertiesToSelect, String.Join(",", result.Select(p => p.Name).OrderBy(n => n)));
-            Assert.Equal(nestedProperteisToSelect,
-                String.Join(",", selectExpandNode.SelectedComplexProperties.Select(p => p.Name).OrderBy(n => n)));
+            if (structuralsToSelect == null)
+            {
+                Assert.Null(selectExpandNode.SelectedStructuralProperties);
+            }
+            else
+            {
+                Assert.Equal(structuralsToSelect, String.Join(",", selectExpandNode.SelectedStructuralProperties.Select(p => p.Name).OrderBy(n => n)));
+            }
+
+            if (complexesToSelect == null)
+            {
+                Assert.Null(selectExpandNode.SelectedComplexProperties);
+            }
+            else
+            {
+                Assert.Equal(complexesToSelect, String.Join(",", selectExpandNode.SelectedComplexProperties.Select(p => p.Name).OrderBy(n => n)));
+            }
         }
 
         [Theory]
@@ -101,64 +111,366 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
         [InlineData("ID,Name,Orders", "Orders($select=ID)", true, "ID")] // expand and select properties on expand on derived type -> select requested
         [InlineData("Orders", "Orders,Orders($expand=Customer)", false, "Amount,City,ID")]
         [InlineData("Orders", "Orders,Orders($expand=Customer)", true, "Amount,City,ID,SpecialOrderProperty")]
-        public void GetPropertiesToBeSelected_Selects_ExpectedProperties_OnExpandedOrders(
-            string select, string expand, bool specialOrder, string structuralPropertiesToSelect)
+        public void SelectProperties_Selects_ExpectedProperties_OnExpandedOrders(string select, string expand, bool specialOrder, string structuralPropertiesToSelect)
         {
             // Arrange
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(_model.Model, _model.Customer, _model.Customers,
-                new Dictionary<string, string> { { "$select", select }, { "$expand", expand } });
-            SelectExpandClause selectExpandClause = parser.ParseSelectAndExpand();
-
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, expand);
             SelectExpandClause nestedSelectExpandClause = selectExpandClause.SelectedItems.OfType<ExpandedNavigationSelectItem>().Single().SelectAndExpand;
-
-            IEdmEntityType entityType = specialOrder ? _model.SpecialOrder : _model.Order;
+            IEdmStructuredType structuralType = specialOrder ? _model.SpecialOrder : _model.Order;
 
             // Act
-            SelectExpandNode selectExpandNode = new SelectExpandNode(nestedSelectExpandClause, entityType, _model.Model);
-            var result = selectExpandNode.SelectedStructuralProperties;
+            SelectExpandNode selectExpandNode = new SelectExpandNode(nestedSelectExpandClause, structuralType, _model.Model);
 
             // Assert
-            Assert.Equal(structuralPropertiesToSelect, String.Join(",", result.Select(p => p.Name).OrderBy(n => n)));
+            Assert.Equal(structuralPropertiesToSelect, String.Join(",", selectExpandNode.SelectedStructuralProperties.Select(p => p.Name).OrderBy(n => n)));
+        }
+
+        [Theory]
+        [InlineData("Address/Street,Address/City,Address/ZipCode", "Address", "Street,City,ZipCode")] // complex
+        [InlineData("Address($select=Street,City,ZipCode)", "Address", "Street,City,ZipCode")]
+        [InlineData("OtherAccounts/Bank,OtherAccounts/CardNum", "OtherAccounts", "Bank,CardNum")] // Collection complex
+        [InlineData("OtherAccounts($select=Bank,CardNum)", "OtherAccounts", "Bank,CardNum")]
+        public void SelectProperties_OnSubPrimitivePropertyFromComplex_SelectsExpectedProperties(string select, string firstSelected, string secondSelected)
+        {
+            // Arrange
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null);
+
+            // Act: Top Level
+            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, _model.Customer, _model.Model);
+
+            // Assert
+            Assert.NotNull(selectExpandNode.SelectedComplexes);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.Equal(firstSelected, firstLevelSelected.Key.Name);
+
+            Assert.NotNull(firstLevelSelected.Value);
+            Assert.NotNull(firstLevelSelected.Value.SelectAndExpand);
+
+            // Act: Sub Level
+            IEdmStructuredType subLevelElementType = firstLevelSelected.Key.Type.ToStructuredType();
+            SelectExpandNode subSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, subLevelElementType, _model.Model);
+            Assert.Null(subSelectExpandNode.SelectedComplexes);
+
+            // Assert
+            Assert.NotNull(subSelectExpandNode.SelectedStructuralProperties);
+            var selectedProperties = secondSelected.Split(',');
+            Assert.Equal(selectedProperties.Length, subSelectExpandNode.SelectedStructuralProperties.Count);
+            Assert.Equal(secondSelected, String.Join(",", subSelectExpandNode.SelectedStructuralProperties.Select(s => s.Name)));
+        }
+
+        [Theory]
+        [InlineData("Account/BankAddress/Street,Account/BankAddress/City,Account/BankAddress/ZipCode")]
+        [InlineData("Account/BankAddress($select=Street,City,ZipCode)")]
+        public void SelectProperties_OnMultipleLevelsPropertyFromComplex_SelectsExpectedProperties(string select)
+        {
+            // Arrange
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null);
+
+            // Act: First Level
+            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, _model.Customer, _model.Model);
+
+            // Assert
+            Assert.Null(selectExpandNode.SelectedStructuralProperties);
+            Assert.NotNull(selectExpandNode.SelectedComplexes);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.Equal("Account", firstLevelSelected.Key.Name);
+            Assert.NotNull(firstLevelSelected.Value);
+            Assert.NotNull(firstLevelSelected.Value.SelectAndExpand);
+
+            // Act: Second Level
+            SelectExpandNode secondSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, _model.Account, _model.Model);
+
+            // Assert
+            Assert.Null(secondSelectExpandNode.SelectedStructuralProperties);
+            Assert.NotNull(secondSelectExpandNode.SelectedComplexes);
+            var secondLevelSelected = Assert.Single(secondSelectExpandNode.SelectedComplexes);
+            Assert.Equal("BankAddress", secondLevelSelected.Key.Name);
+            Assert.NotNull(secondLevelSelected.Value);
+            Assert.NotNull(secondLevelSelected.Value.SelectAndExpand);
+
+            // Act: Third Level
+            SelectExpandNode thirdSelectExpandNode = new SelectExpandNode(secondLevelSelected.Value.SelectAndExpand, _model.Address, _model.Model);
+
+            // Assert
+            Assert.Null(thirdSelectExpandNode.SelectedComplexes);
+            Assert.NotNull(thirdSelectExpandNode.SelectedStructuralProperties);
+            Assert.Equal(3, thirdSelectExpandNode.SelectedStructuralProperties.Count);
+            Assert.Equal(new[] { "Street", "City", "ZipCode" }, thirdSelectExpandNode.SelectedStructuralProperties.Select(s => s.Name));
+        }
+
+        [Theory]
+        [InlineData("Account/DynamicProperty", "Account")]
+        [InlineData("Account($select=DynamicProperty)", "Account")]
+        [InlineData("OtherAccounts/DynamicProperty", "OtherAccounts")]
+        [InlineData("OtherAccounts($select=DynamicProperty)", "OtherAccounts")]
+        public void SelectProperties_OnSubDynamicFromComplex_SelectsExpectedProperties(string select, string firstSelected)
+        {
+            // Arrange
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null);
+
+            // Act
+            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, _model.Customer, _model.Model);
+
+            // Assert: Top Level
+            Assert.False(selectExpandNode.SelectAllDynamicProperties);
+            Assert.Null(selectExpandNode.SelectedDynamicProperties);
+            Assert.Null(selectExpandNode.SelectedStructuralProperties);
+            Assert.Null(selectExpandNode.SelectedNavigationProperties);
+            Assert.NotNull(selectExpandNode.SelectedComplexes);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.Equal(firstSelected, firstLevelSelected.Key.Name);
+
+            Assert.NotNull(firstLevelSelected.Value);
+            Assert.NotNull(firstLevelSelected.Value.SelectAndExpand);
+
+            // Assert: Second Level
+            SelectExpandNode subSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, _model.Account, _model.Model);
+            Assert.Null(subSelectExpandNode.SelectedComplexes);
+            Assert.Null(subSelectExpandNode.SelectedStructuralProperties);
+            Assert.Null(subSelectExpandNode.SelectedNavigationProperties);
+            Assert.False(subSelectExpandNode.SelectAllDynamicProperties);
+            Assert.NotNull(subSelectExpandNode.SelectedDynamicProperties);
+            Assert.Equal("DynamicProperty", Assert.Single(subSelectExpandNode.SelectedDynamicProperties));
+        }
+
+        [Theory]
+        [InlineData("Account/AccountOrderNav", "Account")]
+        [InlineData("Account($select=AccountOrderNav)", "Account")]
+        [InlineData("OtherAccounts/AccountOrderNav", "OtherAccounts")]
+        [InlineData("OtherAccounts($select=AccountOrderNav)", "OtherAccounts")]
+        public void SelectProperties_OnSubNavigationPropertyFromComplex_SelectsExpectedProperties(string select, string firstSelected)
+        {
+            // Arrange
+            _model.Account.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+            {
+                Name = "AccountOrderNav",
+                TargetMultiplicity = EdmMultiplicity.One,
+                Target = _model.Order
+            });
+
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null);
+
+            // Act
+            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, _model.Customer, _model.Model);
+
+            // Assert: Top Level
+            Assert.Null(selectExpandNode.SelectedStructuralProperties);
+            Assert.Null(selectExpandNode.SelectedNavigationProperties);
+            Assert.NotNull(selectExpandNode.SelectedComplexes);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.Equal(firstSelected, firstLevelSelected.Key.Name);
+
+            Assert.NotNull(firstLevelSelected.Value);
+            Assert.NotNull(firstLevelSelected.Value.SelectAndExpand);
+
+            // Assert: Second Level
+            SelectExpandNode subSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, _model.Account, _model.Model);
+            Assert.Null(subSelectExpandNode.SelectedComplexes);
+            Assert.Null(subSelectExpandNode.SelectedStructuralProperties);
+            Assert.NotNull(subSelectExpandNode.SelectedNavigationProperties);
+            Assert.Equal("AccountOrderNav", Assert.Single(subSelectExpandNode.SelectedNavigationProperties).Name);
+        }
+
+        [Fact]
+        public void SelectProperties_OnMultipleSubPropertiesFromComplex_SelectsExpectedProperties()
+        {
+            // Arrange
+            string select = "Account,Account/Bank,Account/BankAddress/Street";
+
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null);
+
+            // Act
+            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, _model.Customer, _model.Model);
+
+            // Assert: Top Level
+            Assert.Null(selectExpandNode.SelectedStructuralProperties);
+            Assert.Null(selectExpandNode.SelectedNavigationProperties);
+            Assert.NotNull(selectExpandNode.SelectedComplexes);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.Equal("Account", firstLevelSelected.Key.Name);
+
+            Assert.NotNull(firstLevelSelected.Value);
+            Assert.NotNull(firstLevelSelected.Value.SelectAndExpand);
+            Assert.True(firstLevelSelected.Value.SelectAndExpand.AllSelected);
+
+            // Assert: Second Level
+            SelectExpandNode secondSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, _model.Account, _model.Model);
+            Assert.NotNull(secondSelectExpandNode.SelectedStructuralProperties);
+            Assert.Equal(2, secondSelectExpandNode.SelectedStructuralProperties.Count); // Because it's select all from first select item.
+            Assert.Equal(new[] { "Bank", "CardNum" }, secondSelectExpandNode.SelectedStructuralProperties.Select(s => s.Name));
+
+            Assert.Null(secondSelectExpandNode.SelectedNavigationProperties);
+
+            Assert.NotNull(secondSelectExpandNode.SelectedComplexes);
+            var secondLevelSelected = Assert.Single(secondSelectExpandNode.SelectedComplexes);
+            Assert.Equal("BankAddress", secondLevelSelected.Key.Name);
+            Assert.NotNull(secondLevelSelected.Value);
+            Assert.NotNull(secondLevelSelected.Value.SelectAndExpand);
+            Assert.False(secondLevelSelected.Value.SelectAndExpand.AllSelected);
+
+            // Assert: Third level
+            SelectExpandNode thirdSelectExpandNode = new SelectExpandNode(secondLevelSelected.Value.SelectAndExpand, _model.Address, _model.Model);
+            Assert.NotNull(thirdSelectExpandNode.SelectedStructuralProperties);
+            Assert.Equal("Street", Assert.Single(thirdSelectExpandNode.SelectedStructuralProperties).Name);
+            Assert.Null(thirdSelectExpandNode.SelectedNavigationProperties);
+            Assert.Null(thirdSelectExpandNode.SelectedComplexes);
+        }
+
+        [Theory]
+        [InlineData("$select=Account/Bank&$expand=Account/AccountOrderNav", "Account")]
+        [InlineData("$select=Account($select=Bank)&$expand=Account/AccountOrderNav", "Account")]
+        [InlineData("$select=OtherAccounts/Bank&$expand=OtherAccounts/AccountOrderNav", "OtherAccounts")]
+        [InlineData("$select=OtherAccounts($select=Bank)&$expand=OtherAccounts/AccountOrderNav", "OtherAccounts")]
+        public void SelectProperties_OnSubSelectAndExpandFromComplex_SelectsExpectedProperties(string selectExpand, string firstSelected)
+        {
+            // Arrange
+            string[] items = selectExpand.Split('&');
+            Assert.Equal(2, items.Length);
+
+            string select = items[0].Substring(8);
+            string expand = items[1].Substring(8);
+
+            _model.Account.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+            {
+                Name = "AccountOrderNav",
+                TargetMultiplicity = EdmMultiplicity.One,
+                Target = _model.Order
+            });
+
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, expand);
+
+            // Act
+            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, _model.Customer, _model.Model);
+
+            // Assert: Top Level
+            Assert.Null(selectExpandNode.SelectedStructuralProperties);
+            Assert.Null(selectExpandNode.SelectedNavigationProperties);
+            Assert.Null(selectExpandNode.ExpandedProperties); // Not expanded at first level
+
+            Assert.NotNull(selectExpandNode.SelectedComplexes);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.Equal(firstSelected, firstLevelSelected.Key.Name);
+
+            Assert.NotNull(firstLevelSelected.Value);
+            Assert.NotNull(firstLevelSelected.Value.SelectAndExpand);
+
+            // Assert: Second Level
+            SelectExpandNode subSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, _model.Account, _model.Model);
+            Assert.Null(subSelectExpandNode.SelectedComplexes);
+            Assert.NotNull(subSelectExpandNode.SelectedStructuralProperties);
+            Assert.Equal("Bank", Assert.Single(subSelectExpandNode.SelectedStructuralProperties).Name);
+
+            Assert.NotNull(subSelectExpandNode.ExpandedProperties);
+            var expandedProperty = Assert.Single(subSelectExpandNode.ExpandedProperties);
+            Assert.Equal("AccountOrderNav", expandedProperty.Key.Name);
+
+            Assert.NotNull(expandedProperty.Value);
+            Assert.NotNull(expandedProperty.Value.SelectAndExpand);
+            Assert.True(expandedProperty.Value.SelectAndExpand.AllSelected);
+            Assert.Empty(expandedProperty.Value.SelectAndExpand.SelectedItems);
+        }
+
+        [Fact]
+        public void SelectProperties_OnSubPropertyWithTypeCastFromComplex_SelectsExpectedProperties()
+        {
+            // Arrange
+            EdmComplexType subComplexType = new EdmComplexType("NS", "CnAddress", _model.Address);
+            subComplexType.AddStructuralProperty("SubAddressProperty", EdmPrimitiveTypeKind.String);
+            subComplexType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+            {
+                Name = "CnAddressOrderNav",
+                TargetMultiplicity = EdmMultiplicity.One,
+                Target = _model.Order
+            });
+            _model.Model.AddElement(subComplexType);
+
+            string select = "Address/NS.CnAddress/SubAddressProperty";
+            string expand = "Address/NS.CnAddress/CnAddressOrderNav";
+
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, expand);
+
+            // Act
+            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, _model.Customer, _model.Model);
+
+            // Assert: Top Level
+            Assert.Null(selectExpandNode.SelectedStructuralProperties);
+            Assert.Null(selectExpandNode.SelectedNavigationProperties);
+            Assert.Null(selectExpandNode.ExpandedProperties); // Not expanded at first level
+
+            Assert.NotNull(selectExpandNode.SelectedComplexes);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.Equal("Address", firstLevelSelected.Key.Name);
+
+            Assert.NotNull(firstLevelSelected.Value);
+            Assert.NotNull(firstLevelSelected.Value.SelectAndExpand);
+
+            // Assert: Second Level
+            {
+                // use the base type to test
+                SelectExpandNode subSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, _model.Address, _model.Model);
+                Assert.Null(subSelectExpandNode.SelectedStructuralProperties);
+                Assert.Null(subSelectExpandNode.SelectedComplexes);
+                Assert.Null(subSelectExpandNode.ExpandedProperties);
+                Assert.Null(subSelectExpandNode.SelectedNavigationProperties);
+            }
+            {
+                // use the sub type to test
+                SelectExpandNode subSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, subComplexType, _model.Model);
+                Assert.Null(subSelectExpandNode.SelectedComplexes);
+                Assert.NotNull(subSelectExpandNode.SelectedStructuralProperties);
+                Assert.Equal("SubAddressProperty", Assert.Single(subSelectExpandNode.SelectedStructuralProperties).Name);
+
+                Assert.NotNull(subSelectExpandNode.ExpandedProperties);
+                var expandedProperty = Assert.Single(subSelectExpandNode.ExpandedProperties);
+                Assert.Equal("CnAddressOrderNav", expandedProperty.Key.Name);
+
+                Assert.NotNull(expandedProperty.Value);
+                Assert.NotNull(expandedProperty.Value.SelectAndExpand);
+                Assert.True(expandedProperty.Value.SelectAndExpand.AllSelected);
+                Assert.Empty(expandedProperty.Value.SelectAndExpand.SelectedItems);
+            }
         }
 
         [Theory]
         [InlineData(null, null, false, "Orders")] // no select and expand -> select all
         [InlineData(null, null, true, "Orders,SpecialOrders")] // no select and expand on derived type -> select all
-        [InlineData("ID", null, false, "")] // simple select -> select none 
-        [InlineData("ID", null, true, "")] // simple select on derived type -> select none
-        [InlineData(null, "Orders", false, "")] // simple expand -> select non expanded
+        [InlineData("ID", null, false, null)] // simple select -> select none 
+        [InlineData("ID", null, true, null)] // simple select on derived type -> select none
+        [InlineData(null, "Orders", false, null)] // simple expand -> select non expanded
         [InlineData(null, "Orders", true, "SpecialOrders")] // simple expand on derived type -> select non expanded
-        [InlineData("ID", "Orders", false, "")] // simple expand without corresponding select -> select none
-        [InlineData("ID", "Orders", true, "")] // simple expand without corresponding select on derived type -> select none
-        [InlineData("ID,Orders", "Orders", false, "")] // simple expand with corresponding select -> select none
-        [InlineData("ID,Orders", "Orders", true, "")] // simple expand with corresponding select on derived type -> select none
+        [InlineData("ID", "Orders", false, null)] // simple expand without corresponding select -> select none
+        [InlineData("ID", "Orders", true, null)] // simple expand without corresponding select on derived type -> select none
+        [InlineData("ID,Orders", "Orders", false, null)] // simple expand with corresponding select -> select none
+        [InlineData("ID,Orders", "Orders", true, null)] // simple expand with corresponding select on derived type -> select none
         [InlineData("ID,Orders", null, false, "Orders")] // simple select without corresponding expand -> select requested
         [InlineData("ID,Orders", null, true, "Orders")] // simple select with corresponding expand on derived type -> select requested
-        [InlineData("NS.SpecialCustomer/SpecialOrders", "", false, "")] // select derived type properties -> select none
-        [InlineData("NS.SpecialCustomer/SpecialOrders", "", true, "SpecialOrders")] // select derived type properties on derived type -> select requested
-        public void GetNavigationPropertiesToBeSelected_Selects_ExpectedProperties(
-            string select, string expand, bool specialCustomer, string navigationPropertiesToSelect)
+        [InlineData("NS.SpecialCustomer/SpecialOrders", null, false, null)] // select derived type properties -> select none
+        [InlineData("NS.SpecialCustomer/SpecialOrders", null, true, "SpecialOrders")] // select derived type properties on derived type -> select requested
+        public void SelectNavigationProperties_SelectsExpectedProperties(string select, string expand, bool specialCustomer, string propertiesToSelect)
         {
             // Arrange
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(_model.Model, _model.Customer, _model.Customers,
-                new Dictionary<string, string> { { "$select", select }, { "$expand", expand } });
-            SelectExpandClause selectExpandClause = parser.ParseSelectAndExpand();
-
-            IEdmEntityType entityType = specialCustomer ? _model.SpecialCustomer : _model.Customer;
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, expand);
+            IEdmStructuredType structuralType = specialCustomer ? _model.SpecialCustomer : _model.Customer;
 
             // Act
-            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, entityType, _model.Model);
-            var result = selectExpandNode.SelectedNavigationProperties;
+            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, structuralType, _model.Model);
 
             // Assert
-            Assert.Equal(navigationPropertiesToSelect, String.Join(",", result.Select(p => p.Name).OrderBy(n => n)));
+            if (propertiesToSelect == null)
+            {
+                Assert.Null(selectExpandNode.SelectedNavigationProperties);
+            }
+            else
+            {
+                Assert.Equal(propertiesToSelect, String.Join(",", selectExpandNode.SelectedNavigationProperties.Select(p => p.Name)));
+            }
         }
 
         [Theory]
-        [InlineData(null, null, false, "")] // no select and expand -> expand none
-        [InlineData(null, null, true, "")] // no select and expand on derived type -> expand none
-        [InlineData("Orders", null, false, "")] // simple select and no expand -> expand none
-        [InlineData("Orders", null, true, "")] // simple select and no expand on derived type -> expand none
+        [InlineData(null, null, false, null)] // no select and expand -> expand none
+        [InlineData(null, null, true, null)] // no select and expand on derived type -> expand none
+        [InlineData("Orders", null, false, null)] // simple select and no expand -> expand none
+        [InlineData("Orders", null, true, null)] // simple select and no expand on derived type -> expand none
         [InlineData(null, "Orders", false, "Orders")] // simple expand and no select -> expand requested
         [InlineData(null, "Orders", true, "Orders")] // simple expand and no select on derived type -> expand requested
         [InlineData(null, "Orders,Orders,Orders", false, "Orders")] // duplicate expand -> expand requested
@@ -168,85 +480,229 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
         [InlineData("Orders", "Orders", false, "Orders")] // only expand -> expand requested
         [InlineData("ID,Orders", "Orders", false, "Orders")] // simple expand and expand in select -> expand requested
         [InlineData("ID,Orders", "Orders", true, "Orders")] // simple expand and expand in select on derived type -> expand requested
-        [InlineData(null, "NS.SpecialCustomer/SpecialOrders", false, "")] // expand derived navigation property -> expand non
+        [InlineData(null, "NS.SpecialCustomer/SpecialOrders", false, null)] // expand derived navigation property -> expand requested
         [InlineData(null, "NS.SpecialCustomer/SpecialOrders", true, "SpecialOrders")] // expand derived navigation property on derived type -> expand requested
-        public void GetNavigationPropertiesToBeExpanded_Expands_ExpectedProperties(
-            string select, string expand, bool specialCustomer, string navigationPropertiesToExpand)
+        public void ExpandNavigationProperties_ExpandsExpectedProperties(string select, string expand, bool specialCustomer, string propertiesToExpand)
         {
             // Arrange
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(_model.Model, _model.Customer, _model.Customers,
-                new Dictionary<string, string> { { "$select", select }, { "$expand", expand } });
-            SelectExpandClause selectExpandClause = parser.ParseSelectAndExpand();
-
-            IEdmEntityType entityType = specialCustomer ? _model.SpecialCustomer : _model.Customer;
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, expand);
+            IEdmStructuredType structuralType = specialCustomer ? _model.SpecialCustomer : _model.Customer;
 
             // Act
-            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, entityType, _model.Model);
-#pragma warning disable CS0618 // Type or member is obsolete
-            var result = selectExpandNode.ExpandedNavigationProperties.Keys;
+            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, structuralType, _model.Model);
 
             // Assert
-            Assert.Equal(navigationPropertiesToExpand, String.Join(",", result.Select(p => p.Name).OrderBy(n => n)));
+            if (propertiesToExpand == null)
+            {
+                Assert.Null(selectExpandNode.ExpandedProperties);
+            }
+            else
+            {
+                Assert.Equal(propertiesToExpand, String.Join(",", selectExpandNode.ExpandedProperties.Select(p => p.Key.Name)));
+            }
         }
 
         [Theory]
-        [InlineData(null, null, false, "upgrade")] // no select and no expand -> select all actions
-        [InlineData(null, null, true, "specialUpgrade,upgrade")] // no select and no expand -> select all actions
-        [InlineData("*", null, false, "")] // select * -> select no actions
-        [InlineData("*", null, true, "")] // select * -> select no actions
-        [InlineData("NS.upgrade", null, false, "upgrade")] // select single actions -> select requested action
-        [InlineData("NS.upgrade", null, true, "upgrade")] // select single actions -> select requested action
-        [InlineData("NS.SpecialCustomer/NS.specialUpgrade", null, false, "")] // select single derived action on base type -> select nothing
-        [InlineData("NS.SpecialCustomer/NS.specialUpgrade", null, true, "specialUpgrade")] // select single derived action on derived type  -> select requested action
-        [InlineData("NS.*", null, false, "upgrade")] // select wild card actions -> select all
-        [InlineData("NS.*", null, true, "specialUpgrade,upgrade")] // select wild card actions -> select all
-        public void GetActionsToBeSelected_Selects_ExpectedActions(
-            string select, string expand, bool specialCustomer, string actionsToSelect)
+        [InlineData(null, false, 1, 8)] // no select and no expand means to select all operations
+        [InlineData(null, true, 2, 10)]
+        [InlineData("*", false, null, null)] // select * means to select no operations
+        [InlineData("*", true, null, null)]
+        [InlineData("NS.*", false, 1, 8)] // select wild card actions means to select all starting with "NS"
+        [InlineData("NS.*", true, 2, 10)]
+        [InlineData("NS.upgrade", false, 1, null)] // select single action -> select requested action
+        [InlineData("NS.upgrade", true, 1, null)]
+        [InlineData("NS.SpecialCustomer/NS.specialUpgrade", false, null, null)] // select single derived action on base type -> select nothing
+        [InlineData("NS.SpecialCustomer/NS.specialUpgrade", true, 1, null)] // select single derived action on derived type  -> select requested action
+        [InlineData("NS.GetSalary", false, null, 1)] // select single function -> select requested function
+        [InlineData("NS.GetSalary", true, null, 1)]
+        [InlineData("NS.SpecialCustomer/NS.IsSpecialUpgraded", false, null, null)] // select single derived function on base type -> select nothing
+        [InlineData("NS.SpecialCustomer/NS.IsSpecialUpgraded", true, null, 1)] // select single derived function on derived type  -> select requested function
+        public void OperationsToBeSelected_Selects_ExpectedOperations(string select, bool specialCustomer, int? actionsSelected, int? functionsSelected)
         {
             // Arrange
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(_model.Model, _model.Customer, _model.Customers,
-                new Dictionary<string, string> { { "$select", select }, { "$expand", expand } });
-            SelectExpandClause selectExpandClause = parser.ParseSelectAndExpand();
-
-            IEdmEntityType entityType = specialCustomer ? _model.SpecialCustomer : _model.Customer;
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, expand: null);
+            IEdmStructuredType structuralType = specialCustomer ? _model.SpecialCustomer : _model.Customer;
 
             // Act
-            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, entityType, _model.Model);
-            var result = selectExpandNode.SelectedActions;
+            SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, structuralType, _model.Model);
 
-            // Assert
-            Assert.Equal(actionsToSelect, String.Join(",", result.Select(p => p.Name).OrderBy(n => n)));
+            // Assert: Actions
+            if (actionsSelected == null)
+            {
+                Assert.Null(selectExpandNode.SelectedActions);
+            }
+            else
+            {
+                Assert.Equal(actionsSelected, selectExpandNode.SelectedActions.Count);
+            }
+
+            // Assert: Functions
+            if (functionsSelected == null)
+            {
+                Assert.Null(selectExpandNode.SelectedFunctions);
+            }
+            else
+            {
+                Assert.Equal(functionsSelected, selectExpandNode.SelectedFunctions.Count);
+            }
         }
 
         [Fact]
         public void BuildSelectExpandNode_ThrowsODataException_IfUnknownSelectItemPresent()
         {
+            // Arrange
             SelectExpandClause selectExpandClause = new SelectExpandClause(new SelectItem[] { new Mock<SelectItem>().Object }, allSelected: false);
-            IEdmEntityType entityType = _model.Customer;
+            IEdmStructuredType structuralType = _model.Customer;
 
-            ExceptionAssert.Throws<ODataException>(
-                () => new SelectExpandNode(selectExpandClause, entityType, _model.Model),
+            // Act & Assert
+            ExceptionAssert.Throws<ODataException>(() => new SelectExpandNode(selectExpandClause, structuralType, _model.Model),
                 "$select does not support selections of type 'SelectItemProxy'.");
         }
 
+        #region Test IsComplexOrCollectionComplex
         [Fact]
-        public void ValidatePathIsSupported_ThrowsForUnsupportedPathForSelect()
+        public void IsComplexOrCollectionComplex_TestNullInputCorrect()
         {
-            ODataPath path = new ODataPath(new ValueSegment(previousType: null));
+            // Arrange & Act
+            IEdmStructuralProperty primitiveProperty = null;
 
-            ExceptionAssert.Throws<ODataException>(
-                () => SelectExpandNode.ValidatePathIsSupportedForSelect(path),
-                "A path within the select or expand query option is not supported.");
+            // Assert
+            Assert.False(SelectExpandNode.IsComplexOrCollectionComplex(primitiveProperty));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void IsComplexOrCollectionComplex_TestPrimitiveStructuralPropertyCorrect(bool isCollection)
+        {
+            // Arrange & Act
+            var stringType = EdmCoreModel.Instance.GetString(false);
+            EdmEntityType entityType = new EdmEntityType("NS", "Entity");
+            IEdmStructuralProperty primitiveProperty;
+            if (isCollection)
+            {
+                primitiveProperty = entityType.AddStructuralProperty("Codes", new EdmCollectionTypeReference(new EdmCollectionType(stringType)));
+            }
+            else
+            {
+                primitiveProperty = entityType.AddStructuralProperty("Id", stringType);
+            }
+
+            // Assert
+            Assert.False(SelectExpandNode.IsComplexOrCollectionComplex(primitiveProperty));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void IsComplexOrCollectionComplex_TestComplexStructuralPropertyCorrect(bool isCollection)
+        {
+            // Arrange & Act
+            var complexType = new EdmComplexTypeReference(new EdmComplexType("NS", "Complex"), false);
+            EdmEntityType entityType = new EdmEntityType("NS", "Entity");
+
+            IEdmStructuralProperty complexProperty;
+            if (isCollection)
+            {
+                complexProperty = entityType.AddStructuralProperty("Complexes", new EdmCollectionTypeReference(new EdmCollectionType(complexType)));
+            }
+            else
+            {
+                complexProperty = entityType.AddStructuralProperty("Single", complexType);
+            }
+
+            // Assert
+            Assert.True(SelectExpandNode.IsComplexOrCollectionComplex(complexProperty));
+        }
+        #endregion
+
+        #region Test EdmStructuralTypeInfo
+        [Theory]
+        [InlineData("Customer", 7, 1, 1, 8)]
+        [InlineData("SpecialCustomer", 9, 2, 2, 10)]
+        [InlineData("Order", 3, 1, 0, 0)]
+        [InlineData("Address", 5, 0, 0, 0)]
+        public void EdmStructuralTypeInfoCtor_ReturnsCorrectProperties(string typeName, int structurals, int navigations, int actions, int functions)
+        {
+            // Assert
+            IEdmStructuredType structuralType = _model.Model.SchemaElements.OfType<IEdmSchemaType>().FirstOrDefault(c => c.Name == typeName) as IEdmStructuredType;
+            Assert.NotNull(structuralType); // Guard
+
+            // Act
+            var structuralTypeInfo = new SelectExpandNode.EdmStructuralTypeInfo(_model.Model, structuralType);
+
+            // Assert
+            Assert.NotNull(structuralTypeInfo.AllStructuralProperties);
+            Assert.Equal(structurals, structuralTypeInfo.AllStructuralProperties.Count);
+
+            if (navigations == 0)
+            {
+                Assert.Null(structuralTypeInfo.AllNavigationProperties);
+            }
+            else
+            {
+                Assert.NotNull(structuralTypeInfo.AllNavigationProperties);
+                Assert.Equal(navigations, structuralTypeInfo.AllNavigationProperties.Count);
+            }
+
+            if (actions == 0)
+            {
+                Assert.Null(structuralTypeInfo.AllActions);
+            }
+            else
+            {
+                Assert.NotNull(structuralTypeInfo.AllActions);
+                Assert.Equal(actions, structuralTypeInfo.AllActions.Count);
+            }
+
+            if (functions == 0)
+            {
+                Assert.Null(structuralTypeInfo.AllFunctions);
+            }
+            else
+            {
+                Assert.NotNull(structuralTypeInfo.AllFunctions);
+                Assert.Equal(functions, structuralTypeInfo.AllFunctions.Count);
+            }
         }
 
         [Fact]
-        public void ValidatePathIsSupported_ThrowsForUnsupportedPathForExpand()
+        public void EdmStructuralTypeInfo_IsStructuralPropertyDefined_ReturnsCorrectBoolean()
         {
-            ODataPath path = new ODataPath(new ValueSegment(previousType: null));
+            // Assert
+            var structuralTypeInfo = new SelectExpandNode.EdmStructuralTypeInfo(_model.Model, _model.Customer);
 
-            ExceptionAssert.Throws<ODataException>(
-                () => SelectExpandNode.ValidatePathIsSupportedForExpand(path),
-                "A path within the select or expand query option is not supported.");
+            IEdmStructuralProperty property = _model.Customer.DeclaredStructuralProperties().FirstOrDefault();
+            IEdmStructuralProperty addressProperty = _model.Address.DeclaredStructuralProperties().FirstOrDefault();
+
+            // Act & Assert
+            Assert.True(structuralTypeInfo.IsStructuralPropertyDefined(property));
+            Assert.False(structuralTypeInfo.IsStructuralPropertyDefined(addressProperty));
+        }
+
+        [Fact]
+        public void EdmStructuralTypeInfo_IsNavigationPropertyDefined_ReturnsCorrectBoolean()
+        {
+            // Assert
+            var structuralTypeInfo = new SelectExpandNode.EdmStructuralTypeInfo(_model.Model, _model.Customer);
+
+            IEdmNavigationProperty property = _model.Customer.DeclaredNavigationProperties().FirstOrDefault();
+            IEdmNavigationProperty orderProperty = _model.Order.DeclaredNavigationProperties().FirstOrDefault();
+
+            // Act & Assert
+            Assert.True(structuralTypeInfo.IsNavigationPropertyDefined(property));
+            Assert.False(structuralTypeInfo.IsNavigationPropertyDefined(orderProperty));
+        }
+        #endregion
+
+        public SelectExpandClause ParseSelectExpand(string select, string expand)
+        {
+            return new ODataQueryOptionParser(_model.Model, _model.Customer, _model.Customers,
+                new Dictionary<string, string>
+                {
+                    { "$expand", expand == null ? "" : expand },
+                    { "$select", select == null ? "" : select }
+                }).ParseSelectAndExpand();
         }
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/SelectExpandNodeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/SelectExpandNodeTest.cs
@@ -96,11 +96,11 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
 
             if (complexesToSelect == null)
             {
-                Assert.Null(selectExpandNode.SelectedComplexProperties);
+                Assert.Null(selectExpandNode.SelectedComplexTypeProperties);
             }
             else
             {
-                Assert.Equal(complexesToSelect, String.Join(",", selectExpandNode.SelectedComplexProperties.Select(p => p.Name).OrderBy(n => n)));
+                Assert.Equal(complexesToSelect, String.Join(",", selectExpandNode.SelectedComplexTypeProperties.Keys.Select(p => p.Name).OrderBy(n => n)));
             }
         }
 
@@ -139,8 +139,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             SelectExpandNode selectExpandNode = new SelectExpandNode(selectExpandClause, _model.Customer, _model.Model);
 
             // Assert
-            Assert.NotNull(selectExpandNode.SelectedComplexes);
-            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.NotNull(selectExpandNode.SelectedComplexTypeProperties);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexTypeProperties);
             Assert.Equal(firstSelected, firstLevelSelected.Key.Name);
 
             Assert.NotNull(firstLevelSelected.Value);
@@ -149,7 +149,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             // Act: Sub Level
             IEdmStructuredType subLevelElementType = firstLevelSelected.Key.Type.ToStructuredType();
             SelectExpandNode subSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, subLevelElementType, _model.Model);
-            Assert.Null(subSelectExpandNode.SelectedComplexes);
+            Assert.Null(subSelectExpandNode.SelectedComplexTypeProperties);
 
             // Assert
             Assert.NotNull(subSelectExpandNode.SelectedStructuralProperties);
@@ -171,8 +171,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
 
             // Assert
             Assert.Null(selectExpandNode.SelectedStructuralProperties);
-            Assert.NotNull(selectExpandNode.SelectedComplexes);
-            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.NotNull(selectExpandNode.SelectedComplexTypeProperties);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexTypeProperties);
             Assert.Equal("Account", firstLevelSelected.Key.Name);
             Assert.NotNull(firstLevelSelected.Value);
             Assert.NotNull(firstLevelSelected.Value.SelectAndExpand);
@@ -182,8 +182,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
 
             // Assert
             Assert.Null(secondSelectExpandNode.SelectedStructuralProperties);
-            Assert.NotNull(secondSelectExpandNode.SelectedComplexes);
-            var secondLevelSelected = Assert.Single(secondSelectExpandNode.SelectedComplexes);
+            Assert.NotNull(secondSelectExpandNode.SelectedComplexTypeProperties);
+            var secondLevelSelected = Assert.Single(secondSelectExpandNode.SelectedComplexTypeProperties);
             Assert.Equal("BankAddress", secondLevelSelected.Key.Name);
             Assert.NotNull(secondLevelSelected.Value);
             Assert.NotNull(secondLevelSelected.Value.SelectAndExpand);
@@ -192,7 +192,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             SelectExpandNode thirdSelectExpandNode = new SelectExpandNode(secondLevelSelected.Value.SelectAndExpand, _model.Address, _model.Model);
 
             // Assert
-            Assert.Null(thirdSelectExpandNode.SelectedComplexes);
+            Assert.Null(thirdSelectExpandNode.SelectedComplexTypeProperties);
             Assert.NotNull(thirdSelectExpandNode.SelectedStructuralProperties);
             Assert.Equal(3, thirdSelectExpandNode.SelectedStructuralProperties.Count);
             Assert.Equal(new[] { "Street", "City", "ZipCode" }, thirdSelectExpandNode.SelectedStructuralProperties.Select(s => s.Name));
@@ -216,8 +216,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             Assert.Null(selectExpandNode.SelectedDynamicProperties);
             Assert.Null(selectExpandNode.SelectedStructuralProperties);
             Assert.Null(selectExpandNode.SelectedNavigationProperties);
-            Assert.NotNull(selectExpandNode.SelectedComplexes);
-            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.NotNull(selectExpandNode.SelectedComplexTypeProperties);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexTypeProperties);
             Assert.Equal(firstSelected, firstLevelSelected.Key.Name);
 
             Assert.NotNull(firstLevelSelected.Value);
@@ -225,7 +225,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
 
             // Assert: Second Level
             SelectExpandNode subSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, _model.Account, _model.Model);
-            Assert.Null(subSelectExpandNode.SelectedComplexes);
+            Assert.Null(subSelectExpandNode.SelectedComplexTypeProperties);
             Assert.Null(subSelectExpandNode.SelectedStructuralProperties);
             Assert.Null(subSelectExpandNode.SelectedNavigationProperties);
             Assert.False(subSelectExpandNode.SelectAllDynamicProperties);
@@ -256,8 +256,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             // Assert: Top Level
             Assert.Null(selectExpandNode.SelectedStructuralProperties);
             Assert.Null(selectExpandNode.SelectedNavigationProperties);
-            Assert.NotNull(selectExpandNode.SelectedComplexes);
-            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.NotNull(selectExpandNode.SelectedComplexTypeProperties);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexTypeProperties);
             Assert.Equal(firstSelected, firstLevelSelected.Key.Name);
 
             Assert.NotNull(firstLevelSelected.Value);
@@ -265,7 +265,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
 
             // Assert: Second Level
             SelectExpandNode subSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, _model.Account, _model.Model);
-            Assert.Null(subSelectExpandNode.SelectedComplexes);
+            Assert.Null(subSelectExpandNode.SelectedComplexTypeProperties);
             Assert.Null(subSelectExpandNode.SelectedStructuralProperties);
             Assert.NotNull(subSelectExpandNode.SelectedNavigationProperties);
             Assert.Equal("AccountOrderNav", Assert.Single(subSelectExpandNode.SelectedNavigationProperties).Name);
@@ -285,8 +285,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             // Assert: Top Level
             Assert.Null(selectExpandNode.SelectedStructuralProperties);
             Assert.Null(selectExpandNode.SelectedNavigationProperties);
-            Assert.NotNull(selectExpandNode.SelectedComplexes);
-            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.NotNull(selectExpandNode.SelectedComplexTypeProperties);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexTypeProperties);
             Assert.Equal("Account", firstLevelSelected.Key.Name);
 
             Assert.NotNull(firstLevelSelected.Value);
@@ -301,8 +301,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
 
             Assert.Null(secondSelectExpandNode.SelectedNavigationProperties);
 
-            Assert.NotNull(secondSelectExpandNode.SelectedComplexes);
-            var secondLevelSelected = Assert.Single(secondSelectExpandNode.SelectedComplexes);
+            Assert.NotNull(secondSelectExpandNode.SelectedComplexTypeProperties);
+            var secondLevelSelected = Assert.Single(secondSelectExpandNode.SelectedComplexTypeProperties);
             Assert.Equal("BankAddress", secondLevelSelected.Key.Name);
             Assert.NotNull(secondLevelSelected.Value);
             Assert.NotNull(secondLevelSelected.Value.SelectAndExpand);
@@ -313,7 +313,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             Assert.NotNull(thirdSelectExpandNode.SelectedStructuralProperties);
             Assert.Equal("Street", Assert.Single(thirdSelectExpandNode.SelectedStructuralProperties).Name);
             Assert.Null(thirdSelectExpandNode.SelectedNavigationProperties);
-            Assert.Null(thirdSelectExpandNode.SelectedComplexes);
+            Assert.Null(thirdSelectExpandNode.SelectedComplexTypeProperties);
         }
 
         [Theory]
@@ -347,8 +347,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             Assert.Null(selectExpandNode.SelectedNavigationProperties);
             Assert.Null(selectExpandNode.ExpandedProperties); // Not expanded at first level
 
-            Assert.NotNull(selectExpandNode.SelectedComplexes);
-            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.NotNull(selectExpandNode.SelectedComplexTypeProperties);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexTypeProperties);
             Assert.Equal(firstSelected, firstLevelSelected.Key.Name);
 
             Assert.NotNull(firstLevelSelected.Value);
@@ -356,7 +356,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
 
             // Assert: Second Level
             SelectExpandNode subSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, _model.Account, _model.Model);
-            Assert.Null(subSelectExpandNode.SelectedComplexes);
+            Assert.Null(subSelectExpandNode.SelectedComplexTypeProperties);
             Assert.NotNull(subSelectExpandNode.SelectedStructuralProperties);
             Assert.Equal("Bank", Assert.Single(subSelectExpandNode.SelectedStructuralProperties).Name);
 
@@ -397,8 +397,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
             Assert.Null(selectExpandNode.SelectedNavigationProperties);
             Assert.Null(selectExpandNode.ExpandedProperties); // Not expanded at first level
 
-            Assert.NotNull(selectExpandNode.SelectedComplexes);
-            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexes);
+            Assert.NotNull(selectExpandNode.SelectedComplexTypeProperties);
+            var firstLevelSelected = Assert.Single(selectExpandNode.SelectedComplexTypeProperties);
             Assert.Equal("Address", firstLevelSelected.Key.Name);
 
             Assert.NotNull(firstLevelSelected.Value);
@@ -409,14 +409,14 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
                 // use the base type to test
                 SelectExpandNode subSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, _model.Address, _model.Model);
                 Assert.Null(subSelectExpandNode.SelectedStructuralProperties);
-                Assert.Null(subSelectExpandNode.SelectedComplexes);
+                Assert.Null(subSelectExpandNode.SelectedComplexTypeProperties);
                 Assert.Null(subSelectExpandNode.ExpandedProperties);
                 Assert.Null(subSelectExpandNode.SelectedNavigationProperties);
             }
             {
                 // use the sub type to test
                 SelectExpandNode subSelectExpandNode = new SelectExpandNode(firstLevelSelected.Value.SelectAndExpand, subComplexType, _model.Model);
-                Assert.Null(subSelectExpandNode.SelectedComplexes);
+                Assert.Null(subSelectExpandNode.SelectedComplexTypeProperties);
                 Assert.NotNull(subSelectExpandNode.SelectedStructuralProperties);
                 Assert.Equal("SubAddressProperty", Assert.Single(subSelectExpandNode.SelectedStructuralProperties).Name);
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
@@ -236,6 +236,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\ModelContainerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\PropertyContainerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandBinderTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandIncludePropertyTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandPathExtensionsTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandWrapperTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\UriFunctionBinderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Validators\CountQueryValidatorTest.cs" />

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
@@ -236,7 +236,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\ModelContainerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\PropertyContainerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandBinderTest.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandIncludePropertyTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandIncludedPropertyTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandPathExtensionsTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandWrapperTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\UriFunctionBinderTests.cs" />

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/OpenEntityTypeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/OpenEntityTypeTest.cs
@@ -238,6 +238,71 @@ namespace Microsoft.AspNet.OData.Test
             Assert.NotNull(resultArray[4]["Token"]);//customer 4 has a token
         }
 
+        [Theory]
+        [InlineData("$select=Address/Street,Address/City")]
+        [InlineData("$select=Address($select=Street,City)")]
+        public async Task Get_OpenEntityTypeWithMultiplePropertySelect(string select)
+        {
+            // Arrange
+            string requestUri = "http://localhost/odata/SimpleOpenCustomers?" + select;
+            var controllers = new[] { typeof(SimpleOpenCustomersController) };
+            var server = TestServerFactory.Create(controllers, (config) =>
+            {
+                config.Select();
+                config.MapODataServiceRoute("odata", "odata", GetEdmModel());
+            });
+            var client = TestServerFactory.CreateClient(server);
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+          //  Assert.True(response.IsSuccessStatusCode);
+            JObject result = JObject.Parse(await response.Content.ReadAsStringAsync());
+            var resultArray = result["value"] as JArray;
+            Assert.Equal(6, resultArray.Count);
+            Assert.Equal(@"[
+  {
+    ""Address"": {
+      ""Street"": ""Street 0"",
+      ""City"": ""City 0""
+    }
+  },
+  {
+    ""Address"": {
+      ""Street"": ""Street 1"",
+      ""City"": ""City 1""
+    }
+  },
+  {
+    ""Address"": {
+      ""Street"": ""Street 2"",
+      ""City"": ""City 2""
+    }
+  },
+  {
+    ""Address"": {
+      ""Street"": ""Street 3"",
+      ""City"": ""City 3""
+    }
+  },
+  {
+    ""Address"": {
+      ""Street"": ""Street 4"",
+      ""City"": ""City 4""
+    }
+  },
+  {
+    ""@odata.type"": ""#Microsoft.AspNet.OData.Test.Common.SimpleVipCustomer"",
+    ""Address"": {
+      ""Street"": ""Vip Street "",
+      ""City"": ""Vip City ""
+    }
+  }
+]", resultArray.ToString());
+        }
+
         [Fact]
         public async Task Get_OpenEntityTypeWithSelectWildcard()
         {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -13,7 +14,6 @@ using Microsoft.AspNet.OData.Query;
 using Microsoft.AspNet.OData.Query.Expressions;
 using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
-using Microsoft.AspNet.OData.Test.Formatter.Serialization.Models;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
@@ -23,43 +23,75 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
 {
     public class SelectExpandBinderTest
     {
+        private static IPropertyMapper PropertyMapper = new IdentityPropertyMapper();
+
         private readonly SelectExpandBinder _binder;
-        private readonly CustomersModelWithInheritance _model;
-        private readonly IQueryable<Customer> _queryable;
+        private readonly IQueryable<QueryCustomer> _queryable;
         private readonly ODataQueryContext _context;
         private readonly ODataQuerySettings _settings;
 
+        private readonly IEdmModel _model;
+        private readonly IEdmEntityType _customer;
+        private readonly IEdmEntityType _order;
+        private readonly IEdmEntitySet _customers;
+        private readonly IEdmEntitySet _orders;
+
         public SelectExpandBinderTest()
         {
-            _settings = new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False };
-            _model = new CustomersModelWithInheritance();
-            _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.Customer, new ClrTypeAnnotation(typeof(Customer)));
-            _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.SpecialCustomer, new ClrTypeAnnotation(typeof(SpecialCustomer)));
-            _context = new ODataQueryContext(_model.Model, typeof(Customer)) { RequestContainer = new MockContainer() };
-            _binder = new SelectExpandBinder(_settings, new SelectExpandQueryOption("*", "", _context));
+            _model = GetEdmModel();
+            _customer = _model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "QueryCustomer");
+            _order = _model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "QueryOrder");
+            _customers = _model.EntityContainer.FindEntitySet("Customers");
+            _orders = _model.EntityContainer.FindEntitySet("Orders");
 
-            Customer customer = new Customer();
-            Order order = new Order { Customer = customer };
+            _settings = new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False };
+            _context = new ODataQueryContext(_model, typeof(QueryCustomer)) { RequestContainer = new MockContainer() };
+            _binder = new SelectExpandBinder(_settings, _context);
+
+            QueryCustomer customer = new QueryCustomer
+            {
+                Orders = new List<QueryOrder>()
+            };
+            QueryOrder order = new QueryOrder { Customer = customer };
             customer.Orders.Add(order);
 
             _queryable = new[] { customer }.AsQueryable();
         }
 
+        private static SelectExpandBinder GetBinder<T>(IEdmModel model, HandleNullPropagationOption nullPropagation = HandleNullPropagationOption.False)
+        {
+            var settings = new ODataQuerySettings { HandleNullPropagation = nullPropagation };
+
+            var context = new ODataQueryContext(model, typeof(T)) { RequestContainer = new MockContainer() };
+
+            return new SelectExpandBinder(settings, context);
+        }
+
         [Fact]
-        public void Bind_ReturnsIEdmObject_WithRightEdmType()
+        public void Bind_ReturnsIEdmObject_WithRightEdmType2()
+        {
+            string csdl = Builder.MetadataTest.GetCSDL(_model);
+            Console.WriteLine(csdl);
+        }
+
+        [Theory]
+        [InlineData("Id")]
+        [InlineData("Name")]
+        [InlineData("HomeAddress")]
+        public void Bind_ReturnsIEdmObject_WithRightEdmType(string select)
         {
             // Arrange
-            SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(select: "ID", expand: null, context: _context);
+            SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(select: select, expand: null, context: _context);
 
             // Act
             IQueryable queryable = SelectExpandBinder.Bind(_queryable, _settings, selectExpand);
 
             // Assert
             Assert.NotNull(queryable);
-            IEdmTypeReference edmType = _model.Model.GetEdmTypeReference(queryable.GetType());
+            IEdmType edmType = _model.GetEdmType(queryable.GetType());
             Assert.NotNull(edmType);
-            Assert.True(edmType.IsCollection());
-            Assert.Same(_model.Customer, edmType.AsCollection().ElementType().Definition);
+            Assert.Equal(EdmTypeKind.Collection, edmType.TypeKind);
+            Assert.Same(_customer, edmType.AsElementType());
         }
 
         [Fact]
@@ -67,8 +99,6 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             // Arrange
             SelectExpandQueryOption selectExpand = new SelectExpandQueryOption("Orders", "Orders,Orders($expand=Customer)", _context);
-            IPropertyMapper mapper = new IdentityPropertyMapper();
-            _model.Model.SetAnnotationValue(_model.Order, new DynamicPropertyDictionaryAnnotation(typeof(Order).GetProperty("OrderProperties")));
 
             // Act
             IQueryable queryable = SelectExpandBinder.Bind(_queryable, _settings, selectExpand);
@@ -76,49 +106,52 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             // Assert
             IEnumerator enumerator = queryable.GetEnumerator();
             Assert.True(enumerator.MoveNext());
-            var partialCustomer = Assert.IsAssignableFrom<SelectExpandWrapper<Customer>>(enumerator.Current);
+            var partialCustomer = Assert.IsAssignableFrom<SelectExpandWrapper<QueryCustomer>>(enumerator.Current);
             Assert.False(enumerator.MoveNext());
             Assert.Null(partialCustomer.Instance);
-            Assert.Equal("NS.Customer", partialCustomer.InstanceType);
-            IEnumerable<SelectExpandWrapper<Order>> innerOrders = partialCustomer.Container
-                .ToDictionary(mapper)["Orders"] as IEnumerable<SelectExpandWrapper<Order>>;
+            Assert.Equal("Microsoft.AspNet.OData.Test.Query.Expressions.QueryCustomer", partialCustomer.InstanceType);
+            IEnumerable<SelectExpandWrapper<QueryOrder>> innerOrders = partialCustomer.Container
+                .ToDictionary(PropertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<QueryOrder>>;
             Assert.NotNull(innerOrders);
-            SelectExpandWrapper<Order> partialOrder = innerOrders.Single();
+            SelectExpandWrapper<QueryOrder> partialOrder = innerOrders.Single();
             Assert.Same(_queryable.First().Orders.First(), partialOrder.Instance);
-            object customer = partialOrder.Container.ToDictionary(mapper)["Customer"];
-            SelectExpandWrapper<Customer> innerInnerCustomer = Assert.IsAssignableFrom<SelectExpandWrapper<Customer>>(customer);
+            object customer = partialOrder.Container.ToDictionary(PropertyMapper)["Customer"];
+            SelectExpandWrapper<QueryCustomer> innerInnerCustomer = Assert.IsAssignableFrom<SelectExpandWrapper<QueryCustomer>>(customer);
             Assert.Same(_queryable.First(), innerInnerCustomer.Instance);
         }
 
-        //[Fact]
-        //public void Bind_GeneratedExpression_CheckNullObjectWithinChainProjectionByKey()
-        //{
-        //    // Arrange
-        //    SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(null, "Orders($expand=Customer($select=City))", _context);
-        //    _model.Model.SetAnnotationValue(_model.Order, new DynamicPropertyDictionaryAnnotation(typeof(Order).GetProperty("OrderProperties")));
+        [Fact]
+        public void Bind_GeneratedExpression_CheckNullObjectWithinChainProjectionByKey()
+        {
+            // Arrange
+            SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(null, "Orders($expand=Customer($select=City))", _context);
 
-        //    // Act
-        //    IQueryable queryable = SelectExpandBinder.Bind(_queryable, _settings, selectExpand);
+            // Act
+            IQueryable queryable = SelectExpandBinder.Bind(_queryable, _settings, selectExpand);
 
-        //    // Assert
-        //    var unaryExpression = (UnaryExpression)((MethodCallExpression)queryable.Expression).Arguments.Single(a => a is UnaryExpression);
-        //    var expressionString = unaryExpression.Operand.ToString();
-        //    Assert.Contains("IsNull = (Convert(Param_1.Customer.ID) == null)", expressionString);
-        //}
+            // Assert
+            var unaryExpression = (UnaryExpression)((MethodCallExpression)queryable.Expression).Arguments.Single(a => a is UnaryExpression);
+            var expressionString = unaryExpression.Operand.ToString();
+#if NETCORE
+            Assert.Contains("IsNull = (Convert(Param_1.Customer.Id, Nullable`1) == null)}", expressionString);
+#else
+            Assert.Contains("IsNull = (Convert(Param_1.Customer.Id) == null)}", expressionString);
+#endif
+        }
 
         [Fact]
         public void ProjectAsWrapper_NonCollection_ContainsRightInstance()
         {
             // Arrange
-            Order order = new Order();
+            QueryOrder order = new QueryOrder();
             SelectExpandClause selectExpand = new SelectExpandClause(new SelectItem[0], allSelected: true);
             Expression source = Expression.Constant(order);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Order, _model.Orders);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
 
             // Assert
-            SelectExpandWrapper<Order> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Order>;
+            SelectExpandWrapper<QueryOrder> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryOrder>;
             Assert.NotNull(projectedOrder);
             Assert.Same(order, projectedOrder.Instance);
         }
@@ -128,22 +161,24 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             // Arrange
             _settings.HandleNullPropagation = HandleNullPropagationOption.True;
+
+            IEdmNavigationProperty customerNav = _order.DeclaredNavigationProperties().Single(c => c.Name == "Customer");
             ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(
-                new ODataExpandPath(new NavigationPropertySegment(_model.Order.NavigationProperties().Single(), navigationSource: _model.Customers)),
-                _model.Customers,
-                selectExpandOption: null);
+                new ODataExpandPath(new NavigationPropertySegment(customerNav, navigationSource: _customers)), _customers, selectExpandOption: null);
             SelectExpandClause selectExpand = new SelectExpandClause(new SelectItem[] { expandItem }, allSelected: true);
-            Expression source = Expression.Constant(null, typeof(Order));
-            _model.Model.SetAnnotationValue(_model.Order, new DynamicPropertyDictionaryAnnotation(typeof(Order).GetProperty("OrderProperties")));
+            Expression source = Expression.Constant(null, typeof(QueryOrder));
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Order, _model.Orders);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
 
             // Assert
-            SelectExpandWrapper<Order> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Order>;
+            SelectExpandWrapper<QueryOrder> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryOrder>;
             Assert.NotNull(projectedOrder);
             Assert.Null(projectedOrder.Instance);
-            Assert.Null(projectedOrder.Container.ToDictionary(new IdentityPropertyMapper())["Customer"]);
+
+            SelectExpandWrapper<QueryCustomer> projectCustomer = projectedOrder.Container.ToDictionary(PropertyMapper)["Customer"] as SelectExpandWrapper<QueryCustomer>;
+            Assert.NotNull(projectCustomer);
+            Assert.Null(projectCustomer.Instance);
         }
 
         [Fact]
@@ -151,20 +186,19 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             // Arrange
             _settings.HandleNullPropagation = HandleNullPropagationOption.False;
+            IEdmNavigationProperty customerNav = _order.DeclaredNavigationProperties().Single(c => c.Name == "Customer");
             ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(
-                new ODataExpandPath(new NavigationPropertySegment(_model.Order.NavigationProperties().Single(), navigationSource: _model.Customers)),
-                _model.Customers,
+                new ODataExpandPath(new NavigationPropertySegment(customerNav, navigationSource: _customers)),
+                _customers,
                 selectExpandOption: null);
             SelectExpandClause selectExpand = new SelectExpandClause(new SelectItem[] { expandItem }, allSelected: true);
-            _model.Model.SetAnnotationValue(_model.Order, new DynamicPropertyDictionaryAnnotation(typeof(Order).GetProperty("OrderProperties")));
-            Expression source = Expression.Constant(null, typeof(Order));
+            Expression source = Expression.Constant(null, typeof(QueryOrder));
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Order, _model.Orders);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
 
             // Assert
-            var e = ExceptionAssert.Throws<TargetInvocationException>(
-                () => Expression.Lambda(projection).Compile().DynamicInvoke());
+            var e = ExceptionAssert.Throws<TargetInvocationException>(() => Expression.Lambda(projection).Compile().DynamicInvoke());
             Assert.IsType<NullReferenceException>(e.InnerException);
         }
 
@@ -172,15 +206,15 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         public void ProjectAsWrapper_Collection_ContainsRightInstance()
         {
             // Arrange
-            Order[] orders = new Order[] { new Order() };
+            QueryOrder[] orders = new QueryOrder[] { new QueryOrder() };
             SelectExpandClause selectExpand = new SelectExpandClause(new SelectItem[0], allSelected: true);
             Expression source = Expression.Constant(orders);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Order, _model.Orders);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
 
             // Assert
-            IEnumerable<SelectExpandWrapper<Order>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<Order>>;
+            IEnumerable<SelectExpandWrapper<QueryOrder>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<QueryOrder>>;
             Assert.NotNull(projectedOrders);
             Assert.Same(orders[0], projectedOrders.Single().Instance);
         }
@@ -190,68 +224,70 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             // Arrange
             int pageSize = 5;
-            var orders = Enumerable.Range(0, 10).Select(i => new Order
+            var orders = Enumerable.Range(0, 10).Select(i => new QueryOrder
             {
-                ID = 10 - i,
+                Id = 10 - i,
             });
             SelectExpandClause selectExpand = new SelectExpandClause(new SelectItem[0], allSelected: true);
             Expression source = Expression.Constant(orders);
             _settings.PageSize = pageSize;
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Order, _model.Orders);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
 
             // Assert
-            IEnumerable<SelectExpandWrapper<Order>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<Order>>;
+            IEnumerable<SelectExpandWrapper<QueryOrder>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<QueryOrder>>;
             Assert.NotNull(projectedOrders);
             Assert.Equal(pageSize + 1, projectedOrders.Count());
-            Assert.Equal(1, projectedOrders.First().Instance.ID);
+            Assert.Equal(1, projectedOrders.First().Instance.Id);
         }
 
         [Fact]
         public void ProjectAsWrapper_ProjectionContainsExpandedProperties()
         {
             // Arrange
-            Order order = new Order();
+            QueryOrder order = new QueryOrder();
+            IEdmNavigationProperty customerNav = _order.DeclaredNavigationProperties().Single(c => c.Name == "Customer");
             ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(
-                new ODataExpandPath(new NavigationPropertySegment(_model.Order.NavigationProperties().Single(), navigationSource: _model.Customers)),
-                _model.Customers,
+                new ODataExpandPath(new NavigationPropertySegment(customerNav, navigationSource: _customers)),
+                _customers,
                 selectExpandOption: null);
             SelectExpandClause selectExpand = new SelectExpandClause(new SelectItem[] { expandItem }, allSelected: true);
             Expression source = Expression.Constant(order);
-            _model.Model.SetAnnotationValue(_model.Order, new DynamicPropertyDictionaryAnnotation(typeof(Order).GetProperty("OrderProperties")));
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Order, _model.Orders);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
 
             // Assert
-            SelectExpandWrapper<Order> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Order>;
+            SelectExpandWrapper<QueryOrder> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryOrder>;
             Assert.NotNull(projectedOrder);
-            Assert.Contains("Customer", projectedOrder.Container.ToDictionary(new IdentityPropertyMapper()).Keys);
+            Assert.Contains("Customer", projectedOrder.Container.ToDictionary(PropertyMapper).Keys);
         }
 
         [Fact]
         public void ProjectAsWrapper_NullExpandedProperty_HasNullValueInProjectedWrapper()
         {
             // Arrange
-            IPropertyMapper mapper = new IdentityPropertyMapper();
-            Order order = new Order();
+            QueryOrder order = new QueryOrder();
+            IEdmNavigationProperty customerNav = _order.DeclaredNavigationProperties().Single(c => c.Name == "Customer");
             ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(
-                new ODataExpandPath(new NavigationPropertySegment(_model.Order.NavigationProperties().Single(), navigationSource: _model.Customers)),
-                _model.Customers,
+                new ODataExpandPath(new NavigationPropertySegment(customerNav, navigationSource: _customers)),
+                _customers,
                 selectExpandOption: null);
             SelectExpandClause selectExpand = new SelectExpandClause(new SelectItem[] { expandItem }, allSelected: true);
             Expression source = Expression.Constant(order);
-            _model.Model.SetAnnotationValue(_model.Order, new DynamicPropertyDictionaryAnnotation(typeof(Order).GetProperty("OrderProperties")));
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Order, _model.Orders);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
 
             // Assert
-            SelectExpandWrapper<Order> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Order>;
+            SelectExpandWrapper<QueryOrder> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryOrder>;
             Assert.NotNull(projectedOrder);
-            Assert.Contains("Customer", projectedOrder.Container.ToDictionary(mapper).Keys);
-            Assert.Null(projectedOrder.Container.ToDictionary(mapper)["Customer"]);
+            Assert.Contains("Customer", projectedOrder.Container.ToDictionary(PropertyMapper).Keys);
+
+            SelectExpandWrapper<QueryCustomer> projectCustomer = projectedOrder.Container.ToDictionary(PropertyMapper)["Customer"] as SelectExpandWrapper<QueryCustomer>;
+            Assert.NotNull(projectCustomer);
+            Assert.Null(projectCustomer.Instance);
         }
 
         [Fact]
@@ -259,14 +295,15 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             // Arrange
             _settings.HandleNullPropagation = HandleNullPropagationOption.True;
+
             SelectExpandClause selectExpand = new SelectExpandClause(new SelectItem[0], allSelected: true);
-            Expression source = Expression.Constant(null, typeof(Order[]));
+            Expression source = Expression.Constant(null, typeof(QueryOrder[]));
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Order, _model.Orders);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
 
             // Assert
-            IEnumerable<SelectExpandWrapper<Order>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<Order>>;
+            IEnumerable<SelectExpandWrapper<QueryOrder>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<QueryOrder>>;
             Assert.Null(projectedOrders);
         }
 
@@ -275,15 +312,16 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             // Arrange
             _settings.HandleNullPropagation = HandleNullPropagationOption.False;
+
             SelectExpandClause selectExpand = new SelectExpandClause(new SelectItem[0], allSelected: true);
-            Expression source = Expression.Constant(null, typeof(Order[]));
+
+            Expression source = Expression.Constant(null, typeof(QueryOrder[]));
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Order, _model.Orders);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _order, _orders);
 
             // Assert
-            var e = ExceptionAssert.Throws<TargetInvocationException>(
-                () => Expression.Lambda(projection).Compile().DynamicInvoke());
+            var e = ExceptionAssert.Throws<TargetInvocationException>(() => Expression.Lambda(projection).Compile().DynamicInvoke());
             Assert.IsType<ArgumentNullException>(e.InnerException);
         }
 
@@ -291,418 +329,1107 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         public void ProjectAsWrapper_Element_ProjectedValueContainsModelID()
         {
             // Arrange
-            Customer customer = new Customer();
             SelectExpandClause selectExpand = new SelectExpandClause(new SelectItem[0], allSelected: true);
-            Expression source = Expression.Constant(customer);
+            QueryCustomer aCustomer = new QueryCustomer();
+            Expression source = Expression.Constant(aCustomer);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Customer, _model.Customers);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _customer, _customers);
 
             // Assert
-            SelectExpandWrapper<Customer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Customer>;
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
             Assert.NotNull(customerWrapper.ModelID);
-            Assert.Same(_model.Model, ModelContainer.GetModel(customerWrapper.ModelID));
-        }
-
-        [Fact]
-        public void ProjectAsWrapper_Element_ProjectedValueContainsSubKeys_IfDollarRefInDollarExpand()
-        {
-            // Arrange
-            _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.SpecialOrder, new ClrTypeAnnotation(typeof(SpecialOrder)));
-            IPropertyMapper propertyMapper = new IdentityPropertyMapper();
-
-            Customer customer = new Customer
-            {
-                Orders = new[]
-                {
-                    new Order { ID = 42 },
-                    new SpecialOrder { ID = 38 }
-                }
-            };
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Customer,
-                _model.Customers,
-                new Dictionary<string, string> { { "$expand", "Orders/$ref" } });
-            SelectExpandClause selectExpand = parser.ParseSelectAndExpand();
-            Expression source = Expression.Constant(customer);
-
-            // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Customer, _model.Customers);
-
-            // Assert
-            Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
-            Assert.NotEmpty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "Instance"));
-            SelectExpandWrapper<Customer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Customer>;
-
-            var orders = customerWrapper.Container.ToDictionary(propertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<Order>>;
-            Assert.NotNull(orders);
-            Assert.Equal(2, orders.Count());
-            Assert.Equal(42, orders.ElementAt(0).Container.ToDictionary(propertyMapper)["ID"]);
-            Assert.Equal(38, orders.ElementAt(1).Container.ToDictionary(propertyMapper)["ID"]);
-        }
-
-        [Fact]
-        public void ProjectAsWrapper_Element_ProjectedValueContainsSubKeys_IfDollarRefInDollarExpand_AndNestedFilterClause()
-        {
-            // Arrange
-            _model.Model.SetAnnotationValue(_model.Order, new ClrTypeAnnotation(typeof(Order)));
-            _model.Model.SetAnnotationValue(_model.SpecialOrder, new ClrTypeAnnotation(typeof(SpecialOrder)));
-            IPropertyMapper propertyMapper = new IdentityPropertyMapper();
-
-            Customer customer = new Customer
-            {
-                Orders = new[]
-                {
-                    new Order { ID = 42, City = "xyz" },
-                    new SpecialOrder { ID = 38, City = "abc" }
-                }
-            };
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Customer,
-                _model.Customers,
-                new Dictionary<string, string> { { "$expand", "Orders/$ref($filter=City eq 'abc')" } });
-            SelectExpandClause selectExpand = parser.ParseSelectAndExpand();
-            Expression source = Expression.Constant(customer);
-
-            // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Customer, _model.Customers);
-
-            // Assert
-            Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
-            Assert.NotEmpty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "Instance"));
-            SelectExpandWrapper<Customer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Customer>;
-
-            var orders = customerWrapper.Container.ToDictionary(propertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<Order>>;
-            Assert.NotNull(orders);
-            var order = Assert.Single(orders); // only one
-            Assert.Equal(38, order.Container.ToDictionary(propertyMapper)["ID"]);
+            Assert.Same(_model, ModelContainer.GetModel(customerWrapper.ModelID));
         }
 
         [Fact]
         public void ProjectAsWrapper_Collection_ProjectedValueContainsSubKeys_IfDollarRefInDollarExpand()
         {
             // Arrange
-            _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.SpecialOrder, new ClrTypeAnnotation(typeof(SpecialOrder)));
-            IPropertyMapper propertyMapper = new IdentityPropertyMapper();
-
-            Customer customer1 = new Customer
+            string expand = "Orders/$ref";
+            QueryCustomer customer1 = new QueryCustomer
             {
                 Orders = new[]
                 {
-                    new Order { ID = 8 },
-                    new SpecialOrder { ID = 9 }
+                    new QueryOrder { Id = 8 },
+                    new QueryVipOrder { Id = 9 }
                 }
             };
-            Customer customer2 = new Customer
+            QueryCustomer customer2 = new QueryCustomer
             {
                 Orders = new[]
                 {
-                    new Order { ID = 18 },
-                    new SpecialOrder { ID = 19 }
+                    new QueryOrder { Id = 18 },
+                    new QueryVipOrder { Id = 19 }
                 }
             };
-
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Customer,
-                _model.Customers,
-                new Dictionary<string, string> { { "$expand", "Orders/$ref" } });
-            SelectExpandClause selectExpand = parser.ParseSelectAndExpand();
             Expression source = Expression.Constant(new[] { customer1, customer2 });
 
+            SelectExpandClause selectExpandClause = ParseSelectExpand(null, expand, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Customer, _model.Customers);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
 
             // Assert
             Assert.Equal(ExpressionType.Call, projection.NodeType);
-            var customerWrappers = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<Customer>>;
+            var customerWrappers = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<QueryCustomer>>;
             Assert.Equal(2, customerWrappers.Count());
 
-            var orders = customerWrappers.ElementAt(0).Container.ToDictionary(propertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<Order>>;
+            var orders = customerWrappers.ElementAt(0).Container.ToDictionary(PropertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<QueryOrder>>;
             Assert.NotNull(orders);
             Assert.Equal(2, orders.Count());
-            Assert.Equal(8, orders.ElementAt(0).Container.ToDictionary(propertyMapper)["ID"]);
-            Assert.Equal(9, orders.ElementAt(1).Container.ToDictionary(propertyMapper)["ID"]);
+            Assert.Equal(8, orders.ElementAt(0).Container.ToDictionary(PropertyMapper)["Id"]);
+            Assert.Equal(9, orders.ElementAt(1).Container.ToDictionary(PropertyMapper)["Id"]);
 
-            orders = customerWrappers.ElementAt(1).Container.ToDictionary(propertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<Order>>;
+            orders = customerWrappers.ElementAt(1).Container.ToDictionary(PropertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<QueryOrder>>;
             Assert.NotNull(orders);
             Assert.Equal(2, orders.Count());
-            Assert.Equal(18, orders.ElementAt(0).Container.ToDictionary(propertyMapper)["ID"]);
-            Assert.Equal(19, orders.ElementAt(1).Container.ToDictionary(propertyMapper)["ID"]);
+            Assert.Equal(18, orders.ElementAt(0).Container.ToDictionary(PropertyMapper)["Id"]);
+            Assert.Equal(19, orders.ElementAt(1).Container.ToDictionary(PropertyMapper)["Id"]);
         }
 
         [Fact]
         public void ProjectAsWrapper_Collection_ProjectedValueContainsSubKeys_IfDollarRefInDollarExpand_AndNestedTopAndSkip()
         {
             // Arrange
-            _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.SpecialOrder, new ClrTypeAnnotation(typeof(SpecialOrder)));
-            IPropertyMapper propertyMapper = new IdentityPropertyMapper();
-
-            Customer customer1 = new Customer
+            string expand = "Orders/$ref($top=1;$skip=1)";
+            QueryCustomer customer1 = new QueryCustomer
             {
                 Orders = new[]
                 {
-                    new Order { ID = 8 },
-                    new SpecialOrder { ID = 9 }
+                    new QueryOrder { Id = 8 },
+                    new QueryVipOrder { Id = 9 }
                 }
             };
-            Customer customer2 = new Customer
+            QueryCustomer customer2 = new QueryCustomer
             {
                 Orders = new[]
                 {
-                    new Order { ID = 18 },
-                    new SpecialOrder { ID = 19 }
+                    new QueryOrder { Id = 18 },
+                    new QueryVipOrder { Id = 19 }
                 }
             };
 
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Customer,
-                _model.Customers,
-                new Dictionary<string, string> { { "$expand", "Orders/$ref($top=1;$skip=1)" } });
-            SelectExpandClause selectExpand = parser.ParseSelectAndExpand();
             Expression source = Expression.Constant(new[] { customer1, customer2 });
+            SelectExpandClause selectExpandClause = ParseSelectExpand(null, expand, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Customer, _model.Customers);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
 
             // Assert
             Assert.Equal(ExpressionType.Call, projection.NodeType);
-            var customerWrappers = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<Customer>>;
+            var customerWrappers = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<QueryCustomer>>;
             Assert.Equal(2, customerWrappers.Count());
 
-            var orders = customerWrappers.ElementAt(0).Container.ToDictionary(propertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<Order>>;
+            var orders = customerWrappers.ElementAt(0).Container.ToDictionary(PropertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<QueryOrder>>;
             Assert.NotNull(orders);
             var order = Assert.Single(orders); // only one
-            Assert.Equal(9, order.Container.ToDictionary(propertyMapper)["ID"]);
+            Assert.Equal(9, order.Container.ToDictionary(PropertyMapper)["Id"]);
 
-            orders = customerWrappers.ElementAt(1).Container.ToDictionary(propertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<Order>>;
+            orders = customerWrappers.ElementAt(1).Container.ToDictionary(PropertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<QueryOrder>>;
             Assert.NotNull(orders);
             order = Assert.Single(orders);
-            Assert.Equal(19, order.Container.ToDictionary(propertyMapper)["ID"]);
+            Assert.Equal(19, order.Container.ToDictionary(PropertyMapper)["Id"]);
         }
 
         [Theory]
         [InlineData("*")]
-        [InlineData("ID,*")]
+        [InlineData("Id,*")]
+        [InlineData("*,Name")]
+        [InlineData("*,HomeAddress/Street")]
         [InlineData("")]
         public void ProjectAsWrapper_Element_ProjectedValueContainsInstance_IfSelectionIsAll(string select)
         {
             // Arrange
-            Customer customer = new Customer();
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Customer,
-                _model.Customers,
-                new Dictionary<string, string> { { "$select", select }, { "$expand", "Orders" } });
-            SelectExpandClause selectExpand = parser.ParseSelectAndExpand();
-            Expression source = Expression.Constant(customer);
+            QueryCustomer aCustomer = new QueryCustomer();
+            Expression source = Expression.Constant(aCustomer);
+
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Customer, _model.Customers);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
 
             // Assert
             Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
             Assert.NotEmpty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "Instance"));
-            SelectExpandWrapper<Customer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Customer>;
-            Assert.Same(customer, customerWrapper.Instance);
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+            Assert.Same(aCustomer, customerWrapper.Instance);
         }
 
         [Fact]
         public void ProjectAsWrapper_Element_ProjectedValueDoesNotContainInstance_IfSelectionIsPartial()
         {
             // Arrange
-            Customer customer = new Customer();
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(_model.Model, _model.Customer, _model.Customers,
-                new Dictionary<string, string> { { "$select", "ID,Orders" }, { "$expand", "Orders" } });
-            SelectExpandClause selectExpand = parser.ParseSelectAndExpand();
-            Expression source = Expression.Constant(customer);
+            string select = "Id,Orders";
+            string expand = "Orders";
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                Orders = new QueryOrder[0]
+            };
+            Expression source = Expression.Constant(aCustomer);
+
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, expand, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Customer, _model.Customers);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
 
             // Assert
             Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
             Assert.Empty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "Instance"));
             Assert.NotEmpty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "InstanceType"));
-            SelectExpandWrapper<Customer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Customer>;
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
             Assert.Null(customerWrapper.Instance);
-            Assert.Equal("NS.Customer", customerWrapper.InstanceType);
-        }
-
-        [Fact]
-        public void ProjectAsWrapper_Element_ProjectedValueContains_SelectedStructuralProperties()
-        {
-            // Arrange
-            Customer customer = new Customer { Name = "OData" };
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(_model.Model, _model.Customer, _model.Customers,
-                new Dictionary<string, string> { { "$select", "Name,Orders" }, { "$expand", "Orders" } });
-            SelectExpandClause selectExpand = parser.ParseSelectAndExpand();
-            Expression source = Expression.Constant(customer);
-
-            // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Customer, _model.Customers);
-
-            // Assert
-            SelectExpandWrapper<Customer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Customer>;
-            Assert.Equal(customer.Name, customerWrapper.Container.ToDictionary(new IdentityPropertyMapper())["Name"]);
+            Assert.Equal("Microsoft.AspNet.OData.Test.Query.Expressions.QueryCustomer", customerWrapper.InstanceType);
         }
 
         [Theory]
-        [InlineData("Name")]
-        [InlineData("NS.upgrade")]
-        public void ProjectAsWrapper_Element_ProjectedValueContains_KeyPropertiesEvenIfNotPresentInSelectClause(string select)
+        [InlineData("Name", "OData")]
+        [InlineData("Age", 31)]
+        public void ProjectAsWrapper_Element_ProjectedValueContains_SelectedStructuralProperties(string select, object expect)
         {
             // Arrange
-            Customer customer = new Customer { ID = 42, FirstName = "OData" };
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(_model.Model, _model.Customer, _model.Customers,
-                new Dictionary<string, string> { { "$select", select } });
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                Name = "OData",
+                Age = 31
+            };
+            Expression source = Expression.Constant(aCustomer);
 
-            SelectExpandClause selectExpand = parser.ParseSelectAndExpand();
-            Expression source = Expression.Constant(customer);
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Customer, _model.Customers);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
 
             // Assert
-            SelectExpandWrapper<Customer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Customer>;
-            Assert.Equal(customer.ID, customerWrapper.Container.ToDictionary(new IdentityPropertyMapper())["ID"]);
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+            Assert.Equal(expect, customerWrapper.Container.ToDictionary(PropertyMapper)[select]);
+        }
+
+
+        [Theory]
+        [InlineData("Emails", new[] { "E1", "E3", "E2" })]
+        [InlineData("Emails($orderby=$it)", new[] { "E1", "E2", "E3" })]
+        [InlineData("Emails($orderby=$it desc)", new[] { "E3", "E2", "E1" })]
+        [InlineData("Emails($top=1)", new[] { "E1" })]
+        [InlineData("Emails($top=1;$skip=1)", new[] { "E3" })]
+        [InlineData("Emails($filter=$it le 'E2')", new[] { "E1", "E2" })]
+        public void ProjectAsWrapper_Element_ProjectedValueContains_SelectedCollectStructuralProperties(string select, object expect)
+        {
+            // Arrange
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                Emails = new [] { "E1", "E3", "E2" }
+            };
+            Expression source = Expression.Constant(aCustomer);
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+
+            // Assert
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+            var emails = customerWrapper.Container.ToDictionary(PropertyMapper)["Emails"];
+            Assert.Equal(expect, emails);
         }
 
         [Theory]
-        [InlineData("Name")]
-        [InlineData("NS.upgrade")]
-        public void ProjectAsWrapper_ProjectedValueContainsConcurrencyProperties_EvenIfNotPresentInSelectClause(string select)
+        [InlineData("HomeAddress/Street,HomeAddress/Region")]
+        [InlineData("HomeAddress($select=Street, Region)")]
+        public void ProjectAsWrapper_Element_ProjectedValueContains_SelectedSubStructuralProperties(string select)
         {
             // Arrange
-            Customer customer = new Customer { ID = 42, City = "any" };
-
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(_model.Model, _model.Customer, _model.Customers,
-                new Dictionary<string, string> { { "$select", select } });
-            SelectExpandClause selectExpand = parser.ParseSelectAndExpand();
-            Expression source = Expression.Constant(customer);
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                HomeAddress = new QueryAddress
+                {
+                    Street = "148TH AVE NE",
+                    Region = "Redmond"
+                }
+            };
+            Expression source = Expression.Constant(aCustomer);
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
 
             // Act
-            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, _model.Customer, _model.Customers);
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
 
             // Assert
-            SelectExpandWrapper<Customer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<Customer>;
-            Assert.Equal(customer.City, customerWrapper.Container.ToDictionary(new IdentityPropertyMapper())["City"]);
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+            SelectExpandWrapper<QueryAddress> addressWrapper = customerWrapper.Container.ToDictionary(PropertyMapper)["HomeAddress"] as SelectExpandWrapper<QueryAddress>;
+            var addressProperties = addressWrapper.Container.ToDictionary(PropertyMapper);
+            Assert.Equal(2, addressProperties.Count);
+            Assert.Equal("148TH AVE NE", addressProperties["Street"]);
+            Assert.Equal("Redmond", addressProperties["Region"]);
+        }
+
+        [Theory]
+        [InlineData("Addresses/Street,Addresses/Region")]
+        [InlineData("Addresses($select=Street,Region)")]
+        public void ProjectAsWrapper_Element_ProjectedValueContains_SelectedTopCollectionWithSubStructuralProperties(string select)
+        {
+            // Arrange
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                Addresses = new List<QueryAddress>
+                {
+                    new QueryCnAddress
+                    {
+                        Street = "Being Rd",
+                        Region = "Region#1"
+                    },
+                    new QueryUsAddress
+                    {
+                        Street = "148TH AVE NE",
+                        Region = "Region#2"
+                    }
+                }
+            };
+            Expression source = Expression.Constant(aCustomer);
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+
+            // Assert
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+            var addressesWrapper = customerWrapper.Container.ToDictionary(PropertyMapper)["Addresses"] as IEnumerable<SelectExpandWrapper<QueryAddress>>;
+            Assert.Equal(2, addressesWrapper.Count());
+
+            var properties = addressesWrapper.ElementAt(0).Container.ToDictionary(PropertyMapper);
+            Assert.Equal("Being Rd", properties["Street"]);
+            Assert.Equal("Region#1", properties["Region"]);
+
+            properties = addressesWrapper.ElementAt(1).Container.ToDictionary(PropertyMapper);
+            Assert.Equal("148TH AVE NE", properties["Street"]);
+            Assert.Equal("Region#2", properties["Region"]);
         }
 
         [Fact]
-        public void CreatePropertyNameExpression_NonDerivedProperty_ReturnsConstantExpression()
+        public void ProjectAsWrapper_Element_ProjectedValueContains_SelectedTopAndSubStructuralProperties()
         {
-            Expression customer = Expression.Constant(new Customer());
-            IEdmNavigationProperty ordersProperty = _model.Customer.NavigationProperties().Single();
+            // Arrange
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                Name = "Peter",
+                HomeAddress = new QueryAddress
+                {
+                    Street = "148TH AVE NE",
+                    Region = "Redmond"
+                }
+            };
+            Expression source = Expression.Constant(aCustomer);
+            string select = "Name,HomeAddress/Street";
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
 
-            Expression property = _binder.CreatePropertyNameExpression(_model.Customer, ordersProperty, customer);
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
 
+            // Assert
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+
+            var customerProperties = customerWrapper.Container.ToDictionary(PropertyMapper);
+            Assert.Equal("Peter", customerProperties["Name"]);
+
+            SelectExpandWrapper<QueryAddress> addressWrapper = customerProperties["HomeAddress"] as SelectExpandWrapper<QueryAddress>;
+            var addressProperties = addressWrapper.Container.ToDictionary(PropertyMapper);
+            var streetProperty = Assert.Single(addressProperties);
+            Assert.Equal("Street", streetProperty.Key);
+            Assert.Equal("148TH AVE NE", streetProperty.Value);
+        }
+
+        [Theory]
+        [InlineData("HomeAddress/Codes", "C1,C4,C2")]
+        [InlineData("HomeAddress($select=Codes)", "C1,C4,C2")]
+        [InlineData("HomeAddress/Codes($top=2;$skip=1)", "C4,C2")]
+        [InlineData("HomeAddress($select=Codes($top=1;$skip=2))", "C2")]
+        [InlineData("HomeAddress/Codes($orderby=$it)", "C1,C2,C4")]
+        [InlineData("HomeAddress($select=Codes($orderby=$it desc))", "C4,C2,C1")]
+        [InlineData("HomeAddress($select=Codes($filter=$it eq 'C2'))", "C2")]
+        public void ProjectAsWrapper_Element_ProjectedValueContains_SelectedSubCollectionStructuralProperties(string select, string expect)
+        {
+            // Arrange
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                HomeAddress = new QueryAddress
+                {
+                    Codes = new [] { "C1", "C4" , "C2" }
+                }
+            };
+            Expression source = Expression.Constant(aCustomer);
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+
+            // Assert
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+            SelectExpandWrapper<QueryAddress> addressWrapper = customerWrapper.Container.ToDictionary(PropertyMapper)["HomeAddress"] as SelectExpandWrapper<QueryAddress>;
+            var addressProperties = addressWrapper.Container.ToDictionary(PropertyMapper);
+            var codeProperty = Assert.Single(addressProperties);
+            Assert.Equal("Codes", codeProperty.Key);
+            var codes = codeProperty.Value as IEnumerable<string>;
+            Assert.Equal(expect, string.Join(",", codes));
+        }
+
+        [Theory]
+        [InlineData("Addresses/Codes", "C1,C4,C2", "C3,C6,C5")]
+        [InlineData("Addresses($select=Codes)", "C1,C4,C2", "C3,C6,C5")]
+        [InlineData("Addresses/Codes($top=2;$skip=1)", "C4,C2", "C6,C5")]
+        [InlineData("Addresses($select=Codes($top=1;$skip=2))", "C2", "C5")]
+        [InlineData("Addresses/Codes($orderby=$it)", "C1,C2,C4", "C3,C5,C6")]
+        [InlineData("Addresses($select=Codes($orderby=$it desc))", "C4,C2,C1", "C6,C5,C3")]
+        [InlineData("Addresses($select=Codes($filter=$it eq 'C2'))", "C2", "")]
+        public void ProjectAsWrapper_Element_ProjectedValueContains_SelectedToCollectionAndSubCollectionStructuralProperties(string select, string expect1, string expect2)
+        {
+            // Arrange
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                Addresses = new List<QueryAddress>
+                {
+                    new QueryCnAddress
+                    {
+                        Codes = new [] { "C1", "C4" , "C2" }
+                    },
+                    new QueryUsAddress
+                    {
+                        Codes = new [] { "C3", "C6", "C5" }
+                    }
+                }
+            };
+
+            Expression source = Expression.Constant(aCustomer);
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+
+            // Assert
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+            var addressesWrapper = customerWrapper.Container.ToDictionary(PropertyMapper)["Addresses"] as IEnumerable<SelectExpandWrapper<QueryAddress>>;
+            Assert.Equal(2, addressesWrapper.Count());
+
+            var properties = addressesWrapper.ElementAt(0).Container.ToDictionary(PropertyMapper);
+            var codes = properties["Codes"] as IEnumerable<string>;
+            Assert.Equal(expect1, string.Join(",", codes));
+
+            properties = addressesWrapper.ElementAt(1).Container.ToDictionary(PropertyMapper);
+            codes = properties["Codes"] as IEnumerable<string>;
+            Assert.Equal(expect2, string.Join(",", codes));
+        }
+
+
+        [Fact(Skip = "ODL parses the following select as \"HomeAddress\\dynamic\\dynamic\", that's not correct.")]
+        public void ProjectAsWrapper_Element_ProjectedValueContains_SelectedTypeCastSubStructuralProperties()
+        {
+            // Arrange
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                HomeAddress = new QueryCnAddress
+                {
+                    Street = "Cn Street",
+                    PostCode = "201501",
+                }
+            };
+            Expression source = Expression.Constant(aCustomer);
+
+            string select = "HomeAddress/Street,HomeAddress/Microsoft.AspNet.OData.Test.Query.Expressions.QueryCnAddress/PostCode";
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+
+            // Assert
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+            SelectExpandWrapper<QueryAddress> addressWrapper = customerWrapper.Container.ToDictionary(PropertyMapper)["HomeAddress"] as SelectExpandWrapper<QueryAddress>;
+            var addressProperties = addressWrapper.Container.ToDictionary(PropertyMapper);
+            Assert.Equal(2, addressProperties.Count);
+
+            Assert.Equal("Cn Street", addressProperties["Street"]);
+            Assert.Equal("201501", addressProperties["PostCode"]);
+        }
+
+        [Fact]
+        public void ProjectAsWrapper_Element_ProjectedValueContainsSubKeys_IfDollarRefInDollarExpand()
+        {
+            // Arrange
+            string expand = "Orders/$ref";
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                Orders = new[]
+                {
+                    new QueryOrder { Id = 42 },
+                    new QueryVipOrder { Id = 38 }
+                }
+            };
+            Expression source = Expression.Constant(aCustomer);
+            SelectExpandClause selectExpandClause = ParseSelectExpand(null, expand, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+
+            // Assert
+            Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
+            Assert.NotEmpty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "Instance"));
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+
+            var orders = customerWrapper.Container.ToDictionary(PropertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<QueryOrder>>;
+            Assert.NotNull(orders);
+            Assert.Equal(2, orders.Count());
+            Assert.Equal(42, orders.ElementAt(0).Container.ToDictionary(PropertyMapper)["Id"]);
+            Assert.Equal(38, orders.ElementAt(1).Container.ToDictionary(PropertyMapper)["Id"]);
+        }
+
+        [Fact]
+        public void ProjectAsWrapper_Element_ProjectedValueContainsSubKeys_IfDollarRefInDollarExpand_AndNestedFilterClause()
+        {
+            // Arrange
+            string expand = "Orders/$ref($filter =Title eq 'abc')";
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                Orders = new[]
+                {
+                    new QueryOrder { Id = 42, Title = "xyz" },
+                    new QueryVipOrder { Id = 38, Title = "abc" }
+                }
+            };
+
+            Expression source = Expression.Constant(aCustomer);
+            SelectExpandClause selectExpandClause = ParseSelectExpand(null, expand, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+
+            // Assert
+            Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
+            Assert.NotEmpty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "Instance"));
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+
+            var orders = customerWrapper.Container.ToDictionary(PropertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<QueryOrder>>;
+            Assert.NotNull(orders);
+            var order = Assert.Single(orders); // only one
+            Assert.Equal(38, order.Container.ToDictionary(PropertyMapper)["Id"]);
+        }
+
+        [Fact]
+        public void ProjectAsWrapper_Element_ProjectedValueContainsSubKeys_IfDollarRefInDollarExpandOnSubNavigationProperty()
+        {
+            // Arrange
+            string expand = "HomeAddress/RelatedCity/$ref";
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                HomeAddress = new QueryAddress
+                {
+                    Street = "156TH",
+                    RelatedCity = new QueryCity
+                    {
+                        Id = 101
+                    }
+                }
+            };
+            Expression source = Expression.Constant(aCustomer);
+            SelectExpandClause selectExpandClause = ParseSelectExpand(null, expand, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+
+            // Assert
+            Assert.Equal(ExpressionType.MemberInit, projection.NodeType);
+            Assert.NotEmpty((projection as MemberInitExpression).Bindings.Where(p => p.Member.Name == "Instance"));
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+
+            var homeAddress = customerWrapper.Container.ToDictionary(PropertyMapper)["HomeAddress"] as SelectExpandWrapper<QueryAddress>;
+            var relatedCity = homeAddress.Container.ToDictionary(PropertyMapper)["RelatedCity"] as SelectExpandWrapper<QueryCity>;
+            Assert.Equal(101, relatedCity.Container.ToDictionary(PropertyMapper)["Id"]);
+        }
+
+        [Theory]
+        [InlineData("Name", false, 3)] // 3 => Id, Name, ETag
+        [InlineData("HomeAddress/Street", true, 3)] // 3 => ID, HomeAddress/Street, ETag
+        [InlineData("Name,HomeAddress/Street", true, 4)] // 4 => ID, Name, HomeAddress/Street, ETag
+        [InlineData("NS.*", false, 2)] // 2 => ID, ETag
+        public void ProjectAsWrapper_ReturnsKeysAndConcurrencyProperties_EvenIfNotPresentInSelectClause(string select, bool containAddress, int count)
+        {
+            // Arrange
+            IEdmStructuralProperty etagProperty =  _customer.DeclaredStructuralProperties().FirstOrDefault(c => c.Name == "CustomerETag");
+            Assert.NotNull(etagProperty); // Guard
+            ((EdmModel)_model).SetOptimisticConcurrencyAnnotation(_customers, new[] { etagProperty });
+
+            QueryCustomer aCustomer = new QueryCustomer
+            {
+                Id = 42,
+                Name = "Peter",
+                HomeAddress = new QueryAddress
+                {
+                    Street = "MyStreet"
+                },
+                CustomerETag = 1.14926
+            };
+            Expression source = Expression.Constant(aCustomer);
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+
+            // Assert
+            SelectExpandWrapper<QueryCustomer> customerWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+            var customerSelectedProperties = customerWrapper.Container.ToDictionary(PropertyMapper);
+            Assert.Equal(count, customerSelectedProperties.Count);
+
+            Assert.Equal(42, customerSelectedProperties["Id"]);
+            Assert.Equal(1.14926, customerSelectedProperties["CustomerETag"]);
+
+            if (containAddress)
+            {
+                SelectExpandWrapper<QueryAddress> addressWrapper = customerSelectedProperties["HomeAddress"] as SelectExpandWrapper<QueryAddress>;
+                var addressSelectedProperties = addressWrapper.Container.ToDictionary(PropertyMapper);
+                Assert.Single(addressSelectedProperties);
+                Assert.Equal("MyStreet", addressSelectedProperties["Street"]);
+            }
+        }
+
+        #region GetSelectExpandProperties Tests
+        [Theory]
+        [InlineData("HomeAddress")] // $select=property
+        [InlineData("Addresses")]
+        [InlineData("Emails")]
+        [InlineData("Name")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/Level")] // $select=typeCast/Property
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/Birthday")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/Taxes")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/VipAddress")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/VipAddresses")]
+        public void GetSelectExpandProperties_ForDirectProperty_OutputCorrectProperties(string select)
+        {
+            // Arrange
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude;
+            IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand;
+            ISet<IEdmStructuralProperty> autoSelectedProperties;
+            bool isContainDynamicProperty = SelectExpandBinder.GetSelectExpandProperties(_model, _customer, _customers, selectExpandClause,
+                out propertiesToInclude,
+                out propertiesToExpand,
+                out autoSelectedProperties);
+
+            // Assert
+            Assert.False(selectExpandClause.AllSelected); // guard
+            SelectItem selectItem = selectExpandClause.SelectedItems.First();
+            PathSelectItem pathSelectItem = Assert.IsType<PathSelectItem>(selectItem); // Guard
+
+            Assert.False(isContainDynamicProperty);
+            Assert.Null(propertiesToExpand); // No navigation property to expand
+
+            Assert.NotNull(autoSelectedProperties); // auto select the keys
+            Assert.Equal("Id", Assert.Single(autoSelectedProperties).Name);
+
+            Assert.NotNull(propertiesToInclude); // has one structural property to select
+            var propertyToInclude = Assert.Single(propertiesToInclude);
+
+            string[] segments = select.Split('/');
+            if (segments.Length == 2)
+            {
+                Assert.Equal(segments[1], propertyToInclude.Key.Name);
+            }
+            else
+            {
+                Assert.Equal(segments[0], propertyToInclude.Key.Name);
+            }
+
+            Assert.NotNull(propertyToInclude.Value);
+            Assert.Same(pathSelectItem, propertyToInclude.Value);
+        }
+
+        [Theory]
+        [InlineData("HomeAddress,HomeAddress/Codes")]
+        [InlineData("HomeAddress,HomeAddress/Codes($top=2)")]
+        public void GetSelectExpandProperties_ForSelectAllAndSelectSpecialy_OutputCorrectProperties(string select)
+        {
+            // Arrange
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude;
+            IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand;
+            ISet<IEdmStructuralProperty> autoSelectedProperties;
+            bool isContainDynamicProperty = SelectExpandBinder.GetSelectExpandProperties(_model, _customer, _customers, selectExpandClause,
+                out propertiesToInclude,
+                out propertiesToExpand,
+                out autoSelectedProperties);
+
+            // Assert
+            Assert.False(isContainDynamicProperty);
+            Assert.Null(propertiesToExpand);
+
+            Assert.NotNull(autoSelectedProperties);
+            Assert.Equal("Id", Assert.Single(autoSelectedProperties).Name); // Key and ETag
+
+            Assert.NotNull(propertiesToInclude);
+            var propertyToInclude = Assert.Single(propertiesToInclude);
+            Assert.Equal("HomeAddress", propertyToInclude.Key.Name);
+
+            Assert.NotNull(propertyToInclude.Value.SelectAndExpand);
+            Assert.True(propertyToInclude.Value.SelectAndExpand.AllSelected);
+            var selectItem = Assert.Single(propertyToInclude.Value.SelectAndExpand.SelectedItems);
+            Assert.IsType<PathSelectItem>(selectItem);
+        }
+
+        [Theory]
+        [InlineData("HomeAddress/Street,HomeAddress/Region,HomeAddress/Codes")]
+        [InlineData("HomeAddress($select=Street,Region,Codes)")]
+        public void GetSelectExpandProperties_ForMultipleSubPropertiesSelection_OutputCorrectProperties(string select)
+        {
+            // Arrange
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude;
+            IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand;
+            ISet<IEdmStructuralProperty> autoSelectedProperties;
+            bool isContainDynamicProperty = SelectExpandBinder.GetSelectExpandProperties(_model, _customer, _customers, selectExpandClause,
+                out propertiesToInclude,
+                out propertiesToExpand,
+                out autoSelectedProperties);
+
+            // Assert
+            Assert.False(isContainDynamicProperty);
+            Assert.Null(propertiesToExpand); // No navigation property to expand
+
+            Assert.NotNull(autoSelectedProperties); // auto select the keys & ETags
+            Assert.Equal("Id", Assert.Single(autoSelectedProperties).Name);
+
+            Assert.NotNull(propertiesToInclude); // has one structural property to select
+            var propertyToInclude = Assert.Single(propertiesToInclude);
+            Assert.Equal("HomeAddress", propertyToInclude.Key.Name);
+
+            Assert.NotNull(propertyToInclude.Value);
+
+            Assert.NotNull(propertyToInclude.Value.SelectAndExpand); // Sub select & expand
+            Assert.False(propertyToInclude.Value.SelectAndExpand.AllSelected);
+
+            Assert.Equal(3, propertyToInclude.Value.SelectAndExpand.SelectedItems.Count()); // Street, Region, Codes
+
+            Assert.Equal(new [] { "Street", "Region", "Codes"},
+                propertyToInclude.Value.SelectAndExpand.SelectedItems.Select(s =>
+            {
+                PathSelectItem subSelectItem = (PathSelectItem)s;
+                PropertySegment propertySegment = subSelectItem.SelectedPath.Single() as PropertySegment;
+                Assert.NotNull(propertySegment);
+                return propertySegment.Property.Name;
+            }));
+        }
+
+        [Theory]
+        [InlineData("CustomerDynamicProperty1", true)]
+        [InlineData("CustomerDynamicProperty2", true)]
+        [InlineData("HomeAddress/AddressDynPriperty", false)]
+        public void GetSelectExpandProperties_ForDynamicProperty_OutputCorrectBoolean(string select, bool expect)
+        {
+            // Arrange
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude;
+            IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem > propertiesToExpand;
+            ISet<IEdmStructuralProperty> autoSelectedProperties;
+            bool isContainDynamicProperty = SelectExpandBinder.GetSelectExpandProperties(_model, _customer, _customers, selectExpandClause,
+                out propertiesToInclude, out propertiesToExpand, out autoSelectedProperties);
+
+            // Assert
+            if (select.StartsWith("HomeAddress"))
+            {
+                Assert.NotNull(propertiesToInclude);
+            }
+            else
+            {
+                Assert.Null(propertiesToInclude);
+            }
+
+            Assert.Null(propertiesToExpand);
+            Assert.NotNull(autoSelectedProperties);
+
+            Assert.False(selectExpandClause.AllSelected); // guard
+            Assert.Equal(expect, isContainDynamicProperty);
+        }
+
+        [Theory]
+        [InlineData("Orders")]
+        [InlineData("PrivateOrder")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/SpecialOrder")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/SpecialOrders")]
+        public void GetSelectExpandProperties_SkipForNavigationSelection(string select)
+        {
+            // Arrange
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, null, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude;
+            IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand;
+            ISet<IEdmStructuralProperty> autoSelectedProperties;
+            bool isContainDynamicProperty = SelectExpandBinder.GetSelectExpandProperties(_model, _customer, _customers, selectExpandClause,
+                out propertiesToInclude,
+                out propertiesToExpand,
+                out autoSelectedProperties);
+
+            // Assert
+            Assert.False(isContainDynamicProperty);
+            Assert.Null(propertiesToInclude);
+            Assert.Null(propertiesToExpand);
+
+            Assert.NotNull(autoSelectedProperties);
+        }
+
+        [Theory]
+        [InlineData("PrivateOrder")]
+        [InlineData("PrivateOrder/$ref")]
+        [InlineData("Orders")]
+        [InlineData("Orders/$ref")]
+        [InlineData("Orders($top=2;$count=true)")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/SpecialOrder")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/SpecialOrder/$ref")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/SpecialOrders")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/SpecialOrders/$ref")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/SpecialOrders($search=abc)")]
+        public void GetSelectExpandProperties_ForDirectNavigationProperty_ReturnsProperties(string expand)
+        {
+            // Arrange
+            SelectExpandClause selectExpandClause = ParseSelectExpand(null, expand, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude;
+            IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand;
+            ISet<IEdmStructuralProperty> autoSelectedProperties;
+            bool isContainDynamicProperty = SelectExpandBinder.GetSelectExpandProperties(_model, _customer, _customers, selectExpandClause,
+                out propertiesToInclude,
+                out propertiesToExpand,
+                out autoSelectedProperties);
+
+            // Assert
+            var selectItem = Assert.Single(selectExpandClause.SelectedItems);
+            ExpandedReferenceSelectItem expandedItem = selectItem as ExpandedReferenceSelectItem;
+            Assert.NotNull(expandedItem);
+            var navigationSegment = expandedItem.PathToNavigationProperty.First(p => p is NavigationPropertySegment) as NavigationPropertySegment;
+
+            Assert.False(isContainDynamicProperty); // not container dynamic properties selection
+            Assert.Null(propertiesToInclude); // no structural properties to include
+            Assert.Null(autoSelectedProperties); // no auto select properties
+
+            Assert.NotNull(propertiesToExpand);
+            var propertyToExpand = Assert.Single(propertiesToExpand);
+
+            Assert.Same(navigationSegment.NavigationProperty, propertyToExpand.Key);
+            Assert.Same(expandedItem, propertyToExpand.Value);
+        }
+
+        [Theory]
+        [InlineData("HomeAddress/RelatedCity")]
+        [InlineData("HomeAddress/RelatedCity/$ref")]
+        [InlineData("HomeAddress/Cities")]
+        [InlineData("HomeAddress/Cities($top=2)")]
+        [InlineData("HomeAddress/Cities/$ref")]
+        [InlineData("Addresses/RelatedCity")]
+        [InlineData("Addresses/RelatedCity/$ref")]
+        [InlineData("Addresses/Cities")]
+        [InlineData("Addresses/Cities($count=true)")]
+        [InlineData("Addresses/Cities/$ref")]
+        [InlineData("HomeAddress/Info/InfoCity")]
+        [InlineData("Addresses/Info/InfoCity")]
+        [InlineData("HomeAddress/Microsoft.AspNet.OData.Test.Query.Expressions.QueryUsAddress/UsCity")]
+        [InlineData("HomeAddress/Microsoft.AspNet.OData.Test.Query.Expressions.QueryUsAddress/UsCities")]
+        [InlineData("HomeAddress/Microsoft.AspNet.OData.Test.Query.Expressions.QueryUsAddress/UsCities($select=CityName)")]
+        [InlineData("HomeAddress/Microsoft.AspNet.OData.Test.Query.Expressions.QueryUsAddress/UsCities/$ref")]
+        [InlineData("Addresses/Microsoft.AspNet.OData.Test.Query.Expressions.QueryCnAddress/CnCity")]
+        [InlineData("Addresses/Microsoft.AspNet.OData.Test.Query.Expressions.QueryCnAddress/CnCities")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/VipAddress/Microsoft.AspNet.OData.Test.Query.Expressions.QueryCnAddress/CnCities")]
+        [InlineData("Microsoft.AspNet.OData.Test.Query.Expressions.QueryVipCustomer/VipAddresses/Microsoft.AspNet.OData.Test.Query.Expressions.QueryUsAddress/UsCities")]
+        public void GetSelectExpandProperties_ForNonDirectNavigationProperty_ReturnsCorrectExpandedProperties(string expand)
+        {
+            // Arrange
+            SelectExpandClause selectExpandClause = ParseSelectExpand(null, expand, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude;
+            IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand;
+            ISet<IEdmStructuralProperty> autoSelectedProperties;
+            bool isContainDynamicProperty = SelectExpandBinder.GetSelectExpandProperties(_model, _customer, _customers, selectExpandClause,
+                out propertiesToInclude,
+                out propertiesToExpand,
+                out autoSelectedProperties);
+
+            // Assert
+            var selectItem = Assert.Single(selectExpandClause.SelectedItems);
+            ExpandedReferenceSelectItem expandedItem = selectItem as ExpandedReferenceSelectItem;
+            Assert.NotNull(expandedItem);
+            var propertySegment = expandedItem.PathToNavigationProperty.First(p => p is PropertySegment) as PropertySegment;
+
+            Assert.Null(propertiesToExpand); // nothing to expand at current level
+
+            Assert.NotEmpty(propertiesToInclude);
+            var propertyToInclude = Assert.Single(propertiesToInclude);
+
+            Assert.Same(propertySegment.Property, propertyToInclude.Key);
+            Assert.NotNull(propertyToInclude.Value);
+
+            PathSelectItem pathItem = propertyToInclude.Value;
+            Assert.NotNull(pathItem);
+            Assert.NotNull(pathItem.SelectAndExpand);
+            Assert.True(pathItem.SelectAndExpand.AllSelected);
+            var nextLevelSelectItem = Assert.Single(pathItem.SelectAndExpand.SelectedItems);
+            var nextLevelExpandedItem = nextLevelSelectItem as ExpandedReferenceSelectItem;
+            Assert.NotNull(nextLevelExpandedItem);
+        }
+
+        [Fact]
+        public void GetSelectExpandProperties_FoSelectAndExpand_ReturnsCorrectExpandedProperties()
+        {
+            // Arrange
+            string select = "HomeAddress($select=Street),Addresses/Codes($top=2)";
+            string expand = "HomeAddress/RelatedCity/$ref,HomeAddress/Cities($count=true),PrivateOrder";
+            SelectExpandClause selectExpandClause = ParseSelectExpand(select, expand, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            IDictionary<IEdmStructuralProperty, PathSelectItem> propertiesToInclude;
+            IDictionary<IEdmNavigationProperty, ExpandedReferenceSelectItem> propertiesToExpand;
+            ISet<IEdmStructuralProperty> autoSelectedProperties;
+            bool isContainDynamicProperty = SelectExpandBinder.GetSelectExpandProperties(_model, _customer, _customers, selectExpandClause,
+                out propertiesToInclude,
+                out propertiesToExpand,
+                out autoSelectedProperties);
+
+            // Arrange
+            Assert.False(isContainDynamicProperty);
+
+            Assert.NotNull(selectExpandClause);
+            Assert.False(selectExpandClause.AllSelected);
+
+            // Why it's 6, because ODL includes "HomeAddress" as Selected automatic when parsing $expand=HomeAddress/Nav
+            // It's an issue reported at: https://github.com/OData/odata.net/issues/1574
+            Assert.Equal(6, selectExpandClause.SelectedItems.Count());
+
+            Assert.NotNull(propertiesToInclude);
+            Assert.Equal(2, propertiesToInclude.Count);
+            Assert.Equal(new[] { "HomeAddress", "Addresses" }, propertiesToInclude.Keys.Select(e => e.Name));
+
+            Assert.NotNull(propertiesToExpand);
+            var propertyToExpand = Assert.Single(propertiesToExpand);
+            Assert.Equal("PrivateOrder", propertyToExpand.Key.Name);
+
+            Assert.NotNull(autoSelectedProperties);
+            Assert.Equal("Id", Assert.Single(autoSelectedProperties).Name);
+        }
+
+        #endregion
+
+        #region CreatePropertyNameExpression Tests
+        [Fact]
+        public void CreatePropertyNameExpression_ReturnsCorrectExpression()
+        {
+            // Arrange
+            // Retrieve base info
+            IEdmProperty baseProperty = _customer.FindProperty("PrivateOrder");
+            Assert.NotNull(baseProperty); // Guard
+
+            // Retrieve derived info
+            IEdmEntityType vipCustomer = _model.SchemaElements.OfType<IEdmEntityType>().FirstOrDefault(c => c.Name == "QueryVipCustomer");
+            Assert.NotNull(vipCustomer); // Guard
+            IEdmProperty derivedProperty = vipCustomer.FindProperty("Birthday");
+            Assert.NotNull(derivedProperty); // Guard
+
+            Expression source = Expression.Parameter(typeof(QueryCustomer), "aCustomer");
+            SelectExpandBinder binder = GetBinder<QueryCustomer>(_model);
+
+            // Act & Assert
+            // #1. Base property on base type
+            Expression property = binder.CreatePropertyNameExpression(_customer, baseProperty, source);
             Assert.Equal(ExpressionType.Constant, property.NodeType);
-            Assert.Equal(ordersProperty.Name, (property as ConstantExpression).Value);
-        }
+            Assert.Equal(typeof(string), property.Type);
+            Assert.Equal("PrivateOrder", (property as ConstantExpression).Value);
 
-        //[Fact]
-        //public void CreatePropertyNameExpression_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
-        //{
-        //    // Arrange
-        //    _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.SpecialCustomer, null);
+            // #2. Base property on derived type
+            property = binder.CreatePropertyNameExpression(vipCustomer, baseProperty, source);
+            Assert.Equal(ExpressionType.Constant, property.NodeType);
+            Assert.Equal(typeof(string), property.Type);
+            Assert.Equal("PrivateOrder", (property as ConstantExpression).Value);
 
-        //    Expression customer = Expression.Constant(new Customer());
-        //    IEdmNavigationProperty specialOrdersProperty = _model.SpecialCustomer.DeclaredNavigationProperties().Single();
-
-            //// Act & Assert
-            //ExceptionAssert.Throws<ODataException>(
-            //    () => _binder.CreatePropertyNameExpression(_model.Customer, specialOrdersProperty, customer),
-            //    "The provided mapping does not contain a resource for the resource type 'NS.SpecialCustomer'.");
-        //}
-
-        [Fact]
-        public void CreatePropertyNameExpression_DerivedProperty_ReturnsConditionalExpression()
-        {
-            Expression customer = Expression.Constant(new Customer());
-            IEdmNavigationProperty specialOrdersProperty = _model.SpecialCustomer.DeclaredNavigationProperties().Single();
-
-            Expression property = _binder.CreatePropertyNameExpression(_model.Customer, specialOrdersProperty, customer);
-
+            // #3. Derived property on base type
+            property = binder.CreatePropertyNameExpression(_customer, derivedProperty, source);
             Assert.Equal(ExpressionType.Conditional, property.NodeType);
-            Assert.Equal(String.Format("IIF(({0} Is SpecialCustomer), \"SpecialOrders\", null)", customer.ToString()), property.ToString());
-        }
+            Assert.Equal(typeof(string), property.Type);
+            Assert.Equal("IIF((aCustomer Is QueryVipCustomer), \"Birthday\", null)", property.ToString());
 
-        [Fact]
-        public void CreatePropertyNameExpression_BaseProperty_From_DerivedType_ReturnsConstantExpression()
-        {
-            Expression customer = Expression.Constant(new SpecialCustomer());
-            IEdmNavigationProperty ordersProperty = _model.Customer.NavigationProperties().Single();
-
-            Expression property = _binder.CreatePropertyNameExpression(_model.SpecialCustomer, ordersProperty, customer);
-
+            // #4. Derived property on derived type.
+            property = binder.CreatePropertyNameExpression(vipCustomer, derivedProperty, source);
             Assert.Equal(ExpressionType.Constant, property.NodeType);
-            Assert.Equal(ordersProperty.Name, (property as ConstantExpression).Value);
+            Assert.Equal(typeof(string), property.Type);
+            Assert.Equal("Birthday", (property as ConstantExpression).Value);
+        }
+
+        [Fact(Skip = "if (!castType.IsAssignableFrom(originalType)) retrun true?")]
+        public void CreatePropertyNameExpression_ReturnsConstantExpression_IfPropertyTypeCannotAssignedToElementType()
+        {
+            // Arrange
+            IEdmComplexType complexType = _model.SchemaElements.OfType<IEdmComplexType>().First(c => c.Name == "QueryAddress");
+            Assert.False(complexType.IsOrInheritsFrom(_customer)); // make sure order has no inheritance-ship with customer.
+
+            IEdmProperty edmProperty = complexType.FindProperty("Street");
+            Assert.NotNull(edmProperty);
+
+            Expression source = Expression.Parameter(typeof(QueryCustomer), "aCustomer");
+
+            // Act
+            Expression property = _binder.CreatePropertyNameExpression(_customer, edmProperty, source);
+
+            // Assert
+            Assert.Equal(ExpressionType.Constant, property.NodeType);
+            Assert.Equal(typeof(string), property.Type);
+            Assert.Equal("Street", (property as ConstantExpression).Value);
         }
 
         [Fact]
-        public void CreatePropertyValueExpression_NonDerivedProperty_ReturnsMemberAccessExpression()
+        public void CreatePropertyNameExpression_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
         {
-            Expression customer = Expression.Constant(new Customer());
-            IEdmNavigationProperty ordersProperty = _model.Customer.NavigationProperties().Single();
+            // Arrange
+            EdmModel model = _model as EdmModel;
 
-            Expression property = _binder.CreatePropertyValueExpression(_model.Customer, ordersProperty, customer);
+            // Create a "SubCustomer" derived from "Customer", but without the CLR type in the Edm model.
+            EdmEntityType subCustomer = new EdmEntityType("NS", "SubCustomer", _customer);
+            EdmStructuralProperty subNameProperty = subCustomer.AddStructuralProperty("SubName", EdmPrimitiveTypeKind.String);
+            model.AddElement(subCustomer);
 
-            Assert.Equal(ExpressionType.MemberAccess, property.NodeType);
-            Assert.Equal(typeof(Customer).GetProperty("Orders"), (property as MemberExpression).Member);
+            Expression source = Expression.Constant(new QueryCustomer());
+            SelectExpandBinder binder = GetBinder<QueryCustomer>(model);
+
+            // Act & Assert
+            ExceptionAssert.Throws<ODataException>(() => binder.CreatePropertyNameExpression(_customer, subNameProperty, source),
+                "The provided mapping does not contain a resource for the resource type 'NS.SubCustomer'.");
+        }
+        #endregion
+
+        #region CreatePropertyValueExpression
+        [Theory]
+        [InlineData("PrivateOrder")]
+        [InlineData("Orders")]
+        public void CreatePropertyValueExpression_NonDerivedNavigationProperty_ReturnsMemberAccessExpression(string property)
+        {
+            // Arrange
+            Expression source = Expression.Constant(new QueryCustomer());
+
+            IEdmNavigationProperty navProperty = _customer.NavigationProperties().Single(c => c.Name == property);
+            Assert.NotNull(navProperty);
+
+            // Act
+            Expression propertyValue = _binder.CreatePropertyValueExpression(_customer, navProperty, source, null);
+
+            // Assert
+            Assert.Equal(ExpressionType.MemberAccess, propertyValue.NodeType);
+            Assert.Equal(typeof(QueryCustomer).GetProperty(property), (propertyValue as MemberExpression).Member);
+            Assert.Equal(String.Format("{0}.{1}", source.ToString(), property), propertyValue.ToString());
         }
 
-        //[Fact]
-        //public void CreatePropertyValueExpression_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
-        //{
-        //    // Arrange
-        //    _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.SpecialCustomer, null);
-        //    Expression customer = Expression.Constant(new Customer());
-        //    IEdmNavigationProperty specialOrdersProperty = _model.SpecialCustomer.DeclaredNavigationProperties().Single();
-
-        //    // Act & Assert
-        //    ExceptionAssert.Throws<ODataException>(
-        //        () => _binder.CreatePropertyValueExpression(_model.Customer, specialOrdersProperty, customer),
-        //        "The provided mapping does not contain a resource for the resource type 'NS.SpecialCustomer'.");
-        //}
-
-        [Fact]
-        public void CreatePropertyValueExpression_DerivedProperty_ReturnsPropertyAccessExpression()
+        [Theory]
+        [InlineData("SpecialOrder")]
+        [InlineData("SpecialOrders")]
+        public void CreatePropertyValueExpression_DerivedNavigationProperty_ReturnsPropertyAccessExpression(string property)
         {
-            Expression customer = Expression.Constant(new Customer());
-            IEdmNavigationProperty specialOrdersProperty = _model.SpecialCustomer.DeclaredNavigationProperties().Single();
+            // Arrange
+            Expression source = Expression.Constant(new QueryCustomer());
 
-            Expression property = _binder.CreatePropertyValueExpression(_model.Customer, specialOrdersProperty, customer);
+            IEdmStructuredType vipCustomer = _model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "QueryVipCustomer");
+            Assert.NotNull(vipCustomer);
 
-            Assert.Equal(String.Format("({0} As SpecialCustomer).SpecialOrders", customer.ToString()), property.ToString());
+            IEdmNavigationProperty specialProperty = vipCustomer.DeclaredNavigationProperties().First(c => c.Name == property);
+            Assert.NotNull(specialProperty);
+
+            // Act
+            Expression propertyValue = _binder.CreatePropertyValueExpression(_customer, specialProperty, source, null);
+
+            // Assert
+            Assert.Equal(String.Format("({0} As QueryVipCustomer).{1}", source.ToString(), property), propertyValue.ToString());
         }
 
-        //[Fact]
-        //public void CreatePropertyValueExpression_DerivedNonNullableProperty_ReturnsPropertyAccessExpressionCastToNullable()
-        //{
-        //    Expression customer = Expression.Constant(new Customer());
-        //    IEdmStructuralProperty specialCustomerProperty = _model.SpecialCustomer.DeclaredStructuralProperties()
-        //        .Single(s => s.Name == "SpecialCustomerProperty");
+        [Theory]
+        [InlineData("Level")]
+        [InlineData("Birthday")]
+        [InlineData("Bonus")]
+        public void CreatePropertyValueExpression_DerivedValueProperty_ReturnsPropertyAccessExpression(string property)
+        {
+            // Arrange
+            Expression source = Expression.Constant(new QueryCustomer());
 
-        //    Expression property = _binder.CreatePropertyValueExpression(_model.Customer, specialCustomerProperty, customer);
+            IEdmStructuredType vipCustomer = _model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "QueryVipCustomer");
+            Assert.NotNull(vipCustomer);
 
-        //    Assert.Equal(
-        //        String.Format("Convert(({0} As SpecialCustomer).SpecialCustomerProperty)", customer.ToString()),
-        //        property.ToString());
-        //}
+            IEdmStructuralProperty edmProperty = vipCustomer.DeclaredStructuralProperties().First(c => c.Name == property);
+            Assert.NotNull(vipCustomer);
+
+            // Act
+            Expression propertyValue = _binder.CreatePropertyValueExpression(_customer, edmProperty, source, null);
+
+            // Assert
+#if NETCORE
+            Assert.Equal(String.Format("Convert(({0} As QueryVipCustomer).{1}, Nullable`1)", source.ToString(), property), propertyValue.ToString());
+#else
+            Assert.Equal(String.Format("Convert(({0} As QueryVipCustomer).{1})", source.ToString(), property), propertyValue.ToString());
+#endif
+        }
+
+        [Theory]
+        [InlineData("Taxes")]
+        [InlineData("VipAddress")]
+        [InlineData("VipAddresses")]
+        public void CreatePropertyValueExpression_DerivedReferenceProperty_ReturnsPropertyAccessExpression(string property)
+        {
+            // Arrange
+            Expression source = Expression.Constant(new QueryCustomer());
+
+            IEdmStructuredType vipCustomer = _model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "QueryVipCustomer");
+            Assert.NotNull(vipCustomer);
+
+            IEdmStructuralProperty edmProperty = vipCustomer.DeclaredStructuralProperties().First(c => c.Name == property);
+            Assert.NotNull(vipCustomer);
+
+            // Act
+            Expression propertyValue = _binder.CreatePropertyValueExpression(_customer, edmProperty, source, null);
+
+            // Assert
+            Assert.Equal(String.Format("({0} As QueryVipCustomer).{1}", source.ToString(), property), propertyValue.ToString());
+        }
 
         [Fact]
         public void CreatePropertyValueExpression_HandleNullPropagationTrue_AddsNullCheck()
         {
+            // Arrange
             _settings.HandleNullPropagation = HandleNullPropagationOption.True;
-            Expression customer = Expression.Constant(new Customer());
-            IEdmProperty idProperty = _model.Customer.StructuralProperties().Single(p => p.Name == "ID");
+            Expression source = Expression.Constant(new QueryCustomer());
+            IEdmProperty idProperty = _customer.StructuralProperties().Single(p => p.Name == "Id");
 
-            Expression property = _binder.CreatePropertyValueExpression(_model.Customer, idProperty, customer);
+            // Act
+            Expression property = _binder.CreatePropertyValueExpression(_customer, idProperty, source, null);
 
+            // Assert
             // NetFx and NetCore differ in the way Expression is converted to a string.
             Assert.Equal(ExpressionType.Conditional, property.NodeType);
             ConditionalExpression conditionalExpression = property as ConditionalExpression;
@@ -712,7 +1439,7 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             Assert.Equal(ExpressionType.Convert, conditionalExpression.IfFalse.NodeType);
             UnaryExpression falseUnaryExpression = conditionalExpression.IfFalse as UnaryExpression;
             Assert.NotNull(falseUnaryExpression);
-            Assert.Equal(String.Format("{0}.ID", customer.ToString()), falseUnaryExpression.Operand.ToString());
+            Assert.Equal(String.Format("{0}.Id", source.ToString()), falseUnaryExpression.Operand.ToString());
             Assert.Equal(typeof(int?), falseUnaryExpression.Type);
 
             Assert.Equal(ExpressionType.Constant, conditionalExpression.IfTrue.NodeType);
@@ -723,7 +1450,7 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             Assert.Equal(ExpressionType.Equal, conditionalExpression.Test.NodeType);
             BinaryExpression binaryExpression = conditionalExpression.Test as BinaryExpression;
             Assert.NotNull(binaryExpression);
-            Assert.Equal(customer.ToString(), binaryExpression.Left.ToString());
+            Assert.Equal(source.ToString(), binaryExpression.Left.ToString());
             Assert.Equal("null", binaryExpression.Right.ToString());
             Assert.Equal(typeof(bool), binaryExpression.Type);
         }
@@ -731,278 +1458,209 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         [Fact]
         public void CreatePropertyValueExpression_HandleNullPropagationFalse_ConvertsToNullableType()
         {
+            // Arrange
             _settings.HandleNullPropagation = HandleNullPropagationOption.False;
-            Expression customer = Expression.Constant(new Customer());
-            IEdmProperty idProperty = _model.Customer.StructuralProperties().Single(p => p.Name == "ID");
+            Expression source = Expression.Constant(new QueryCustomer());
+            IEdmProperty idProperty = _customer.StructuralProperties().Single(p => p.Name == "Id");
 
-            Expression property = _binder.CreatePropertyValueExpression(_model.Customer, idProperty, customer);
+            // Act
+            Expression property = _binder.CreatePropertyValueExpression(_customer, idProperty, source, filterClause: null);
 
+            // Assert
 #if NETCORE
-            Assert.Equal(String.Format("Convert({0}.ID, Nullable`1)", customer.ToString()), property.ToString());
+            Assert.Equal(String.Format("Convert({0}.Id, Nullable`1)", source.ToString()), property.ToString());
 #else
-            Assert.Equal(String.Format("Convert({0}.ID)", customer.ToString()), property.ToString());
+            Assert.Equal(String.Format("Convert({0}.Id)", source.ToString()), property.ToString());
 #endif
             Assert.Equal(typeof(int?), property.Type);
         }
 
         [Fact]
-        public void CreatePropertyValueExpressionWithFilter_Collection_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
+        public void CreatePropertyValueExpression_Collection_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
         {
             // Arrange
-            _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.Order, value: null);
-            var customer = Expression.Constant(new Customer());
-            var ordersProperty = _model.Customer.NavigationProperties().Single(p => p.Name == "Orders");
-            var parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Order,
-                _model.Orders,
-                new Dictionary<string, string> { { "$filter", "ID eq 1" } });
-            var filterClause = parser.ParseFilter();
-            ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(new ODataExpandPath(new NavigationPropertySegment(_model.Order.NavigationProperties().Single(), navigationSource: _model.Customers)),
-                null, null, filterClause, null, null, null, null, null, null);
+            _model.SetAnnotationValue(_order, new ClrTypeAnnotation(null));
+
+            var source = Expression.Constant(new QueryCustomer
+            {
+                Orders = new[]
+                {
+                    new QueryOrder { Id = 1 },
+                    new QueryOrder { Id = 2 }
+                }
+            });
+
+            var ordersProperty = _customer.NavigationProperties().Single(p => p.Name == "Orders");
+
+            SelectExpandClause selectExpand = ParseSelectExpand(null, "Orders($filter=Id eq 1)", _model, _customer, _customers);
+            ExpandedNavigationSelectItem expandItem = Assert.Single(selectExpand.SelectedItems) as ExpandedNavigationSelectItem;
+            Assert.NotNull(expandItem);
+            Assert.NotNull(expandItem.FilterOption);
 
             // Act & Assert
             ExceptionAssert.Throws<ODataException>(
-                () => _binder.CreatePropertyValueExpressionWithFilter(_model.Customer, ordersProperty, customer, expandItem),
-                "The provided mapping does not contain a resource for the resource type 'NS.Order'.");
-
-            // NetFx and NetCore differ in the way Expression is converted to a string.
-            //Assert.Equal(ExpressionType.Convert, property.NodeType);
-            //var unaryExpression = (property as UnaryExpression);
-            //Assert.NotNull(unaryExpression);
-            //Assert.Equal(String.Format("{0}.ID", customer.ToString()), unaryExpression.Operand.ToString());
-            //Assert.Equal(typeof(int?), unaryExpression.Type);
+                () => _binder.CreatePropertyValueExpression(_customer, ordersProperty, source, expandItem.FilterOption),
+                String.Format("The provided mapping does not contain a resource for the resource type '{0}'.",
+                ordersProperty.Type.Definition.AsElementType().FullTypeName()));
         }
 
-        //[Fact]
-        //public void CreatePropertyValueExpressionWithFilter_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
-        //{
-        //    // Arrange
-        //    _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.Order, value: null);
-        //    var customer = Expression.Constant(new Customer());
-        //    var ordersProperty = _model.Customer.NavigationProperties().Single(p => p.Name == "Orders");
-        //    var parser = new ODataQueryOptionParser(
-        //        _model.Model,
-        //        _model.Order,
-        //        _model.Orders,
-        //        new Dictionary<string, string> { { "$filter", "ID eq 1" } });
-        //    var filterCaluse = parser.ParseFilter();
-
-        //    // Act & Assert
-        //    ExceptionAssert.Throws<ODataException>(
-        //        () => _binder.CreatePropertyValueExpressionWithFilter(_model.Customer, ordersProperty, customer, filterCaluse),
-        //        "The provided mapping does not contain a resource for the resource type 'NS.Order'.");
-        //}
-
-        [Fact]
-        public void CreatePropertyValueExpressionWithFilter_Collection_Works_HandleNullPropagationOptionIsTrue()
+        [Theory]
+        [InlineData(HandleNullPropagationOption.True)]
+        [InlineData(HandleNullPropagationOption.False)]
+        public void CreatePropertyValueExpression_Collection_Works_HandleNullPropagationOption(HandleNullPropagationOption nullOption)
         {
             // Arrange
-            _model.Model.SetAnnotationValue(_model.Order, new ClrTypeAnnotation(typeof(Order)));
-            _settings.HandleNullPropagation = HandleNullPropagationOption.True;
-            var customer =
-                Expression.Constant(new Customer { Orders = new[] { new Order { ID = 1 }, new Order { ID = 2 } } });
-            var ordersProperty = _model.Customer.NavigationProperties().Single(p => p.Name == "Orders");
-            var parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Order,
-                _model.Orders,
-                new Dictionary<string, string> { { "$filter", "ID eq 1" } });
-            var filterClause = parser.ParseFilter();
-            ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(new ODataExpandPath(new NavigationPropertySegment(_model.Order.NavigationProperties().Single(), navigationSource: _model.Customers)),
-                            null, null, filterClause, null, null, null, null, null, null);
+            _settings.HandleNullPropagation = nullOption;
+            var source = Expression.Constant(new QueryCustomer
+            {
+                Orders = new[]
+                {
+                    new QueryOrder { Id = 1 },
+                    new QueryOrder { Id = 2 }
+                }
+            });
+
+            var ordersProperty = _customer.NavigationProperties().Single(p => p.Name == "Orders");
+
+            SelectExpandClause selectExpand = ParseSelectExpand(null, "Orders($filter=Id eq 1)", _model, _customer, _customers);
+            ExpandedNavigationSelectItem expandItem = Assert.Single(selectExpand.SelectedItems) as ExpandedNavigationSelectItem;
+            Assert.NotNull(expandItem);
+            Assert.NotNull(expandItem.FilterOption);
 
             // Act
-            var filterInExpand = _binder.CreatePropertyValueExpressionWithFilter(
-                _model.Customer,
-                ordersProperty,
-                customer,
-                expandItem);
+            var filterInExpand = _binder.CreatePropertyValueExpression(_customer, ordersProperty, source, expandItem.FilterOption);
 
             // Assert
-            Assert.Equal(
-                string.Format(
-                    "IIF((value({0}) == null), null, IIF((value({0}).Orders == null), null, " +
-                    "value({0}).Orders.Where($it => ($it.ID == value({1}).TypedProperty))))",
-                    customer.Type,
-                    "Microsoft.AspNet.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]"),
-                filterInExpand.ToString());
-            var orders = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as IEnumerable<Order>;
-            Assert.Single(orders);
-            Assert.Equal(1, orders.ToList()[0].ID);
+            if (nullOption == HandleNullPropagationOption.True)
+            {
+                Assert.Equal(
+                    string.Format(
+                        "IIF((value({0}) == null), null, IIF((value({0}).Orders == null), null, " +
+                        "value({0}).Orders.Where($it => ($it.Id == value({1}).TypedProperty))))",
+                        source.Type,
+                        "Microsoft.AspNet.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]"),
+                    filterInExpand.ToString());
+            }
+            else
+            {
+                Assert.Equal(
+                    string.Format(
+                        "value({0}).Orders.Where($it => ($it.Id == value(" +
+                        "Microsoft.AspNet.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]).TypedProperty))",
+                        source.Type),
+                    filterInExpand.ToString());
+            }
+
+            var orders = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as IEnumerable<QueryOrder>;
+            QueryOrder order = Assert.Single(orders);
+            Assert.Equal(1, order.Id);
         }
 
         [Fact]
-        public void CreatePropertyValueExpressionWithFilter_Collection_Works_HandleNullPropagationOptionIsFalse()
+        public void CreatePropertyValueExpression_Single_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
         {
             // Arrange
-            _model.Model.SetAnnotationValue(_model.Order, new ClrTypeAnnotation(typeof(Order)));
-            _settings.HandleNullPropagation = HandleNullPropagationOption.False;
-            var customer =
-                Expression.Constant(new Customer { Orders = new[] { new Order { ID = 1 }, new Order { ID = 2 } } });
-            var ordersProperty = _model.Customer.NavigationProperties().Single(p => p.Name == "Orders");
-            var parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Order,
-                _model.Orders,
-                new Dictionary<string, string> { { "$filter", "ID eq 1" } });
-            var filterClause = parser.ParseFilter();
-            ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(new ODataExpandPath(new NavigationPropertySegment(_model.Order.NavigationProperties().Single(), navigationSource: _model.Customers)),
-                            null, null, filterClause, null, null, null, null, null, null);
+            _model.SetAnnotationValue(_customer, new ClrTypeAnnotation(null));
 
-            // Act
-            var filterInExpand = _binder.CreatePropertyValueExpressionWithFilter(
-                _model.Customer,
-                ordersProperty,
-                customer,
-                expandItem);
-
-            // Assert
-            Assert.Equal(
-                string.Format(
-                    "value({0}).Orders.Where($it => ($it.ID == value(" +
-                    "Microsoft.AspNet.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]).TypedProperty))",
-                    customer.Type),
-                filterInExpand.ToString());
-            var orders = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as IEnumerable<Order>;
-            Assert.Single(orders);
-            Assert.Equal(1, orders.ToList()[0].ID);
-        }
-
-        [Fact]
-        public void CreatePropertyValueExpressionWithFilter_Single_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
-        {
-            // Arrange
-            _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.Customer, value: null);
             _settings.HandleReferenceNavigationPropertyExpandFilter = true;
-            var order = Expression.Constant(new Order());
-            var customerProperty = _model.Order.NavigationProperties().Single(p => p.Name == "Customer");
+            var source = Expression.Constant(new QueryOrder());
+            var customerProperty = _order.NavigationProperties().Single(p => p.Name == "Customer");
 
-            var parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Customer,
-                _model.Customers,
-                new Dictionary<string, string> { { "$filter", "ID eq 1" } });
-            var filterClause = parser.ParseFilter();
-            ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(new ODataExpandPath(new NavigationPropertySegment(_model.Order.NavigationProperties().Single(), navigationSource: _model.Customers)),
-                            null, null, filterClause, null, null, null, null, null, null);
+            SelectExpandClause selectExpand = ParseSelectExpand(null, "Customer($filter=Id ne 1)", _model, _order, _orders);
+            ExpandedNavigationSelectItem expandItem = Assert.Single(selectExpand.SelectedItems) as ExpandedNavigationSelectItem;
+            Assert.NotNull(expandItem);
+            Assert.NotNull(expandItem.FilterOption);
+
             // Act & Assert
             ExceptionAssert.Throws<ODataException>(
-                () => _binder.CreatePropertyValueExpressionWithFilter(_model.Order, customerProperty, order, expandItem),
-                "The provided mapping does not contain a resource for the resource type 'NS.Customer'.");
+                () => _binder.CreatePropertyValueExpression(_order, customerProperty, source, expandItem.FilterOption),
+                String.Format("The provided mapping does not contain a resource for the resource type '{0}'.", customerProperty.Type.FullName()));
         }
 
         [Fact]
-        public void CreatePropertyValueExpressionWithFilter_Single_Works_IfSettingIsOff()
+        public void CreatePropertyValueExpression_Single_Works_IfSettingIsOff()
         {
             // Arrange
             _settings.HandleReferenceNavigationPropertyExpandFilter = false;
             var order = Expression.Constant(
-                    new Order
+                    new QueryOrder
                     {
-                        Customer = new Customer
+                        Customer = new QueryCustomer
                         {
-                            ID = 1
+                            Id = 1
                         }
                     }
             );
-            var customerProperty = _model.Order.NavigationProperties().Single(p => p.Name == "Customer");
+            var customerProperty = _order.NavigationProperties().Single(p => p.Name == "Customer");
 
-            var parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Customer,
-                _model.Customers,
-                new Dictionary<string, string> { { "$filter", "ID ne 1" } });
-            var filterClause = parser.ParseFilter();
-            ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(new ODataExpandPath(new NavigationPropertySegment(_model.Order.NavigationProperties().Single(), navigationSource: _model.Customers)),
-                            null, null, filterClause, null, null, null, null, null, null);
+            SelectExpandClause selectExpand = ParseSelectExpand(null, "Customer($filter=Id ne 1)", _model, _order, _orders);
+            Assert.True(selectExpand.AllSelected); // Guard
+            ExpandedNavigationSelectItem expandItem = Assert.Single(selectExpand.SelectedItems) as ExpandedNavigationSelectItem;
+            Assert.NotNull(expandItem);
+            Assert.NotNull(expandItem.FilterOption);
+
             // Act 
-            var filterInExpand = _binder.CreatePropertyValueExpressionWithFilter(_model.Order, customerProperty, order, expandItem);
+            var filterInExpand = _binder.CreatePropertyValueExpression(_order, customerProperty, order, expandItem.FilterOption);
 
-            // Assert            
-            var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as Customer;
+            // Assert
+            var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as QueryCustomer;
             Assert.NotNull(customer);
-            Assert.Equal(1, customer.ID);
+            Assert.Equal(1, customer.Id);
         }
 
-        [Fact]
-        public void CreatePropertyValueExpressionWithFilter_Single_Works_HandleNullPropagationOptionIsTrue()
+        [Theory]
+        [InlineData(HandleNullPropagationOption.True)]
+        [InlineData(HandleNullPropagationOption.False)]
+        public void CreatePropertyValueExpression_Single_Works_HandleNullPropagationOption(HandleNullPropagationOption nullOption)
         {
             // Arrange
             _settings.HandleReferenceNavigationPropertyExpandFilter = true;
-            _settings.HandleNullPropagation = HandleNullPropagationOption.True;
-            var order = Expression.Constant(
-                    new Order
+            _settings.HandleNullPropagation = nullOption;
+            var source = Expression.Constant(
+                    new QueryOrder
                     {
-                        Customer = new Customer
+                        Customer = new QueryCustomer
                         {
-                            ID = 1
+                            Id = 1
                         }
                     }
             );
-            var customerProperty = _model.Order.NavigationProperties().Single(p => p.Name == "Customer");
+            var customerProperty = _order.NavigationProperties().Single(p => p.Name == "Customer");
 
-            var parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Customer,
-                _model.Customers,
-                new Dictionary<string, string> { { "$filter", "ID ne 1" } });
-            var filterClause = parser.ParseFilter();
-            ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(new ODataExpandPath(new NavigationPropertySegment(_model.Order.NavigationProperties().Single(), navigationSource: _model.Customers)),
-                            null, null, filterClause, null, null, null, null, null, null);
+            SelectExpandClause selectExpand = ParseSelectExpand(null, "Customer($filter=Id ne 1)", _model, _order, _orders);
+            Assert.True(selectExpand.AllSelected); // Guard
+            ExpandedNavigationSelectItem expandItem = Assert.Single(selectExpand.SelectedItems) as ExpandedNavigationSelectItem;
+            Assert.NotNull(expandItem);
+            Assert.NotNull(expandItem.FilterOption);
+
             // Act
-            var filterInExpand = _binder.CreatePropertyValueExpressionWithFilter(_model.Order, customerProperty, order, expandItem);
+            var filterInExpand = _binder.CreatePropertyValueExpression(_order, customerProperty, source, expandItem.FilterOption);
 
             // Assert
-            Assert.Equal(
-                string.Format(
-                    "IIF((value({0}) == null), null, IIF((value({0}).Customer == null), null, " +
-                    "IIF((value({0}).Customer.ID != value(Microsoft.AspNet.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]).TypedProperty), " +
-                    "value({0}).Customer, null)))",
-                    order.Type),
-                filterInExpand.ToString());
-            var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as Customer;
+            if (nullOption == HandleNullPropagationOption.True)
+            {
+                Assert.Equal(
+                    string.Format(
+                        "IIF((value({0}) == null), null, IIF((value({0}).Customer == null), null, " +
+                        "IIF((value({0}).Customer.Id != value(Microsoft.AspNet.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]).TypedProperty), " +
+                        "value({0}).Customer, null)))",
+                        source.Type),
+                    filterInExpand.ToString());
+            }
+            else
+            {
+                Assert.Equal(
+                    string.Format(
+                        "IIF((value({0}).Customer.Id != value(Microsoft.AspNet.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]).TypedProperty), " +
+                        "value({0}).Customer, null)",
+                        source.Type),
+                    filterInExpand.ToString());
+            }
+
+            var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as QueryCustomer;
             Assert.Null(customer);
         }
-
-        [Fact]
-        public void CreatePropertyValueExpressionWithFilter_Single_Works_HandleNullPropagationOptionIsFalse()
-        {
-            // Arrange
-            _settings.HandleReferenceNavigationPropertyExpandFilter = true;
-            _settings.HandleNullPropagation = HandleNullPropagationOption.False;
-            var order = Expression.Constant(
-                    new Order
-                    {
-                        Customer = new Customer
-                        {
-                            ID = 1
-                        }
-                    }
-            );
-            var customerProperty = _model.Order.NavigationProperties().Single(p => p.Name == "Customer");
-
-            var parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Customer,
-                _model.Customers,
-                new Dictionary<string, string> { { "$filter", "ID ne 1" } });
-            var filterClause = parser.ParseFilter();
-            ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(new ODataExpandPath(new NavigationPropertySegment(_model.Order.NavigationProperties().Single(), navigationSource: _model.Customers)),
-                            null, null, filterClause, null, null, null, null, null, null);
-            // Act
-            var filterInExpand = _binder.CreatePropertyValueExpressionWithFilter(_model.Order, customerProperty, order, expandItem);
-
-            // Assert
-            Assert.Equal(
-                string.Format(
-                    "IIF((value({0}).Customer.ID != value(Microsoft.AspNet.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]).TypedProperty), " +
-                    "value({0}).Customer, null)",
-                    order.Type),
-                filterInExpand.ToString());
-            var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as Customer;
-            Assert.Null(customer);
-        }
+        #endregion
 
         [Fact]
         public void CreateTypeNameExpression_ReturnsNull_IfTypeHasNoDerivedTypes()
@@ -1021,23 +1679,23 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             Assert.Null(result);
         }
 
-        //[Fact]
-        //public void CreateTypeNameExpression_ThrowsODataException_IfTypeHasNoMapping()
-        //{
-        //    // Arrange
-        //    IEdmEntityType baseType = new EdmEntityType("NS", "BaseType");
-        //    IEdmEntityType derivedType = new EdmEntityType("NS", "DerivedType", baseType);
-        //    EdmModel model = new EdmModel();
-        //    model.AddElement(baseType);
-        //    model.AddElement(derivedType);
+        [Fact]
+        public void CreateTypeNameExpression_ThrowsODataException_IfTypeHasNoMapping()
+        {
+            // Arrange
+            IEdmEntityType baseType = new EdmEntityType("NS", "BaseType");
+            IEdmEntityType derivedType = new EdmEntityType("NS", "DerivedType", baseType);
+            EdmModel model = new EdmModel();
+            model.AddElement(baseType);
+            model.AddElement(derivedType);
 
-        //    Expression source = Expression.Constant(42);
+            Expression source = Expression.Constant(42);
 
-        //    // Act & Assert
-        //    ExceptionAssert.Throws<ODataException>(
-        //        () => SelectExpandBinder.CreateTypeNameExpression(source, baseType, model),
-        //        "The provided mapping does not contain a resource for the resource type 'NS.DerivedType'.");
-        //}
+            // Act & Assert
+            ExceptionAssert.Throws<ODataException>(
+                () => SelectExpandBinder.CreateTypeNameExpression(source, baseType, model),
+                "The provided mapping does not contain a resource for the resource type 'NS.DerivedType'.");
+        }
 
         [Fact]
         public void CreateTypeNameExpression_ReturnsConditionalExpression_IfTypeHasDerivedTypes()
@@ -1075,21 +1733,19 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             // Arrange
             _settings.EnableCorrelatedSubqueryBuffering = enableOptimization;
-            var customer =
-                Expression.Constant(new Customer { Orders = new[] { new Order { ID = 1 }, new Order { ID = 2 } } });
-            var parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Customer,
-                _model.Customers,
-                new Dictionary<string, string> { { "$expand", "Orders" } });
-            var expandClause = parser.ParseSelectAndExpand();
+            var source = Expression.Constant(new QueryCustomer
+            {
+                Orders = new[]
+                {
+                    new QueryOrder { Id = 1 },
+                    new QueryOrder { Id = 2 }
+                }
+            });
+
+            var expandClause = ParseSelectExpand(null, "Orders", _model, _customer, _customers);
 
             // Act
-            var expand = _binder.ProjectAsWrapper(
-                customer,
-                expandClause,
-                _model.Customer,
-                _model.Customers);
+            var expand = _binder.ProjectAsWrapper(source, expandClause, _customer, _customers);
 
             // Assert
             Assert.True(expand.ToString().Contains("ToList") == enableOptimization);
@@ -1103,36 +1759,167 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             // Arrange
             _settings.EnableCorrelatedSubqueryBuffering = enableOptimization;
             _settings.PageSize = 100;
-            var customer =
-                Expression.Constant(new Customer { Orders = new[] { new Order { ID = 1 }, new Order { ID = 2 } } });
-            var parser = new ODataQueryOptionParser(
-                _model.Model,
-                _model.Customer,
-                _model.Customers,
-                new Dictionary<string, string> { { "$expand", "Orders" } });
-            var expandClause = parser.ParseSelectAndExpand();
+            var source = Expression.Constant(new QueryCustomer
+            {
+                Orders = new[]
+                {
+                    new QueryOrder { Id = 1 },
+                    new QueryOrder { Id = 2 }
+                }
+            });
+
+            var expandClause = ParseSelectExpand(null, "Orders", _model, _customer, _customers);
 
             // Act
-            var expand = _binder.ProjectAsWrapper(
-                customer,
-                expandClause,
-                _model.Customer,
-                _model.Customers);
+            var expand = _binder.ProjectAsWrapper(source, expandClause, _customer, _customers);
 
             // Assert
             Assert.True(expand.ToString().Contains("ToList") == enableOptimization);
         }
 
-        private class SpecialCustomer : Customer
+        public static IEdmModel GetEdmModel()
         {
-            public int SpecialCustomerProperty { get; set; }
+            var builder = new ODataConventionModelBuilder();
+            var customer = builder.EntitySet<QueryCustomer>("Customers").EntityType;
+            builder.EntitySet<QueryOrder>("Orders");
+            builder.EntitySet<QueryCity>("Cities");
 
-            public SpecialOrder[] SpecialOrders { get; set; }
+            customer.Collection.Function("IsUpgraded").Returns<bool>().Namespace="NS";
+            customer.Collection.Action("UpgradeAll").Namespace = "NS";
+            return builder.GetEdmModel();
         }
 
-        private class SpecialOrder : Order
+        public static SelectExpandClause ParseSelectExpand(string select, string expand, IEdmModel model, IEdmType edmType, IEdmNavigationSource navigationSource)
         {
-            public SpecialCustomer[] SpecialCustomers { get; set; }
+            return new ODataQueryOptionParser(model, edmType, navigationSource,
+                new Dictionary<string, string>
+                {
+                    { "$expand", expand == null ? "" : expand },
+                    { "$select", select == null ? "" : select }
+                }).ParseSelectAndExpand();
         }
+    }
+
+    public class QueryCity
+    {
+        public int Id { get; set; }
+
+        public int CityName { get; set; }
+    }
+
+
+    public class QueryAddressInfo
+    {
+        public QueryCity InfoCity { get; set; }
+    }
+
+    public class QueryAddress
+    {
+        public string Street { get; set; }
+
+        public string Region { get; set; }
+
+        public IList<string> Codes { get; set; }
+
+        public QueryAddressInfo Info { get; set; }
+
+        public IList<int> Prices { get; set; }
+
+        public QueryCity RelatedCity { get; set; }
+
+        [ConcurrencyCheck] // ETag on property of complex is not fully supported.
+        public double AddressETag { get; set; }
+
+        public IList<QueryCity> Cities { get; set; }
+
+        public IDictionary<string, object> AddressDynaicProperties { get; set; }
+    }
+
+    public class QueryUsAddress : QueryAddress
+    {
+        public string ZipCode { get; set; }
+
+        public QueryCity UsCity { get; set; }
+
+        public IList<QueryCity> UsCities { get; set; }
+    }
+
+    public class QueryCnAddress : QueryAddress
+    {
+        public string PostCode { get; set; }
+
+        public QueryCity CnCity { get; set; }
+
+        public IList<QueryCity> CnCities { get; set; }
+    }
+
+    public class QueryOrder
+    {
+        public int Id { get; set; }
+
+        public string Title { get; set; }
+
+        public QueryCustomer Customer { get; set; }
+
+        public IDictionary<string, object> OrderProperties { get; set; }
+    }
+
+    public class QueryCustomer
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public int Age { get; set; }
+
+        public IList<string> Emails { get; set; }
+
+        // [ConcurrencyCheck]
+        public double CustomerETag { get; set; }
+
+        public QueryColor FarivateColor { get; set; }
+
+        public QueryAddress HomeAddress { get; set; }
+
+        public IList<QueryAddress> Addresses { get; set; }
+
+        public QueryOrder PrivateOrder { get; set; }
+
+        public IList<QueryOrder> Orders { get; set; }
+
+        public IDictionary<string, object> CustomerProperties { get; set; }
+    }
+
+    public class QueryVipCustomer : QueryCustomer
+    {
+        public int Level { get; set; }
+
+        public DateTimeOffset Birthday { get; set; }
+
+        public IList<int> Taxes { get; set; }
+
+        public decimal Bonus { get; set; }
+
+        public QueryAddress VipAddress { get; set; }
+
+        public QueryAddress[] VipAddresses { get; set; }
+
+        public QueryVipOrder SpecialOrder { get; set; }
+
+        public QueryVipOrder[] SpecialOrders { get; set; }
+    }
+
+    public class QueryVipOrder : QueryOrder
+    {
+        public QueryVipCustomer[] SpecialCustomers { get; set; }
+    }
+
+    public enum QueryColor
+    {
+        Red,
+
+        Green,
+
+        Blue
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandIncludePropertyTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandIncludePropertyTest.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.AspNet.OData.Query.Expressions;
+using Microsoft.AspNet.OData.Test.Common;
+using Xunit;
+
+namespace Microsoft.AspNet.OData.Test.Query.Expressions
+{
+    public class SelectExpandIncludePropertyTest
+    {
+        [Fact]
+        public void Constructor_ThrowsPropertySegmentArgumentNull_IfMissPropertySegment()
+        {
+            // Act & Assert
+            ExceptionAssert.ThrowsArgumentNull(() => new SelectExpandIncludeProperty(null, null),
+                "propertySegment");
+        }
+    }
+}

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandIncludedPropertyTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandIncludedPropertyTest.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Query.Expressions
 {
-    public class SelectExpandIncludedPropertyTest
+    public class SelectExpandIncludePropertyTest
     {
         [Fact]
         public void Constructor_ThrowsPropertySegmentArgumentNull_IfMissPropertySegment()

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandPathExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandPathExtensionsTest.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Query.Expressions;
+using Microsoft.AspNet.OData.Test.Common;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+using Xunit;
+
+namespace Microsoft.AspNet.OData.Test.Query.Expressions
+{
+    public class SelectExpandPathExtensionsTest
+    {
+        [Fact]
+        public void GetFirstNonTypeCastSegment_SelectPath_ThrowsArgumentNull()
+        {
+            // Arrange & Act
+            ODataSelectPath selectPath = null;
+            IList<ODataPathSegment> remainingSegments;
+
+            // Assert
+            ExceptionAssert.ThrowsArgumentNull(() => selectPath.GetFirstNonTypeCastSegment(out remainingSegments), "selectPath");
+        }
+
+        [Fact]
+        public void GetFirstNonTypeCastSegment_ExpandPath_ThrowsArgumentNull()
+        {
+            // Arrange & Act
+            ODataExpandPath expandPath = null;
+            IList<ODataPathSegment> remainingSegments;
+
+            // Assert
+            ExceptionAssert.ThrowsArgumentNull(() => expandPath.GetFirstNonTypeCastSegment(out remainingSegments), "expandPath");
+        }
+
+        [Fact]
+        public void GetFirstNonTypeCastSegment_ThrowsForUnsupportedMiddleSegmentInSelectPath()
+        {
+            // Arrange & Act
+            ODataSelectPath selectPath = new ODataSelectPath(new DynamicPathSegment("abc"), new DynamicPathSegment("xyz"));
+            IList<ODataPathSegment> remainingSegments;
+
+            // Assert
+            ExceptionAssert.Throws<ODataException>(() => selectPath.GetFirstNonTypeCastSegment(out remainingSegments),
+                String.Format(SRResources.InvalidSegmentInSelectExpandPath, "DynamicPathSegment"));
+        }
+
+        [Fact]
+        public void GetFirstNonTypeCastSegment_ThrowsForUnsupportedLastSegmentInSelectPath()
+        {
+            // Arrange & Act
+            IEdmType stringType = EdmCoreModel.Instance.GetString(false).Definition;
+            ODataSelectPath selectPath = new ODataSelectPath(new TypeSegment(stringType, null), new TypeSegment(stringType, null));
+            IList<ODataPathSegment> remainingSegments;
+
+            // Assert
+            ExceptionAssert.Throws<ODataException>(() => selectPath.GetFirstNonTypeCastSegment(out remainingSegments),
+                String.Format(SRResources.InvalidLastSegmentInSelectExpandPath, "TypeSegment"));
+        }
+
+        [Fact]
+        public void GetFirstNonTypeCastSegment_WorksForSelectPathWithFirstNonTypeSegmentAtBegin()
+        {
+            // Arrange
+            EdmEntityType entityType = new EdmEntityType("NS", "Customer");
+            IEdmStructuralProperty property = entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.String);
+
+            ODataPathSegment firstPropertySegment = new PropertySegment(property);
+            ODataPathSegment secondPropertySegment = new PropertySegment(property);
+            ODataSelectPath selectPath = new ODataSelectPath(firstPropertySegment, secondPropertySegment);
+
+            // Act
+            IList<ODataPathSegment> remainingSegments;
+            ODataPathSegment firstNonTypeSegment = selectPath.GetFirstNonTypeCastSegment(out remainingSegments);
+
+            // Assert
+            Assert.NotNull(firstNonTypeSegment);
+            Assert.Same(firstPropertySegment, firstNonTypeSegment);
+
+            Assert.NotNull(remainingSegments);
+            Assert.Same(secondPropertySegment, Assert.Single(remainingSegments));
+        }
+
+        [Fact]
+        public void GetFirstNonTypeCastSegment_WorksForSelectPathWithFirstNonTypeSegmentAtMiddle()
+        {
+            // Arrange
+            EdmEntityType entityType = new EdmEntityType("NS", "Customer");
+            IEdmStructuralProperty property = entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.String);
+
+            ODataPathSegment firstTypeSegment = new TypeSegment(entityType, null);
+            ODataPathSegment secondTypeSegment = new TypeSegment(entityType, null);
+            ODataPathSegment firstPropertySegment = new PropertySegment(property);
+            ODataPathSegment secondPropertySegment = new PropertySegment(property);
+            ODataSelectPath selectPath = new ODataSelectPath(
+                firstTypeSegment,
+                secondTypeSegment,
+                firstPropertySegment, // here
+                secondPropertySegment);
+
+            // Act
+            IList<ODataPathSegment> remainingSegments;
+            ODataPathSegment firstNonTypeSegment = selectPath.GetFirstNonTypeCastSegment(out remainingSegments);
+
+            // Assert
+            Assert.NotNull(firstNonTypeSegment);
+            Assert.Same(firstPropertySegment, firstNonTypeSegment);
+
+            Assert.NotNull(remainingSegments);
+            Assert.Same(secondPropertySegment, Assert.Single(remainingSegments));
+        }
+
+        [Fact]
+        public void GetFirstNonTypeCastSegment_WorksForSelectPathWithFirstNonTypeSegmentAtLast()
+        {
+            // Arrange
+            EdmEntityType entityType = new EdmEntityType("NS", "Customer");
+            IEdmStructuralProperty property = entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.String);
+
+            ODataPathSegment firstTypeSegment = new TypeSegment(entityType, null);
+            ODataPathSegment secondTypeSegment = new TypeSegment(entityType, null);
+            ODataPathSegment firstPropertySegment = new PropertySegment(property);
+            ODataSelectPath selectPath = new ODataSelectPath(
+                firstTypeSegment,
+                secondTypeSegment,
+                firstPropertySegment);
+
+            // Act
+            IList<ODataPathSegment> remainingSegments;
+            ODataPathSegment firstNonTypeSegment = selectPath.GetFirstNonTypeCastSegment(out remainingSegments);
+
+            // Assert
+            Assert.NotNull(firstNonTypeSegment);
+            Assert.Same(firstPropertySegment, firstNonTypeSegment);
+
+            Assert.Null(remainingSegments);
+        }
+
+        [Fact]
+        public void GetFirstNonTypeCastSegment_WorksForExpandPathOnlyWithTypeAndNavigationSegment()
+        {
+            // Arrange
+            EdmEntityType entityType = new EdmEntityType("NS", "Customer");
+            var navProperty = entityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+            {
+                Name = "Nav",
+                Target = entityType,
+                TargetMultiplicity = EdmMultiplicity.One
+            });
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Container");
+            EdmEntitySet set = new EdmEntitySet(container, "set", entityType);
+            NavigationPropertySegment navSegment = new NavigationPropertySegment(navProperty, set);
+            TypeSegment typeSegment = new TypeSegment(entityType, null);
+            ODataExpandPath expandPath = new ODataExpandPath(typeSegment, navSegment);
+
+            // Act
+            IList<ODataPathSegment> remainingSegments;
+            ODataPathSegment firstNonTypeSegment = expandPath.GetFirstNonTypeCastSegment(out remainingSegments);
+
+            // Assert
+            Assert.NotNull(firstNonTypeSegment);
+            Assert.Same(navSegment, firstNonTypeSegment);
+
+            Assert.Null(remainingSegments);
+        }
+
+        [Fact]
+        public void GetFirstNonTypeCastSegment_WorksForExpandPathWithPropertySegment()
+        {
+            // Arrange
+            EdmEntityType entityType = new EdmEntityType("NS", "Customer");
+            IEdmStructuralProperty property = entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.String);
+            var navProperty = entityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+            {
+                Name = "Nav",
+                Target = entityType,
+                TargetMultiplicity = EdmMultiplicity.One
+            });
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Container");
+            EdmEntitySet set = new EdmEntitySet(container, "set", entityType);
+            NavigationPropertySegment navSegment = new NavigationPropertySegment(navProperty, set);
+            TypeSegment typeSegment = new TypeSegment(entityType, null);
+            ODataPathSegment propertySegment = new PropertySegment(property);
+            ODataExpandPath expandPath = new ODataExpandPath(typeSegment, propertySegment, navSegment);
+
+            // Act
+            IList<ODataPathSegment> remainingSegments;
+            ODataPathSegment firstNonTypeSegment = expandPath.GetFirstNonTypeCastSegment(out remainingSegments);
+
+            // Assert
+            Assert.NotNull(firstNonTypeSegment);
+            Assert.Same(propertySegment, firstNonTypeSegment);
+
+            Assert.NotNull(remainingSegments);
+            Assert.Same(navSegment, Assert.Single(remainingSegments));
+        }
+    }
+}

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -3334,7 +3334,11 @@ public class Microsoft.AspNet.OData.Formatter.Serialization.SelectExpandNode {
 	public SelectExpandNode (Microsoft.OData.UriParser.SelectExpandClause selectExpandClause, Microsoft.OData.Edm.IEdmStructuredType structuredType, Microsoft.OData.Edm.IEdmModel model)
 
 	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.ExpandedNavigationSelectItem]] ExpandedProperties  { public get; }
+	[
+	ObsoleteAttribute(),
+	]
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmNavigationProperty]] ReferencedNavigationProperties  { public get; }
+
 	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.ExpandedReferenceSelectItem]] ReferencedProperties  { public get; }
 	bool SelectAllDynamicProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmAction]] SelectedActions  { public get; }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -3333,15 +3333,12 @@ public class Microsoft.AspNet.OData.Formatter.Serialization.SelectExpandNode {
 	public SelectExpandNode (Microsoft.OData.Edm.IEdmStructuredType structuredType, ODataSerializerContext writeContext)
 	public SelectExpandNode (Microsoft.OData.UriParser.SelectExpandClause selectExpandClause, Microsoft.OData.Edm.IEdmStructuredType structuredType, Microsoft.OData.Edm.IEdmModel model)
 
-	[
-	ObsoleteAttribute(),
-	]
-	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.SelectExpandClause]] ExpandedNavigationProperties  { public get; }
-
 	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.ExpandedNavigationSelectItem]] ExpandedProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmNavigationProperty]] ReferencedNavigationProperties  { public get; }
+	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.ExpandedReferenceSelectItem]] ReferencedProperties  { public get; }
 	bool SelectAllDynamicProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmAction]] SelectedActions  { public get; }
+	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmStructuralProperty],[Microsoft.OData.UriParser.PathSelectItem]] SelectedComplexes  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] SelectedComplexProperties  { public get; }
 	System.Collections.Generic.ISet`1[[System.String]] SelectedDynamicProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmFunction]] SelectedFunctions  { public get; }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -3338,13 +3338,20 @@ public class Microsoft.AspNet.OData.Formatter.Serialization.SelectExpandNode {
 	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.ExpandedReferenceSelectItem]] ReferencedProperties  { public get; }
 	bool SelectAllDynamicProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmAction]] SelectedActions  { public get; }
-	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmStructuralProperty],[Microsoft.OData.UriParser.PathSelectItem]] SelectedComplexes  { public get; }
+	[
+	ObsoleteAttribute(),
+	]
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] SelectedComplexProperties  { public get; }
+
+	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmStructuralProperty],[Microsoft.OData.UriParser.PathSelectItem]] SelectedComplexTypeProperties  { public get; }
 	System.Collections.Generic.ISet`1[[System.String]] SelectedDynamicProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmFunction]] SelectedFunctions  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmNavigationProperty]] SelectedNavigationProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] SelectedStructuralProperties  { public get; }
 
+	[
+	ObsoleteAttribute(),
+	]
 	public static void GetStructuralProperties (Microsoft.OData.Edm.IEdmStructuredType structuredType, System.Collections.Generic.HashSet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] structuralProperties, System.Collections.Generic.HashSet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] nestedStructuralProperties)
 }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -3469,15 +3469,12 @@ public class Microsoft.AspNet.OData.Formatter.Serialization.SelectExpandNode {
 	public SelectExpandNode (Microsoft.OData.Edm.IEdmStructuredType structuredType, ODataSerializerContext writeContext)
 	public SelectExpandNode (Microsoft.OData.UriParser.SelectExpandClause selectExpandClause, Microsoft.OData.Edm.IEdmStructuredType structuredType, Microsoft.OData.Edm.IEdmModel model)
 
-	[
-	ObsoleteAttribute(),
-	]
-	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.SelectExpandClause]] ExpandedNavigationProperties  { public get; }
-
 	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.ExpandedNavigationSelectItem]] ExpandedProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmNavigationProperty]] ReferencedNavigationProperties  { public get; }
+	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.ExpandedReferenceSelectItem]] ReferencedProperties  { public get; }
 	bool SelectAllDynamicProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmAction]] SelectedActions  { public get; }
+	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmStructuralProperty],[Microsoft.OData.UriParser.PathSelectItem]] SelectedComplexes  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] SelectedComplexProperties  { public get; }
 	System.Collections.Generic.ISet`1[[System.String]] SelectedDynamicProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmFunction]] SelectedFunctions  { public get; }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -3474,13 +3474,20 @@ public class Microsoft.AspNet.OData.Formatter.Serialization.SelectExpandNode {
 	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.ExpandedReferenceSelectItem]] ReferencedProperties  { public get; }
 	bool SelectAllDynamicProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmAction]] SelectedActions  { public get; }
-	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmStructuralProperty],[Microsoft.OData.UriParser.PathSelectItem]] SelectedComplexes  { public get; }
+	[
+	ObsoleteAttribute(),
+	]
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] SelectedComplexProperties  { public get; }
+
+	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmStructuralProperty],[Microsoft.OData.UriParser.PathSelectItem]] SelectedComplexTypeProperties  { public get; }
 	System.Collections.Generic.ISet`1[[System.String]] SelectedDynamicProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmFunction]] SelectedFunctions  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmNavigationProperty]] SelectedNavigationProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] SelectedStructuralProperties  { public get; }
 
+	[
+	ObsoleteAttribute(),
+	]
 	public static void GetStructuralProperties (Microsoft.OData.Edm.IEdmStructuredType structuredType, System.Collections.Generic.HashSet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] structuralProperties, System.Collections.Generic.HashSet`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] nestedStructuralProperties)
 }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -3470,7 +3470,11 @@ public class Microsoft.AspNet.OData.Formatter.Serialization.SelectExpandNode {
 	public SelectExpandNode (Microsoft.OData.UriParser.SelectExpandClause selectExpandClause, Microsoft.OData.Edm.IEdmStructuredType structuredType, Microsoft.OData.Edm.IEdmModel model)
 
 	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.ExpandedNavigationSelectItem]] ExpandedProperties  { public get; }
+	[
+	ObsoleteAttribute(),
+	]
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmNavigationProperty]] ReferencedNavigationProperties  { public get; }
+
 	System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmNavigationProperty],[Microsoft.OData.UriParser.ExpandedReferenceSelectItem]] ReferencedProperties  { public get; }
 	bool SelectAllDynamicProperties  { public get; }
 	System.Collections.Generic.ISet`1[[Microsoft.OData.Edm.IEdmAction]] SelectedActions  { public get; }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #196.*

### Description

1. The PR is intended to enable:

* $select=../complex/property
* $select=.../TypeCast/Property
* $select=....($select=...;$top=..;$skip=...;$orderby=...;$filter=....)

This PR is not supporting the nested ($compute and $search).

2. This PR is adjusting the implementation about navigation property on complex property.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
