### PR TITLE
Fixes #1953. Generation of skip token value with a DateTime

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataPrimitiveSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataPrimitiveSerializer.cs
@@ -166,52 +166,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
                     case TypeCode.DateTime:
                         DateTime dateTime = (DateTime)value;
-
-                        TimeZoneInfo timeZone = TimeZoneInfoHelper.TimeZone;
-                        TimeSpan utcOffset = timeZone.GetUtcOffset(dateTime);
-                        if (utcOffset >= TimeSpan.Zero)
-                        {
-                            if (dateTime <= DateTime.MinValue + utcOffset)
-                            {
-                                return DateTimeOffset.MinValue;
-                            }
-                        }
-                        else
-                        {
-                            if (dateTime >= DateTime.MaxValue + utcOffset)
-                            {
-                                return DateTimeOffset.MaxValue;
-                            }
-                        }
-
-                        if (dateTime.Kind == DateTimeKind.Local)
-                        {
-                            TimeZoneInfo localTimeZoneInfo = TimeZoneInfo.Local;
-                            TimeSpan localTimeSpan = localTimeZoneInfo.GetUtcOffset(dateTime);
-                            if (localTimeSpan < TimeSpan.Zero)
-                            {
-                                if (dateTime >= DateTime.MaxValue + localTimeSpan)
-                                {
-                                    return DateTimeOffset.MaxValue;
-                                }
-                            }
-                            else
-                            {
-                                if (dateTime <= DateTime.MinValue + localTimeSpan)
-                                {
-                                    return DateTimeOffset.MinValue;
-                                }
-                            }
-
-                            return TimeZoneInfo.ConvertTime(new DateTimeOffset(dateTime), timeZone);
-                        }
-
-                        if (dateTime.Kind == DateTimeKind.Utc)
-                        {
-                            return TimeZoneInfo.ConvertTime(new DateTimeOffset(dateTime), timeZone);
-                        }
-
-                        return new DateTimeOffset(dateTime, timeZone.GetUtcOffset(dateTime));
+                        return TimeZoneInfoHelper.ConvertToDateTimeOffset(dateTime);
 
                     default:
                         if (type == typeof(char[]))

--- a/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
@@ -138,6 +138,11 @@ namespace Microsoft.AspNet.OData.Query
                     ODataEnumValue enumValue = new ODataEnumValue(value.ToString(), value.GetType().FullName);
                     uriLiteral = ODataUriUtils.ConvertToUriLiteral(enumValue, ODataVersion.V401, model);
                 }
+                else if(edmProperty.Type.IsDateTimeOffset() && value is DateTime d)
+                {
+                    var dateTimeOffsetValue = TimeZoneInfoHelper.ConvertToDateTimeOffset(d);
+                    uriLiteral = ODataUriUtils.ConvertToUriLiteral(dateTimeOffsetValue, ODataVersion.V401, model);
+                }
                 else
                 {
                     uriLiteral = ODataUriUtils.ConvertToUriLiteral(value, ODataVersion.V401, model);

--- a/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
@@ -138,9 +138,10 @@ namespace Microsoft.AspNet.OData.Query
                     ODataEnumValue enumValue = new ODataEnumValue(value.ToString(), value.GetType().FullName);
                     uriLiteral = ODataUriUtils.ConvertToUriLiteral(enumValue, ODataVersion.V401, model);
                 }
-                else if(edmProperty.Type.IsDateTimeOffset() && value is DateTime d)
+                else if(edmProperty.Type.IsDateTimeOffset() && value is DateTime)
                 {
-                    var dateTimeOffsetValue = TimeZoneInfoHelper.ConvertToDateTimeOffset(d);
+                    var dateTime = (DateTime)value;
+                    var dateTimeOffsetValue = TimeZoneInfoHelper.ConvertToDateTimeOffset(dateTime);
                     uriLiteral = ODataUriUtils.ConvertToUriLiteral(dateTimeOffsetValue, ODataVersion.V401, model);
                 }
                 else

--- a/src/Microsoft.AspNet.OData.Shared/TimeZoneInfoHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/TimeZoneInfoHelper.cs
@@ -22,5 +22,54 @@ namespace Microsoft.AspNet.OData
             }
             set { _defaultTimeZoneInfo = value; }
         }
+
+        public static DateTimeOffset ConvertToDateTimeOffset(DateTime dateTime)
+        {
+            TimeZoneInfo timeZone = TimeZoneInfoHelper.TimeZone;
+            TimeSpan utcOffset = timeZone.GetUtcOffset(dateTime);
+            if (utcOffset >= TimeSpan.Zero)
+            {
+                if (dateTime <= DateTime.MinValue + utcOffset)
+                {
+                    return DateTimeOffset.MinValue;
+                }
+            }
+            else
+            {
+                if (dateTime >= DateTime.MaxValue + utcOffset)
+                {
+                    return DateTimeOffset.MaxValue;
+                }
+            }
+
+            if (dateTime.Kind == DateTimeKind.Local)
+            {
+                TimeZoneInfo localTimeZoneInfo = TimeZoneInfo.Local;
+                TimeSpan localTimeSpan = localTimeZoneInfo.GetUtcOffset(dateTime);
+                if (localTimeSpan < TimeSpan.Zero)
+                {
+                    if (dateTime >= DateTime.MaxValue + localTimeSpan)
+                    {
+                        return DateTimeOffset.MaxValue;
+                    }
+                }
+                else
+                {
+                    if (dateTime <= DateTime.MinValue + localTimeSpan)
+                    {
+                        return DateTimeOffset.MinValue;
+                    }
+                }
+
+                return TimeZoneInfo.ConvertTime(new DateTimeOffset(dateTime), timeZone);
+            }
+
+            if (dateTime.Kind == DateTimeKind.Utc)
+            {
+                return TimeZoneInfo.ConvertTime(new DateTimeOffset(dateTime), timeZone);
+            }
+
+            return new DateTimeOffset(dateTime, timeZone.GetUtcOffset(dateTime));
+        }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ModelBoundQuerySettings/PageAttributeTest/SkipTokenController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ModelBoundQuerySettings/PageAttributeTest/SkipTokenController.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNet.OData;
 using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
 
@@ -85,7 +86,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.ModelBoundQuerySettings.PageAttributeT
                         {
                             Id = i * 3 - 2,
                             Details = details
-                            
+
                         },
                         new Order
                         {
@@ -179,5 +180,14 @@ namespace Microsoft.Test.E2E.AspNet.OData.ModelBoundQuerySettings.PageAttributeT
                 }
             }
         }
+    }
+
+    public class DatesController : TestODataController
+    {
+        private static readonly DateTime _baseDate = new DateTime(2019, 11, 09, 0, 0, 0, DateTimeKind.Utc);
+        private readonly List<Date> _dates = Enumerable.Range(0, 5).Select(i => new Date() { DateValue = _baseDate.AddSeconds(i) }).ToList();
+
+        [EnableQuery]
+        public List<Date> Get() => _dates;
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ModelBoundQuerySettings/PageAttributeTest/SkipTokenEdmModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ModelBoundQuerySettings/PageAttributeTest/SkipTokenEdmModel.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNet.OData.Query;
 using Microsoft.OData.Edm;
 using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
@@ -45,7 +46,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.ModelBoundQuerySettings.PageAttributeT
 
         public string Name { get; set; }
 
-        public IList<OrderDetail> Details { get; set;}
+        public IList<OrderDetail> Details { get; set; }
 
         public int Price { get; set; }
         [Page]
@@ -65,12 +66,19 @@ namespace Microsoft.Test.E2E.AspNet.OData.ModelBoundQuerySettings.PageAttributeT
         public string SpecialName { get; set; }
     }
 
-    [Page(PageSize =2)]
+    [Page(PageSize = 2)]
     public class Address
     {
         public string Name { get; set; }
 
         public string Street { get; set; }
+    }
+
+    [Page(PageSize = 2)]
+    public class Date
+    {
+        [Key]
+        public DateTime DateValue { get; set; }
     }
 
     public class SkipTokenEdmModel
@@ -81,6 +89,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.ModelBoundQuerySettings.PageAttributeT
             builder.EntitySet<Customer>("Customers");
             builder.EntitySet<Order>("Orders");
             builder.EntitySet<OrderDetail>("Details");
+            builder.EntitySet<Date>("Dates");
             IEdmModel model = builder.GetEdmModel();
             return model;
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1953.*

### Description

DefaultSkipTokenHandler supports CLR types using DateTime

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
