### PR TITLE
Pass keyId parameter to controller actions of single-key entities

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/RoutingConventionHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/RoutingConventionHelpers.cs
@@ -191,8 +191,6 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
                         AddKeyValues(anotherKeyName, keyValuePair.Value, keyProperty.Type, controllerContext.RouteData, routingConventionsStore);
                     }
                 }
-
-                
             }
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/RoutingConventionHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/RoutingConventionHelpers.cs
@@ -172,21 +172,27 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
                 }
                 Contract.Assert(keyProperty != null);
 
-                // if there's only one key, just use the given key name, for example: "key, relatedKey"
-                // otherwise, to append the key name after the given key name.
+                // if there's only one key, provide two paramters, one using the given key name, e.g., "key, relatedKey"
+                // and the other appending the property name to the given key name: "keyId, relatedKeyId"
+                // in other cases, just append the property names to the given key name
                 // so for multiple keys, the parameter name is "keyId1, keyId2..."
                 // for navigation property, the parameter name is "relatedKeyId1, relatedKeyId2 ..."
-                string newKeyName;
                 if (alternateKey || keyCount > 1)
                 {
-                    newKeyName = keyName + keyValuePair.Key;
+                    var newKeyName = keyName + keyValuePair.Key;
+                    AddKeyValues(newKeyName, keyValuePair.Value, keyProperty.Type, controllerContext.RouteData, routingConventionsStore);
                 }
                 else
                 {
-                    newKeyName = keyName;
+                    AddKeyValues(keyName, keyValuePair.Value, keyProperty.Type, controllerContext.RouteData, routingConventionsStore);
+                    if (keyCount == 1)
+                    {
+                        var anotherKeyName = keyName + keyValuePair.Key;
+                        AddKeyValues(anotherKeyName, keyValuePair.Value, keyProperty.Type, controllerContext.RouteData, routingConventionsStore);
+                    }
                 }
 
-                AddKeyValues(newKeyName, keyValuePair.Value, keyProperty.Type, controllerContext.RouteData, routingConventionsStore);
+                
             }
         }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/DynamicPropertyRoutingConventionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/DynamicPropertyRoutingConventionTest.cs
@@ -151,8 +151,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             Assert.Equal("GetDynamicPropertyFromAccount", selectedAction);
 
             var routeData = SelectActionHelper.GetRouteData(request);
-            Assert.Equal(3, routeData.Values.Count);
+            Assert.Equal(4, routeData.Values.Count);
             Assert.Equal(7, routeData.Values["key"]);
+            Assert.Equal(7, routeData.Values["keyID"]);
             Assert.Equal("Amount", routeData.Values["dynamicProperty"]);
             Assert.Equal("Amount", (routeData.Values[ODataParameterValue.ParameterValuePrefix + "dynamicProperty"] as ODataParameterValue).Value);
         }
@@ -202,8 +203,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             Assert.Equal("GetDynamicProperty", selectedAction);
 
             var routeData = SelectActionHelper.GetRouteData(request);
-            Assert.Equal(3, routeData.Values.Count);
+            Assert.Equal(4, routeData.Values.Count);
             Assert.Equal(7, routeData.Values["key"]);
+            Assert.Equal(7, routeData.Values["keyID"]);
             Assert.Equal("DynamicPropertyA", routeData.Values["dynamicProperty"]);
             Assert.Equal("DynamicPropertyA", (routeData.Values[ODataParameterValue.ParameterValuePrefix + "dynamicProperty"] as ODataParameterValue).Value);
         }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/FunctionRoutingConventionTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/FunctionRoutingConventionTests.cs
@@ -128,8 +128,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
 
             // Assert
             Assert.Equal("IsUpgraded", selectedAction);
-            Assert.Single(SelectActionHelper.GetRouteData(request).Values);
+            Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
             Assert.Equal(1, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(1, SelectActionHelper.GetRouteData(request).Values["keyID"]);
         }
 
         [Fact]
@@ -183,8 +184,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
 
             // Assert
             Assert.Equal("IsUpgradedWithParam", selectedAction);
-            Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
+            Assert.Equal(3, SelectActionHelper.GetRouteData(request).Values.Count);
             Assert.Equal(1, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(1, SelectActionHelper.GetRouteData(request).Values["keyID"]);
             Assert.Equal("any", SelectActionHelper.GetRouteData(request).Values["city"]);
         }
 
@@ -239,8 +241,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
 
             // Assert
             Assert.Equal("GetOrders", selectedAction);
-            Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
+            Assert.Equal(3, SelectActionHelper.GetRouteData(request).Values.Count);
             Assert.Equal(1, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(1, SelectActionHelper.GetRouteData(request).Values["keyID"]);
             Assert.Equal(5, SelectActionHelper.GetRouteData(request).Values["parameter"]);
         }
     }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/NavigationRoutingConventionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/NavigationRoutingConventionTest.cs
@@ -52,8 +52,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             }
             else
             {
-                Assert.Single(SelectActionHelper.GetRouteData(request).Values);
+                Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
                 Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["key"]);
+                Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["keyID"]);
             }
         }
 
@@ -122,8 +123,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             }
             else
             {
-                Assert.Single(SelectActionHelper.GetRouteData(request).Values);
+                Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
                 Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["key"]);
+                Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["keyID"]);
             }
         }
 
@@ -229,6 +231,7 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             // Assert
             Assert.Equal(expectedSelectedAction, selectedAction);
             Assert.Equal(1, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(1, SelectActionHelper.GetRouteData(request).Values["keyID"]);
         }
 
         [Theory]
@@ -253,8 +256,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
 
             // Assert
             Assert.Equal(expectedSelectedAction, selectedAction);
-            Assert.Single(SelectActionHelper.GetRouteData(request).Values);
+            Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
             Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["keyID"]);
         }
 
         [Theory]
@@ -283,8 +287,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
 
             // Assert
             Assert.Equal(expectedSelectedAction, selectedAction);
-            Assert.Single(SelectActionHelper.GetRouteData(request).Values);
+            Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
             Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["keyID"]);
         }
 
         [Theory]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/PropertyRoutingConventionTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/PropertyRoutingConventionTests.cs
@@ -112,8 +112,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             // Assert
             Assert.NotNull(selectedAction);
             Assert.Equal(prefix + "NameFromCustomer", selectedAction);
-            Assert.Single(SelectActionHelper.GetRouteData(request).Values);
+            Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
             Assert.Equal(7, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(7, SelectActionHelper.GetRouteData(request).Values["keyID"]);
         }
 
         [Theory]
@@ -134,8 +135,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             // Assert
             Assert.NotNull(selectedAction);
             Assert.Equal(prefix + "AccountOfSpecialAccountFromCustomer", selectedAction);
-            Assert.Single(SelectActionHelper.GetRouteData(request).Values);
+            Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
             Assert.Equal(7, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(7, SelectActionHelper.GetRouteData(request).Values["keyID"]);
         }
 
         [Fact]
@@ -155,8 +157,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             // Assert
             Assert.NotNull(selectedAction);
             Assert.Equal("GetEnumCollectionPropFromDollarCountEntity", selectedAction);
-            Assert.Single(SelectActionHelper.GetRouteData(request).Values);
+            Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
             Assert.Equal(7, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(7, SelectActionHelper.GetRouteData(request).Values["keyID"]);
         }
 
         [Theory]
@@ -272,8 +275,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             // Assert
             Assert.NotNull(selectedAction);
             Assert.Equal(prefix + "OtherAccountsFromCustomer", selectedAction);
-            Assert.Single(SelectActionHelper.GetRouteData(request).Values);
+            Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
             Assert.Equal(7, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(7, SelectActionHelper.GetRouteData(request).Values["keyID"]);
         }
 
         [Theory]
@@ -294,8 +298,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             // Assert
             Assert.NotNull(selectedAction);
             Assert.Equal(prefix + "EnumCollectionProp", selectedAction);
-            Assert.Single(SelectActionHelper.GetRouteData(request).Values);
+            Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
             Assert.Equal(7, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(7, SelectActionHelper.GetRouteData(request).Values["keyID"]);
         }
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/RefRoutingConventionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/RefRoutingConventionTest.cs
@@ -57,8 +57,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             }
             else
             {
-                Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
+                Assert.Equal(3, SelectActionHelper.GetRouteData(request).Values.Count);
                 Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["key"]);
+                Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["keyID"]);
                 Assert.Equal(ordersProperty.Name, SelectActionHelper.GetRouteData(request).Values["navigationProperty"]);
             }
         }
@@ -107,8 +108,9 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             }
             else
             {
-                Assert.Equal(2, SelectActionHelper.GetRouteData(request).Values.Count);
+                Assert.Equal(3, SelectActionHelper.GetRouteData(request).Values.Count);
                 Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["key"]);
+                Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["keyID"]);
                 Assert.Equal(specialOrdersProperty.Name, SelectActionHelper.GetRouteData(request).Values["navigationProperty"]);
             }
         }
@@ -137,8 +139,10 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
 
             // Assert
             Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["keyID"]);
             Assert.Equal("SpecialOrders", SelectActionHelper.GetRouteData(request).Values["navigationProperty"]);
             Assert.Equal(24, SelectActionHelper.GetRouteData(request).Values["relatedKey"]);
+            Assert.Equal(24, SelectActionHelper.GetRouteData(request).Values["relatedKeyID"]);
         }
 
         [Theory]
@@ -158,8 +162,10 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             // Assert
             Assert.Equal("DeleteRef", selectedAction);
             Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["keyID"]);
             Assert.Equal("Orders", SelectActionHelper.GetRouteData(request).Values["navigationProperty"]);
             Assert.Equal(24, SelectActionHelper.GetRouteData(request).Values["relatedKey"]);
+            Assert.Equal(24, SelectActionHelper.GetRouteData(request).Values["relatedKeyID"]);
         }
 
         [Theory]
@@ -210,6 +216,7 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
 
             // Assert
             Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["key"]);
+            Assert.Equal(42, SelectActionHelper.GetRouteData(request).Values["keyID"]);
             Assert.Equal("SpecialOrders", SelectActionHelper.GetRouteData(request).Values["navigationProperty"]);
         }
     }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingModel.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingModel.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNet.OData.Test.Routing
             builder.Singleton<Product>("MyProduct");
             builder.EntitySet<DateTimeOffsetKeyCustomer>("DateTimeOffsetKeyCustomers");
             builder.EntitySet<Destination>("Destinations");
+            builder.EntitySet<Incident>("Incidents");
             builder.ComplexType<Dog>();
             builder.ComplexType<Cat>();
             builder.EntityType<SpecialProduct>();
@@ -367,6 +368,12 @@ namespace Microsoft.AspNet.OData.Test.Routing
         public class DestinationGroup : Destination
         {
             public int GroupLocation { get; set; }
+        }
+
+        public class Incident
+        {
+            public int ID { get; set; }
+            public string Name { get; set; }
         }
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingTest.cs
@@ -57,6 +57,7 @@ namespace Microsoft.AspNet.OData.Test.Routing
                 typeof(ProductsController),
                 typeof(EnumCustomersController),
                 typeof(DestinationsController),
+                typeof(IncidentsController),
             };
 
             // Separate clients and servers so routes are not ambiguous.
@@ -126,6 +127,12 @@ namespace Microsoft.AspNet.OData.Test.Routing
                     { "PATCH", "Products(10)", "Patch(10)" },
                     { "MERGE", "Products(10)", "Patch(10)" },
                     { "DELETE", "Products(10)", "Delete(10)" },
+                    // entity by key  defaults using keyID as param name
+                    { "GET", "Incidents(10)", "Get(10) with keyID" },
+                    { "PUT", "Incidents(10)", "Put(10) with keyID" },
+                    { "PATCH", "Incidents(10)", "Patch(10) with keyID" },
+                    { "MERGE", "Incidents(10)", "Patch(10) with keyID" },
+                    { "DELETE", "Incidents(10)", "Delete(10) with keyID" },
                     // entity by key
                     { "GET", "RoutingCustomers(10)", "GetRoutingCustomer(10)" },
                     { "PUT", "RoutingCustomers(10)", "PutRoutingCustomer(10)" },
@@ -143,6 +150,7 @@ namespace Microsoft.AspNet.OData.Test.Routing
                     { "GET", "RoutingCustomers(10)/Address", "GetAddress(10)" },
                     { "GET", "RoutingCustomers(10)/Microsoft.AspNet.OData.Test.Routing.VIP/Name", "GetName(10)" },
                     { "GET", "RoutingCustomers(10)/Microsoft.AspNet.OData.Test.Routing.VIP/Company", "GetCompanyFromVIP(10)" },
+                    { "GET", "Incidents(10)/Name", "GetName(10) with keyID" },
                     // refs
                     { "PUT", "RoutingCustomers(1)/Products/$ref", "CreateRef(1)(Products)" },
                     { "POST", "RoutingCustomers(1)/Products/$ref", "CreateRef(1)(Products)" },
@@ -854,6 +862,35 @@ namespace Microsoft.AspNet.OData.Test.Routing
                     Color = Color.Red | Color.Blue
                 }
             });
+        }
+    }
+
+    public class IncidentsController : TestODataController
+    {
+        public string Get(int keyID)
+        {
+            return String.Format(CultureInfo.InvariantCulture, "Get({0}) with keyID", keyID);
+        }
+
+        public string Put(int keyID)
+        {
+            return String.Format(CultureInfo.InvariantCulture, "Put({0}) with keyID", keyID);
+        }
+
+        [AcceptVerbs("PATCH", "MERGE")]
+        public string Patch(int keyID)
+        {
+            return String.Format(CultureInfo.InvariantCulture, "Patch({0}) with keyID", keyID);
+        }
+
+        public string Delete(int keyID)
+        {
+            return String.Format(CultureInfo.InvariantCulture, "Delete({0}) with keyID", keyID);
+        }
+
+        public string GetName(int keyID)
+        {
+            return String.Format(CultureInfo.InvariantCulture, "GetName({0}) with keyID", keyID);
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1965

### Description

Assuming an entity has a single key property called `ID`.

A convention controller action for that entity will not support having `keyID` as the parameter name, in addition to `key` for routes that contain a key segment . That is, either `key` or `keyID` will work and receive the bound value.

i.e. this will still work as it currently does:
```cs
// GET /odata/Customers(10)

public IActionResult<Customer> Get(int key)
{
    // key == 10
}
```

and this will now also work:
```cs
// GET /odata/Customers(10)

public IActionResult<Customer> Get(int keyID)
{
    // key == 10
}
```

**Note**: Both `key` and `keyID` are added to the route data regardless of the actual name of the parameter used on the controller action. So this fix relies on the fact that values that do not correspond to action parameters are ignored.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

Documentation will need an update mentioning that it's now possible to bind route key segments to `key{KeyPropertyName}` action parameters by default using convention-based routing.