### PR TITLE
Fix incorrect evaluation of IsNull expression

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/AggregationPropertyContainer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/AggregationPropertyContainer.cs
@@ -154,6 +154,11 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 memberBindings.Add(Expression.Bind(namedPropertyType.GetProperty("IsNull"), property.NullCheck));
             }
 
+            if (property.RawValue != null)
+            {
+                memberBindings.Add(Expression.Bind(namedPropertyType.GetProperty("RawValue"), property.RawValue));
+            }
+
             return Expression.MemberInit(Expression.New(namedPropertyType), memberBindings);
         }
     }

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/NamedPropertyExpression.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/NamedPropertyExpression.cs
@@ -34,6 +34,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         // and use Value only if IsNull is false.
         public Expression NullCheck { get; set; }
 
+        public Expression RawValue { get; set; }
+
         public int? PageSize { get; set; }
 
         public bool AutoSelected { get; set; }

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/PropertyContainer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/PropertyContainer.cs
@@ -137,6 +137,11 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 memberBindings.Add(Expression.Bind(namedPropertyType.GetProperty("IsNull"), property.NullCheck));
             }
 
+            if (property.RawValue != null)
+            {
+                memberBindings.Add(Expression.Bind(namedPropertyType.GetProperty("RawValue"), property.RawValue));
+            }
+
             return Expression.MemberInit(Expression.New(namedPropertyType), memberBindings);
         }
 
@@ -172,6 +177,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             public string Name { get; set; }
 
             public T Value { get; set; }
+
+            public object RawValue { get; set; }
 
             public bool AutoSelected { get; set; }
 
@@ -212,7 +219,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
             public override object GetValue()
             {
-                return IsNull ? (object)null : Value;
+                return (IsNull || RawValue == null) ? (object)null : Value;
             }
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -703,6 +703,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             // Sub select and expand could be null if the expanded navigation property is not further projected or expanded.
             SelectExpandClause subSelectExpandClause = GetOrCreateSelectExpandClause(navigationProperty, expandedItem);
 
+            Expression rawPropertyValue = propertyValue;
             Expression nullCheck = GetNullCheckExpression(navigationProperty, propertyValue, subSelectExpandClause);
 
             Expression countExpression = CreateTotalCountExpression(propertyValue, expandedItem.CountOption);
@@ -720,6 +721,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 if (!navigationProperty.Type.IsCollection())
                 {
                     propertyExpression.NullCheck = nullCheck;
+                    propertyExpression.RawValue = rawPropertyValue;
                 }
                 else if (_settings.PageSize.HasValue)
                 {
@@ -786,6 +788,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 return;
             }
 
+            Expression rawPropertyValue = propertyValue;
             Expression nullCheck = GetNullCheckExpression(structuralProperty, propertyValue, subSelectExpandClause);
 
             Expression countExpression = CreateTotalCountExpression(propertyValue, pathSelectItem.CountOption);
@@ -810,7 +813,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             {
                 if (!structuralProperty.Type.IsCollection())
                 {
-                     propertyExpression.NullCheck = nullCheck;
+                    propertyExpression.NullCheck = nullCheck;
+                    propertyExpression.RawValue = rawPropertyValue;
                 }
                 else if (_settings.PageSize.HasValue)
                 {

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" />
     <!-- PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="1.1.0" /> -->
+    <!-- <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="1.1.0" /> -->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" />
     <!-- PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="1.1.0" /> -->
     <!-- <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="1.1.0" /> -->
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/PropertyContainerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/PropertyContainerTest.cs
@@ -82,8 +82,9 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             int propertyValue = 42;
             Expression propertyNameExpression = Expression.Constant(propertyName);
             Expression propertyValueExpression = Expression.Constant(propertyValue);
+            Expression rawPropertyValueExpression = Expression.Constant(propertyValue);
             Expression nullCheckExpression = Expression.Constant(false);
-            var properties = new[] { new NamedPropertyExpression(propertyNameExpression, propertyValueExpression) { NullCheck = nullCheckExpression } };
+            var properties = new[] { new NamedPropertyExpression(propertyNameExpression, propertyValueExpression) { NullCheck = nullCheckExpression, RawValue = rawPropertyValueExpression } };
 
             // Act
             Expression containerExpression = PropertyContainer.CreatePropertyContainer(properties);
@@ -96,13 +97,36 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Fact]
+        public void CreatePropertyContainer_WithNullCheckFalseAndNullProperty_PropertyIsNull()
+        {
+            // Arrange
+            string propertyName = "PropertyName";
+            object propertyValue = 42;
+            object rawPropertyValue = null;
+            Expression propertyNameExpression = Expression.Constant(propertyName);
+            Expression propertyValueExpression = Expression.Constant(propertyValue);
+            Expression rawPropertyValueExpression = Expression.Constant(rawPropertyValue);
+            Expression nullCheckExpression = Expression.Constant(false);
+            var properties = new[] { new NamedPropertyExpression(propertyNameExpression, propertyValueExpression) { NullCheck = nullCheckExpression, RawValue = rawPropertyValueExpression } };
+
+            // Act
+            Expression containerExpression = PropertyContainer.CreatePropertyContainer(properties);
+
+            // Assert
+            PropertyContainer container = ToContainer(containerExpression);
+            var dict = container.ToDictionary(new IdentityPropertyMapper());
+            Assert.Contains(propertyName, dict.Keys);
+            Assert.Null(dict[propertyName]);
+        }
+
+        [Fact]
         public void CreatePropertyContainer_MultiplePropertiesWithNullCheck()
         {
             // Arrange
             var properties = new[] 
             { 
                 new NamedPropertyExpression(name: Expression.Constant("Prop1"), value: Expression.Constant(1)) { NullCheck = Expression.Constant(true) },
-                new NamedPropertyExpression(name: Expression.Constant("Prop2"), value: Expression.Constant(2)) { NullCheck = Expression.Constant(false) },
+                new NamedPropertyExpression(name: Expression.Constant("Prop2"), value: Expression.Constant(2)) { NullCheck = Expression.Constant(false), RawValue = Expression.Constant(2) },
             };
 
             // Act

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Fact]
-        public void Bind_GeneratedExpression_CheckNullObjectWithinChainProjectionByKey()
+        public void Bind_GeneratedExpression_CheckNullObjectAndRawValueWithinChainProjectionByKey()
         {
             // Arrange
             SelectExpandQueryOption selectExpand = new SelectExpandQueryOption(null, "Orders($expand=Customer($select=City))", _context);
@@ -133,9 +133,9 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             var unaryExpression = (UnaryExpression)((MethodCallExpression)queryable.Expression).Arguments.Single(a => a is UnaryExpression);
             var expressionString = unaryExpression.Operand.ToString();
 #if NETCORE
-            Assert.Contains("IsNull = (Convert(Param_1.Customer.Id, Nullable`1) == null)}", expressionString);
+            Assert.Contains("IsNull = (Convert(Param_1.Customer.Id, Nullable`1) == null), RawValue = Param_1.Customer}", expressionString);
 #else
-            Assert.Contains("IsNull = (Convert(Param_1.Customer.Id) == null)}", expressionString);
+            Assert.Contains("IsNull = (Convert(Param_1.Customer.Id) == null), RawValue = Param_1.Customer}", expressionString);
 #endif
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1979

### Description

The problem: when multiple keys with shadow property is used, NullCheck expression is incorrectly evaluated. This causes null value to be incorrectly recognized as actual object and referencing parameters of this object fails.

The solution: we have introduced new property RawValue which holds actual object referenced by navigation property we use it to double check if the property is null.

### Checklist (Uncheck if it is not completed)

- [x] Test cases added
- [x] Build and test with one-click build and test script passed

### Additional work necessary
None