### PR TITLE
Fix the byte[] and char[] property in select

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -779,6 +779,12 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             // $compute=...
 
             propertyValue = CreatePropertyValueExpression(structuredType, structuralProperty, source, pathSelectItem.FilterOption);
+            Type propertyValueType = propertyValue.Type;
+            if (propertyValueType == typeof(char[]) || propertyValueType == typeof(byte[]))
+            {
+                includedProperties.Add(new NamedPropertyExpression(propertyName, propertyValue));
+                return;
+            }
 
             Expression nullCheck = GetNullCheckExpression(structuralProperty, propertyValue, subSelectExpandClause);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1985.*

### Description

*For property defined by byte[] and char[] is mapping to "Edm.Binary" and "Edm.String".
So, for these properties, we don't need to further process the nested query options.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
