### PR TITLE
Fix error message to state that value must be 1 or greater

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/ModelBoundQuerySettings.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ModelBoundQuerySettings.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNet.OData.Query
             {
                 if (value.HasValue && value <= 0)
                 {
-                    throw Error.ArgumentMustBeGreaterThanOrEqualTo("value", value, 0);
+                    throw Error.ArgumentMustBeGreaterThanOrEqualTo("value", value, 1);
                 }
 
                 _maxTop = value;


### PR DESCRIPTION
instead of zero or greater.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1989.*

### Description

This changes the error message to recognize that passing 0 as a value is not valid. Note that the same change was already made for PageSize.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

None. (Perhaps make a test, but none was made for PageSize). I ran all the tests and nothing broke.
