### PR TITLE
Fix the int16 overflow during build

### DIFF
--- a/tools/WebStack.versions.settings.targets
+++ b/tools/WebStack.versions.settings.targets
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- Set the version number: major, minor, build and release (i.e. alpha, beta or blank for RTM)-->
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">5</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">7</VersionMinor>
-    <VersionBuild Condition="'$(VersionBuild)' == ''">1</VersionBuild>
+    <VersionBuild Condition="'$(VersionBuild)' == ''">2</VersionBuild>
     <VersionRelease Condition="'$(VersionRelease)' == ''">beta</VersionRelease>
   </PropertyGroup>
 
@@ -17,11 +17,11 @@
   </PropertyGroup>
 
   <!--
-    Revision number is a date code. Note that this only work for 6 years before the year part (year minus 2017)
+    Revision number is a date code. Note that this only work for 6 years before the year part (year minus 2020)
     overflows the Int16. The system convert below will throw errors when this happens.
   -->
   <PropertyGroup>
-    <VersionStartYear Condition="'$(VersionStartYear)' == ''">2017</VersionStartYear>
+    <VersionStartYear Condition="'$(VersionStartYear)' == ''">2020</VersionStartYear>
     <VersionDateCode>$([System.Convert]::ToInt16('$([MSBuild]::Add(1, $([MSBuild]::Subtract($([System.DateTime]::Now.Year), $(VersionStartYear)))))$([System.DateTime]::Now.ToString("MMdd"))'))</VersionDateCode>
     <VersionRevision Condition="'$(VersionRevision)' == '' OR '$(VersionRevision)' == '0'">$([System.Convert]::ToString($(VersionDateCode)))</VersionRevision>
   </PropertyGroup>
@@ -48,7 +48,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionStartYear Condition="'$(VersionStartYear)' == ''">2017</VersionStartYear>
+    <VersionStartYear Condition="'$(VersionStartYear)' == ''">2020</VersionStartYear>
     <VersionMajor Condition="'$(VersionMajor)' == '0'">INVALID_VersionMajor</VersionMajor>
     <VersionMajor Condition="'$(VersionMajor)' == ''">INVALID_VersionMajor</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">INVALID_VersionMinor</VersionMinor>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

This change fixes the overflow during generation of VersionDateCode

`F:\repos\OData-WebApi\src\System.Web.Http.OData\System.Web.Http.OData.csproj : error  : The expression "[System.Convert]::ToInt16(40102)" cannot be evaluated. Value was either too large or too small for an Int16.  F:\repos\OData-WebApi\tools\WebStack.versions.settings.targets`

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*

