### PR TITLE
Fix Performance drop when using a big model.

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/ETagMessageHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ETagMessageHandler.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNet.OData
                 return edmTypeReference.AsEntity();
             }
 
-            IEdmTypeReference reference = EdmLibHelpers.GetEdmTypeReference(model, value.GetType());
+            IEdmTypeReference reference = model.GetTypeMappingCache().GetEdmType(value.GetType(), model);
             if (reference != null && reference.Definition.IsOrInheritsFrom(edmType))
             {
                 return (IEdmEntityTypeReference)reference;

--- a/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
@@ -751,8 +751,8 @@ namespace Microsoft.AspNet.OData
                 throw Error.InvalidOperation(SRResources.QueryGetModelMustNotReturnNull);
             }
 
-            IEdmEntityType baseEntityType = model.GetTypeMappingCache().GetEdmType(elementClrType, model).Definition as IEdmEntityType;
-            IEdmStructuredType structuredType = model.GetTypeMappingCache().GetEdmType(elementClrType, model).Definition as IEdmStructuredType;
+            IEdmEntityType baseEntityType     = model.GetTypeMappingCache().GetEdmType(elementClrType, model)?.Definition as IEdmEntityType;
+            IEdmStructuredType structuredType = model.GetTypeMappingCache().GetEdmType(elementClrType, model)?.Definition as IEdmStructuredType;
             IEdmProperty property = null;
             if (path != null)
             {

--- a/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
@@ -751,8 +751,9 @@ namespace Microsoft.AspNet.OData
                 throw Error.InvalidOperation(SRResources.QueryGetModelMustNotReturnNull);
             }
 
-            IEdmEntityType baseEntityType     = model.GetTypeMappingCache().GetEdmType(elementClrType, model)?.Definition as IEdmEntityType;
-            IEdmStructuredType structuredType = model.GetTypeMappingCache().GetEdmType(elementClrType, model)?.Definition as IEdmStructuredType;
+            IEdmType edmType = model.GetTypeMappingCache().GetEdmType(elementClrType, model)?.Definition;
+            IEdmEntityType baseEntityType = edmType as IEdmEntityType;
+            IEdmStructuredType structuredType = edmType as IEdmStructuredType;
             IEdmProperty property = null;
             if (path != null)
             {

--- a/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
@@ -751,8 +751,8 @@ namespace Microsoft.AspNet.OData
                 throw Error.InvalidOperation(SRResources.QueryGetModelMustNotReturnNull);
             }
 
-            IEdmEntityType baseEntityType = model.GetEdmType(elementClrType) as IEdmEntityType;
-            IEdmStructuredType structuredType = model.GetEdmType(elementClrType) as IEdmStructuredType;
+            IEdmEntityType baseEntityType = model.GetTypeMappingCache().GetEdmType(elementClrType, model).Definition as IEdmEntityType;
+            IEdmStructuredType structuredType = model.GetTypeMappingCache().GetEdmType(elementClrType, model).Definition as IEdmStructuredType;
             IEdmProperty property = null;
             if (path != null)
             {

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
@@ -895,7 +895,7 @@ namespace Microsoft.AspNet.OData.Formatter
             else
             {
                 TryGetInnerTypeForDelta(ref type);
-                expectedPayloadType = model.GetEdmTypeReference(type);
+                expectedPayloadType = model.GetTypeMappingCache().GetEdmType(type, model);
             }
 
             return expectedPayloadType;

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 #if NETFX // System.Data.Linq.Binary is only supported in the AspNet version.
 using System.Data.Linq;

--- a/src/Microsoft.AspNet.OData.Shared/ODataQueryContext.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ODataQueryContext.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.OData
                 throw Error.ArgumentNull("elementClrType");
             }
 
-            ElementType = model.GetEdmType(elementClrType);
+            ElementType = model.GetTypeMappingCache().GetEdmType(elementClrType, model).Definition;
 
             if (ElementType == null)
             {

--- a/src/Microsoft.AspNet.OData.Shared/ODataQueryContext.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ODataQueryContext.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.OData
                 throw Error.ArgumentNull("elementClrType");
             }
 
-            ElementType = model.GetTypeMappingCache().GetEdmType(elementClrType, model).Definition;
+            ElementType = model.GetTypeMappingCache().GetEdmType(elementClrType, model)?.Definition;
 
             if (ElementType == null)
             {

--- a/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
@@ -418,7 +418,7 @@ namespace Microsoft.AspNet.OData.Query
             }
 
             Type clrType = value.GetType();
-            return EdmLibHelpers.GetEdmType(model, clrType);
+            return model.GetTypeMappingCache().GetEdmType(clrType, model).Definition;
         }
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
@@ -418,7 +418,7 @@ namespace Microsoft.AspNet.OData.Query
             }
 
             Type clrType = value.GetType();
-            return model.GetTypeMappingCache().GetEdmType(clrType, model).Definition;
+            return model.GetTypeMappingCache().GetEdmType(clrType, model)?.Definition;
         }
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
         /// <inheritdoc />
         public IEdmTypeReference GetEdmType()
-        {
+        { 
             IEdmModel model = GetModel();
 
             if (InstanceType != null)
@@ -62,7 +62,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             }
 
             Type elementType = GetElementType();
-            return model.GetEdmTypeReference(elementType);
+            return model.GetTypeMappingCache().GetEdmType(elementType, model);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
         /// <inheritdoc />
         public IEdmTypeReference GetEdmType()
-        { 
+        {
             IEdmModel model = GetModel();
 
             if (InstanceType != null)

--- a/src/Microsoft.AspNet.OData.Shared/Results/ResultHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Results/ResultHelpers.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNet.OData.Results
         private static IEdmEntityTypeReference GetEntityType(IEdmModel model, object entity)
         {
             Type entityType = entity.GetType();
-            IEdmTypeReference edmType = model.GetEdmTypeReference(entityType);
+            IEdmTypeReference edmType = model.GetTypeMappingCache().GetEdmType(entityType, model);
             if (edmType == null)
             {
                 throw Error.InvalidOperation(SRResources.ResourceTypeNotInModel, entityType.FullName);

--- a/src/Microsoft.AspNet.OData/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNet.OData/EnableQueryAttribute.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNet.OData
         /// <param name="actionExecutedContext">The context related to this action, including the response message,
         /// request message and HttpConfiguration etc.</param>
         [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling",
-                Justification = "The majority of types referenced by this method result from HttpActionExecutedContext")]
+            Justification = "The majority of types referenced by this method result from HttpActionExecutedContext")]
         public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
         {
             if (actionExecutedContext == null)

--- a/src/Microsoft.AspNet.OData/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNet.OData/EnableQueryAttribute.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNet.OData
     /// <see cref="EnableQueryAttribute"/> to validate incoming queries. For more information, visit
     /// http://go.microsoft.com/fwlink/?LinkId=279712.
     /// </summary>
+    [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "The majority of types referenced by this method result from HttpActionExecutedContext")]
     [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes",
         Justification = "We want to be able to subclass this type.")]
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
@@ -41,7 +42,7 @@ namespace Microsoft.AspNet.OData
         /// <param name="actionExecutedContext">The context related to this action, including the response message,
         /// request message and HttpConfiguration etc.</param>
         [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling",
-            Justification = "The majority of types referenced by this method result from HttpActionExecutedContext")]
+                Justification = "The majority of types referenced by this method result from HttpActionExecutedContext")]
         public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
         {
             if (actionExecutedContext == null)

--- a/src/Microsoft.AspNet.OData/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNet.OData/EnableQueryAttribute.cs
@@ -183,7 +183,7 @@ namespace Microsoft.AspNet.OData
             // Get model for the request
             IEdmModel model = request.GetModel();
 
-            if (model == EdmCoreModel.Instance || model.GetEdmType(elementClrType) == null)
+            if (model == EdmCoreModel.Instance || model.GetTypeMappingCache().GetEdmType(elementClrType, model) == null)
             {
                 // user has not configured anything or has registered a model without the element type
                 // let's create one just for this type and cache it in the action descriptor


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue  #2001

### Description

When requesting an entity collection with a simple $expand of a many to one relation, performance is killed when the model has many entities and actions defined

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

The ticket has a exported project to reproduce the issue.

### Additional work necessary

The pull request has a static cache, with has as a key the model. The cache will be holding a reference to the model, wich might be a memory problem if there is an escenario where models are create and discarded often. An option could be to use a hash of the model or any other unique identity that the model could have. 
 
