### PR TITLE
1610 - Fix OData AddLink (CreateRef) error when performing batch operations

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Adapters/WebApiRequestMessage.cs
+++ b/src/Microsoft.AspNetCore.OData/Adapters/WebApiRequestMessage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http.Headers;
+using Microsoft.AspNet.OData.Batch;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Formatter;
@@ -183,7 +184,7 @@ namespace Microsoft.AspNet.OData.Adapters
         /// <returns></returns>
         public IDictionary<string, string> ODataContentIdMapping
         {
-            get { return null; }
+            get { return this.innerRequest.GetODataContentIdMapping(); }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs
@@ -300,21 +300,6 @@ namespace Microsoft.AspNet.OData.Extensions
         }
 
         /// <summary>
-        /// Retrieves the Content-ID to Location mapping associated with the request.
-        /// </summary>
-        /// <param name="request">The request.</param>
-        /// <returns>The Content-ID to Location mapping associated with this request, or <c>null</c> if there isn't one.</returns>
-        public static IDictionary<string, string> GetODataContentIdMapping(this HttpRequest request)
-        {
-            if (request == null)
-            {
-                throw Error.ArgumentNull("request");
-            }
-
-            return null;
-        }
-
-        /// <summary>
         /// Gets the set of flags for <see cref="CompatibilityOptions"/> from ODataOptions. 
         /// </summary>
         /// <param name="request">The request.</param>

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
@@ -8,6 +8,7 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.OData.Adapters;
+using Microsoft.AspNet.OData.Batch;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Formatter.Deserialization;

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
@@ -39,7 +39,13 @@ namespace Microsoft.AspNet.OData.Test.Batch
                 builder.EntitySet<BatchTestCustomer>("BatchTestCustomers");
                 builder.EntitySet<BatchTestOrder>("BatchTestOrders");
 
-                config.MapODataServiceRoute("odata", null, builder.GetEdmModel(), new DefaultODataBatchHandler());
+#if !NETCORE
+                var batchHandler = new DefaultODataBatchHandler(new HttpServer());
+#else
+                var batchHandler = new DefaultODataBatchHandler();
+#endif
+
+                config.MapODataServiceRoute("odata", null, builder.GetEdmModel(), batchHandler);
                 config.Count().Filter().OrderBy().Expand().MaxTop(null).Select();
 
                 config.EnableDependencyInjection();

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
@@ -471,7 +471,7 @@ namespace Microsoft.AspNet.OData.Test.Batch
             createOrderMessageContent.Headers.TryAddWithoutValidation("Content-Transfer-Encoding", "binary");
             createOrderMessageContent.Headers.TryAddWithoutValidation("Content-ID", "3");
 
-            // Create reference request
+            // Create ref request
             var createRefPayload = "{\"@odata.id\":\"$3\"}";
             HttpRequestMessage createRefRequest = new HttpRequestMessage(HttpMethod.Post, $"{endpoint}/BatchTestCustomers(2)/Orders/$ref");
             createRefRequest.Content = new StringContent(createRefPayload, System.Text.Encoding.UTF8, AcceptJson);

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ServerFactory.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ServerFactory.cs
@@ -64,6 +64,7 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
                 });
 #endif
 
+                app.UseODataBatching();
                 app.UseMvc((routeBuilder) =>
                 {
                     configureAction(routeBuilder);

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/TestODataController.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/TestODataController.cs
@@ -1,11 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.OData.UriParser;
 
 namespace Microsoft.AspNet.OData.Test.Abstraction
 {
@@ -43,6 +48,32 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
         public new TestUpdatedObjectResult<TEntity> Updated<TEntity>(TEntity value)
         {
             return new TestUpdatedObjectResult<TEntity>(new UpdatedODataResult<TEntity>(value));
+        }
+
+        [NonAction]
+        public new TestNoContentResult NoContent() { return new TestNoContentResult(base.NoContent()); }
+
+        // Helper method for extracting key for the entity from a Uri
+        public TKey GetKeyFromLinkUri<TKey>(HttpRequest request, Uri link)
+        {
+            if (link == null)
+                throw new ArgumentNullException("link");
+
+            var serviceRoot = request.GetUrlHelper().CreateODataLink(
+                                    request.ODataFeature().RouteName,
+                                    request.GetPathHandler(),
+                                    new List<ODataPathSegment>());
+
+            // NOTE: Fails when a routePrefix is added to OData route's path template
+            var odataPath = request.GetPathHandler().Parse(serviceRoot, link.LocalPath, request.GetRequestContainer());
+
+            var keySegment = odataPath.Segments.OfType<KeySegment>().FirstOrDefault();
+
+            if (keySegment == null || !keySegment.Keys.Any())
+                throw new InvalidOperationException("This link does not contain a key.");
+
+            // Return the key value of the first segment
+            return (TKey)keySegment.Keys.First().Value;
         }
     }
 
@@ -171,6 +202,17 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
     public class TestObjectResult : ObjectResult, ITestActionResult
     {
         public TestObjectResult(object innerResult)
+            : base(innerResult)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Wrapper for NoContentResult
+    /// </summary>
+    public class TestNoContentResult : TestActionResult
+    {
+        public TestNoContentResult(NoContentResult innerResult)
             : base(innerResult)
         {
         }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
@@ -60,4 +60,8 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+  </ItemGroup>
+
 </Project>

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -1873,11 +1873,6 @@ public sealed class Microsoft.AspNet.OData.Extensions.HttpRequestExtensions {
 	[
 	ExtensionAttribute(),
 	]
-	public static System.Collections.Generic.IDictionary`2[[System.String],[System.String]] GetODataContentIdMapping (Microsoft.AspNetCore.Http.HttpRequest request)
-
-	[
-	ExtensionAttribute(),
-	]
 	public static IODataPathHandler GetPathHandler (Microsoft.AspNetCore.Http.HttpRequest request)
 
 	[

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -1873,11 +1873,6 @@ public sealed class Microsoft.AspNet.OData.Extensions.HttpRequestExtensions {
 	[
 	ExtensionAttribute(),
 	]
-	public static System.Collections.Generic.IDictionary`2[[System.String],[System.String]] GetODataContentIdMapping (Microsoft.AspNetCore.Http.HttpRequest request)
-
-	[
-	ExtensionAttribute(),
-	]
 	public static IODataPathHandler GetPathHandler (Microsoft.AspNetCore.Http.HttpRequest request)
 
 	[


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue [#1610](https://github.com/OData/odata.net/issues/1610).*

### Description

An error is observed when an entity is created by an insert request and then referenced in a subsequent add link (create ref) request _in the same batch_. This behaviour is observed on an OData service created using **Microsoft.AspNetCore.OData 7.3.0** or lower. The behaviour is not observed against an equivalent service created using **Microsoft.AspNet.OData**.

The bug seems to have been introduced by the addition of an extension method `GetODataContentIdMapping()` in the [**Microsoft.AspNetCore.OData.Extensions**](https://github.com/OData/WebApi/blob/d669038523e8dbb8e1709b1044ac0d51aed40a6a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs#L307) namespace that returns `null` instead of the expected dictionary comprising of Content-ID to Location mapping. An extension method with a similar signature is defined in the [**Microsoft.AspNetCore.OData.Batch**](https://github.com/OData/WebApi/blob/d669038523e8dbb8e1709b1044ac0d51aed40a6a/src/Microsoft.AspNetCore.OData/Extensions/HttpRequestExtensions.cs#L307) namespace where it returns the expected value.

The inability to fetch the Content-ID to Location mapping results into the create ref action method in the controller being sent the $-prefixed request identifier as the Uri instead of the resource location.

By examining the logic in **Microsoft.AspNet.OData** codebase, and based on the fact that the Content-ID to Location mapping is (currently) applicable to batch requests, the `GetODataContentIdMapping()` in **Microsoft.AspNetCore.OData.Extensions** namespace is dropped to allow **Microsoft.AspNetCore.OData.Batch** namespace provide the implementation of `GetODataContentIdMapping()` required for use within the [**ODataInputFormatter**](https://github.com/OData/WebApi/blob/d669038523e8dbb8e1709b1044ac0d51aed40a6a/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs#L159) class.

This change fixes the error.

A related fix was made to a property `ODataContentIdMapping` in the [**WebApiRequestMessage**](https://github.com/OData/WebApi/blob/d669038523e8dbb8e1709b1044ac0d51aed40a6a/src/Microsoft.AspNetCore.OData/Adapters/WebApiRequestMessage.cs#L186) adapter class that also return `null` instead of the Content-ID to Location mapping.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
