### PR TITLE
Batch Fixes

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchContent.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchContent.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.OData.Batch
 
             foreach (ODataBatchResponseItem response in Responses)
             {
-                await response.WriteResponseAsync(writer);
+                await response.WriteResponseAsync(writer, /*asyncWriter*/ true);
             }
 
             await writer.WriteEndBatchAsync();

--- a/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchContent.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchContent.cs
@@ -48,16 +48,16 @@ namespace Microsoft.AspNet.OData.Batch
         private async Task WriteToResponseMessageAsync(IODataResponseMessage responseMessage)
         {
             ODataMessageWriter messageWriter = new ODataMessageWriter(responseMessage, _writerSettings);
-            ODataBatchWriter writer = messageWriter.CreateODataBatchWriter();
+            ODataBatchWriter writer = await messageWriter.CreateODataBatchWriterAsync();
 
-            writer.WriteStartBatch();
+            await writer.WriteStartBatchAsync();
 
             foreach (ODataBatchResponseItem response in Responses)
             {
                 await response.WriteResponseAsync(writer);
             }
 
-            writer.WriteEndBatch();
+            await writer.WriteEndBatchAsync();
         }
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataMessageWrapper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataMessageWrapper.cs
@@ -103,6 +103,15 @@ namespace Microsoft.AspNet.OData.Formatter
                 return value;
             }
 
+            // try case-insensitive
+            foreach (string key in _headers.Keys)
+            {
+                if (key.Equals(headerName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return _headers[key];
+                }
+            }
+
             return null;
         }
 

--- a/src/Microsoft.AspNet.OData/Batch/ChangeSetResponseItem.cs
+++ b/src/Microsoft.AspNet.OData/Batch/ChangeSetResponseItem.cs
@@ -36,6 +36,27 @@ namespace Microsoft.AspNet.OData.Batch
         public IEnumerable<HttpResponseMessage> Responses { get; private set; }
 
         /// <summary>
+        /// Writes the responses as a ChangeSet Synchronously.
+        /// </summary>
+        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
+        public override void WriteResponse(ODataBatchWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull("writer");
+            }
+
+            writer.WriteStartChangeset();
+
+            foreach (HttpResponseMessage responseMessage in Responses)
+            {
+                WriteMessage(writer, responseMessage);
+            }
+
+            writer.WriteEndChangeset();
+        }
+
+        /// <summary>
         /// Writes the responses as a ChangeSet.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
@@ -47,14 +68,14 @@ namespace Microsoft.AspNet.OData.Batch
                 throw Error.ArgumentNull("writer");
             }
 
-            writer.WriteStartChangeset();
+            await writer.WriteStartChangesetAsync();
 
             foreach (HttpResponseMessage responseMessage in Responses)
             {
                 await WriteMessageAsync(writer, responseMessage, cancellationToken);
             }
 
-            writer.WriteEndChangeset();
+            await writer.WriteEndChangesetAsync();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData/Batch/LazyStreamContent.cs
+++ b/src/Microsoft.AspNet.OData/Batch/LazyStreamContent.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.OData.Batch
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
-            return StreamContent.CopyToAsync(stream, context);
+            return StreamContent.CopyToAsync(stream, context).ContinueWith((Task)=>StreamContent.Dispose());
         }
 
         protected override bool TryComputeLength(out long length)

--- a/src/Microsoft.AspNet.OData/Batch/ODataBatchResponseItem.cs
+++ b/src/Microsoft.AspNet.OData/Batch/ODataBatchResponseItem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.IO;
 using System.Net.Http;
 using System.Threading;
@@ -18,67 +19,38 @@ namespace Microsoft.AspNet.OData.Batch
     public abstract class ODataBatchResponseItem : IDisposable
     {
         /// <summary>
-        /// Writes a single OData batch response.
+        /// Writes a single OData batch response to a synchronous writer.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
         /// <param name="response">The response message.</param>
         /// <returns>A task object representing writing the given batch response using the given writer.</returns>
         public static Task WriteMessageAsync(ODataBatchWriter writer, HttpResponseMessage response)
         {
-            return WriteMessageAsync(writer, response, CancellationToken.None);
+            return WriteMessageAsync(writer, response, CancellationToken.None, false);
         }
 
         /// <summary>
-        /// Writes a single OData batch response Synchronously.
+        /// Writes a single OData batch response to a synchronous writer.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
         /// <param name="response">The response message.</param>
-        public static void WriteMessage(ODataBatchWriter writer, HttpResponseMessage response)
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task object representing writing the given batch response using the given writer.</returns>
+        public static async Task WriteMessageAsync(ODataBatchWriter writer, HttpResponseMessage response, CancellationToken cancellationToken)
         {
-            if (writer == null)
-            {
-                throw Error.ArgumentNull("writer");
-            }
-            if (response == null)
-            {
-                throw Error.ArgumentNull("response");
-            }
-
-            HttpRequestMessage request = response.RequestMessage;
-            string contentId = (request != null) ? request.GetODataContentId() : String.Empty;
-
-            ODataBatchOperationResponseMessage batchResponse = writer.CreateOperationResponseMessage(contentId);
-
-            batchResponse.StatusCode = (int)response.StatusCode;
-
-            foreach (KeyValuePair<string, IEnumerable<string>> header in response.Headers)
-            {
-                batchResponse.SetHeader(header.Key, String.Join(",", header.Value));
-            }
-
-            if (response.Content != null)
-            {
-                foreach (KeyValuePair<string, IEnumerable<string>> header in response.Content.Headers)
-                {
-                    batchResponse.SetHeader(header.Key, String.Join(",", header.Value));
-                }
-
-                using (Stream stream = batchResponse.GetStream())
-                {
-                    response.Content.CopyToAsync(stream).Wait();
-                }
-            }
+            await WriteMessageAsync(writer, response, cancellationToken, false);
         }
-
+        
         /// <summary>
         /// Writes a single OData batch response.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
         /// <param name="response">The response message.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="asyncWriter">Whether or not the writer is writing asynchronously.</param>
         /// <returns>A task object representing writing the given batch response using the given writer.</returns>
         public static async Task WriteMessageAsync(ODataBatchWriter writer, HttpResponseMessage response,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken, bool asyncWriter)
         {
             if (writer == null)
             {
@@ -92,7 +64,9 @@ namespace Microsoft.AspNet.OData.Batch
             HttpRequestMessage request = response.RequestMessage;
             string contentId = (request != null) ? request.GetODataContentId() : String.Empty;
 
-            ODataBatchOperationResponseMessage batchResponse = await writer.CreateOperationResponseMessageAsync(contentId);
+            ODataBatchOperationResponseMessage batchResponse = asyncWriter ?
+                await writer.CreateOperationResponseMessageAsync(contentId) :
+                writer.CreateOperationResponseMessage(contentId);
 
             batchResponse.StatusCode = (int)response.StatusCode;
 
@@ -124,31 +98,38 @@ namespace Microsoft.AspNet.OData.Batch
         }
 
         /// <summary>
-        /// Writes the response Synchronously.
+        /// Writes the response using a synchronous writer.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
-        public abstract void WriteResponse(ODataBatchWriter writer);
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public Task WriteResponseAsync(ODataBatchWriter writer, CancellationToken cancellationToken)
+        {
+            return WriteResponseAsync(writer, cancellationToken, false);
+        }
 
         /// <summary>
         /// Writes the response.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        public abstract Task WriteResponseAsync(ODataBatchWriter writer, CancellationToken cancellationToken);
+        /// <param name="asyncWriter">Whether or not the writer is writing asynchronously.</param>
+        public abstract Task WriteResponseAsync(ODataBatchWriter writer, CancellationToken cancellationToken, bool asyncWriter);
 
         /// <summary>
         /// Writes the response.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
+        /// <param name="asyncWriter">Whether or not the writer is writing asynchronously.</param>
         /// <remarks>
         /// This method exists to provide a consistent API to <see cref="ODataBatchContent"/>.
         /// The AspNetCore call does not need the CancellationToken passed in and instead of
         /// adding an internal call on that side, I opted to add the internal call here since
         /// the AspNetCore call would ignore the parameter and this one just assumes one.
         /// </remarks>
-        internal Task WriteResponseAsync(ODataBatchWriter writer)
+        internal Task WriteResponseAsync(ODataBatchWriter writer, bool asyncWriter)
         {
-            return WriteResponseAsync(writer, CancellationToken.None);
+            Contract.Assert(asyncWriter, "Calling WriteResponseAsync with a synchronous writer");
+            return WriteResponseAsync(writer, CancellationToken.None, asyncWriter);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData/Batch/OperationResponseItem.cs
+++ b/src/Microsoft.AspNet.OData/Batch/OperationResponseItem.cs
@@ -34,6 +34,20 @@ namespace Microsoft.AspNet.OData.Batch
         public HttpResponseMessage Response { get; private set; }
 
         /// <summary>
+        /// Writes the response as an Operation Synchronously.
+        /// </summary>
+        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
+        public override void WriteResponse(ODataBatchWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull("writer");
+            }
+
+            WriteMessage(writer, Response);
+        }
+
+        /// <summary>
         /// Writes the response as an Operation.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>

--- a/src/Microsoft.AspNet.OData/Batch/OperationResponseItem.cs
+++ b/src/Microsoft.AspNet.OData/Batch/OperationResponseItem.cs
@@ -34,32 +34,19 @@ namespace Microsoft.AspNet.OData.Batch
         public HttpResponseMessage Response { get; private set; }
 
         /// <summary>
-        /// Writes the response as an Operation Synchronously.
-        /// </summary>
-        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
-        public override void WriteResponse(ODataBatchWriter writer)
-        {
-            if (writer == null)
-            {
-                throw Error.ArgumentNull("writer");
-            }
-
-            WriteMessage(writer, Response);
-        }
-
-        /// <summary>
         /// Writes the response as an Operation.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        public override Task WriteResponseAsync(ODataBatchWriter writer, CancellationToken cancellationToken)
+        /// <param name="asyncWriter">Whether or not the writer is writing asynchronously.</param>
+        public override Task WriteResponseAsync(ODataBatchWriter writer, CancellationToken cancellationToken, bool asyncWriter)
         {
             if (writer == null)
             {
                 throw Error.ArgumentNull("writer");
             }
 
-            return WriteMessageAsync(writer, Response, cancellationToken);
+            return WriteMessageAsync(writer, Response, cancellationToken, asyncWriter);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Batch/ChangeSetResponseItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ChangeSetResponseItem.cs
@@ -36,45 +36,39 @@ namespace Microsoft.AspNet.OData.Batch
         public IEnumerable<HttpContext> Contexts { get; private set; }
 
         /// <summary>
-        /// Writes the responses as a ChangeSet Synchronously.
-        /// </summary>
-        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
-        public override void WriteResponse(ODataBatchWriter writer)
-        {
-            if (writer == null)
-            {
-                throw Error.ArgumentNull("writer");
-            }
-
-            writer.WriteStartChangeset();
-
-            foreach (HttpContext context in Contexts)
-            {
-                WriteMessage(writer, context);
-            }
-
-            writer.WriteEndChangeset();
-        }
-
-        /// <summary>
         /// Writes the responses as a ChangeSet.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
-        public override async Task WriteResponseAsync(ODataBatchWriter writer)
+        /// <param name="asyncWriter">Whether or not the writer is in async mode. </param>
+        public override async Task WriteResponseAsync(ODataBatchWriter writer, bool asyncWriter)
         {
             if (writer == null)
             {
                 throw Error.ArgumentNull("writer");
             }
 
-            await writer.WriteStartChangesetAsync();
-
-            foreach (HttpContext context in Contexts)
+            if (asyncWriter)
             {
-                await WriteMessageAsync(writer, context);
-            }
+                await writer.WriteStartChangesetAsync();
 
-            await writer.WriteEndChangesetAsync();
+                foreach (HttpContext context in Contexts)
+                {
+                    await WriteMessageAsync(writer, context, asyncWriter);
+                }
+
+                await writer.WriteEndChangesetAsync();
+            }
+            else
+            {
+                writer.WriteStartChangeset();
+
+                foreach (HttpContext context in Contexts)
+                {
+                    await WriteMessageAsync(writer, context, asyncWriter);
+                }
+
+                writer.WriteEndChangeset();
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Batch/ChangeSetResponseItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ChangeSetResponseItem.cs
@@ -36,6 +36,27 @@ namespace Microsoft.AspNet.OData.Batch
         public IEnumerable<HttpContext> Contexts { get; private set; }
 
         /// <summary>
+        /// Writes the responses as a ChangeSet Synchronously.
+        /// </summary>
+        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
+        public override void WriteResponse(ODataBatchWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull("writer");
+            }
+
+            writer.WriteStartChangeset();
+
+            foreach (HttpContext context in Contexts)
+            {
+                WriteMessage(writer, context);
+            }
+
+            writer.WriteEndChangeset();
+        }
+
+        /// <summary>
         /// Writes the responses as a ChangeSet.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>

--- a/src/Microsoft.AspNetCore.OData/Batch/ChangeSetResponseItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ChangeSetResponseItem.cs
@@ -46,14 +46,14 @@ namespace Microsoft.AspNet.OData.Batch
                 throw Error.ArgumentNull("writer");
             }
 
-            writer.WriteStartChangeset();
+            await writer.WriteStartChangesetAsync();
 
             foreach (HttpContext context in Contexts)
             {
                 await WriteMessageAsync(writer, context);
             }
 
-            writer.WriteEndChangeset();
+            await writer.WriteEndChangesetAsync();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchContent.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchContent.cs
@@ -65,6 +65,18 @@ namespace Microsoft.AspNet.OData.Batch
         public HeaderDictionary Headers { get; } = new HeaderDictionary();
 
         /// <summary>
+        /// Serialize the batch content to a stream Synchronously.
+        /// </summary>
+        /// <param name="stream">The stream to serialize to.</param>
+        /// <returns>A <see cref="Task"/> that can be awaited.</returns>
+        /// <remarks>This function uses types that are AspNetCore-specific.</remarks>
+        public void SerializeToStream(Stream stream)
+        {
+            IODataResponseMessage responseMessage = ODataMessageWrapperHelper.Create(stream, Headers, _requestContainer);
+            WriteToResponseMessage(responseMessage);
+        }
+
+        /// <summary>
         /// Serialize the batch content to a stream.
         /// </summary>
         /// <param name="stream">The stream to serialize to.</param>
@@ -74,6 +86,26 @@ namespace Microsoft.AspNet.OData.Batch
         {
             IODataResponseMessage responseMessage = ODataMessageWrapperHelper.Create(stream, Headers, _requestContainer);
             return WriteToResponseMessageAsync(responseMessage);
+        }
+
+        /// <summary>
+        ///  Serialize the batch responses to an <see cref="IODataResponseMessage"/> Synchronously.
+        /// </summary>
+        /// <param name="responseMessage">The response message.</param>
+        /// <returns></returns>
+        private void WriteToResponseMessage(IODataResponseMessage responseMessage)
+        {
+            ODataMessageWriter messageWriter = new ODataMessageWriter(responseMessage, _writerSettings);
+            ODataBatchWriter writer = messageWriter.CreateODataBatchWriter();
+
+            writer.WriteStartBatch();
+
+            foreach (ODataBatchResponseItem response in Responses)
+            {
+                response.WriteResponse(writer);
+            }
+
+            writer.WriteEndBatch();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchContent.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchContent.cs
@@ -5,13 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Microsoft.OData;
 
@@ -65,18 +61,6 @@ namespace Microsoft.AspNet.OData.Batch
         public HeaderDictionary Headers { get; } = new HeaderDictionary();
 
         /// <summary>
-        /// Serialize the batch content to a stream Synchronously.
-        /// </summary>
-        /// <param name="stream">The stream to serialize to.</param>
-        /// <returns>A <see cref="Task"/> that can be awaited.</returns>
-        /// <remarks>This function uses types that are AspNetCore-specific.</remarks>
-        public void SerializeToStream(Stream stream)
-        {
-            IODataResponseMessage responseMessage = ODataMessageWrapperHelper.Create(stream, Headers, _requestContainer);
-            WriteToResponseMessage(responseMessage);
-        }
-
-        /// <summary>
         /// Serialize the batch content to a stream.
         /// </summary>
         /// <param name="stream">The stream to serialize to.</param>
@@ -86,26 +70,6 @@ namespace Microsoft.AspNet.OData.Batch
         {
             IODataResponseMessage responseMessage = ODataMessageWrapperHelper.Create(stream, Headers, _requestContainer);
             return WriteToResponseMessageAsync(responseMessage);
-        }
-
-        /// <summary>
-        ///  Serialize the batch responses to an <see cref="IODataResponseMessage"/> Synchronously.
-        /// </summary>
-        /// <param name="responseMessage">The response message.</param>
-        /// <returns></returns>
-        private void WriteToResponseMessage(IODataResponseMessage responseMessage)
-        {
-            ODataMessageWriter messageWriter = new ODataMessageWriter(responseMessage, _writerSettings);
-            ODataBatchWriter writer = messageWriter.CreateODataBatchWriter();
-
-            writer.WriteStartBatch();
-
-            foreach (ODataBatchResponseItem response in Responses)
-            {
-                response.WriteResponse(writer);
-            }
-
-            writer.WriteEndBatch();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -233,7 +233,7 @@ namespace Microsoft.AspNet.OData.Batch
             // Create a response body as the default response feature does not
             // have a valid stream.
             // Use a special batch stream that remains open after the writer is disposed.
-            context.Response.Body = new BatchStream();
+            context.Response.Body = new ODataBatchStream();
 
             return context;
         }

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -232,7 +232,8 @@ namespace Microsoft.AspNet.OData.Batch
 
             // Create a response body as the default response feature does not
             // have a valid stream.
-            context.Response.Body = new MemoryStream();
+            // Use a special batch stream that remains open after the writer is disposed.
+            context.Response.Body = new BatchStream();
 
             return context;
         }

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchResponseItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchResponseItem.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.OData.Batch
 
             string contentId = (context.Request != null) ? context.Request.GetODataContentId() : String.Empty;
 
-            ODataBatchOperationResponseMessage batchResponse = writer.CreateOperationResponseMessage(contentId);
+            ODataBatchOperationResponseMessage batchResponse = await writer.CreateOperationResponseMessageAsync(contentId);
 
             batchResponse.StatusCode = context.Response.StatusCode;
 
@@ -51,6 +51,13 @@ namespace Microsoft.AspNet.OData.Batch
                     context.RequestAborted.ThrowIfCancellationRequested();
                     context.Response.Body.Seek(0L, SeekOrigin.Begin);
                     await context.Response.Body.CopyToAsync(stream);
+
+                    // Close and release the stream for the individual response
+                    BatchStream batchStream = context.Response.Body as BatchStream;
+                    if (batchStream != null)
+                    {
+                        batchStream.Release();
+                    }
                 }
             }
         }

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchResponseItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchResponseItem.cs
@@ -18,6 +18,51 @@ namespace Microsoft.AspNet.OData.Batch
     public abstract class ODataBatchResponseItem
     {
         /// <summary>
+        /// Writes a single OData batch response Synchronously.
+        /// </summary>
+        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
+        /// <param name="context">The message context.</param>
+        public static void WriteMessage(ODataBatchWriter writer, HttpContext context)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull("writer");
+            }
+            if (context == null)
+            {
+                throw Error.ArgumentNull("context");
+            }
+
+            string contentId = (context.Request != null) ? context.Request.GetODataContentId() : String.Empty;
+
+            ODataBatchOperationResponseMessage batchResponse = writer.CreateOperationResponseMessage(contentId);
+
+            batchResponse.StatusCode = context.Response.StatusCode;
+
+            foreach (KeyValuePair<string, StringValues> header in context.Response.Headers)
+            {
+                batchResponse.SetHeader(header.Key, String.Join(",", header.Value.ToArray()));
+            }
+
+            if (context.Response.Body != null && context.Response.Body.Length != 0)
+            {
+                using (Stream stream = batchResponse.GetStream())
+                {
+                    context.RequestAborted.ThrowIfCancellationRequested();
+                    context.Response.Body.Seek(0L, SeekOrigin.Begin);
+                    context.Response.Body.CopyToAsync(stream).Wait();
+
+                    // Close and release the stream for the individual response
+                    ODataBatchStream batchStream = context.Response.Body as ODataBatchStream;
+                    if (batchStream != null)
+                    {
+                        batchStream.InternalDispose();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Writes a single OData batch response.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
@@ -53,14 +98,20 @@ namespace Microsoft.AspNet.OData.Batch
                     await context.Response.Body.CopyToAsync(stream);
 
                     // Close and release the stream for the individual response
-                    BatchStream batchStream = context.Response.Body as BatchStream;
+                    ODataBatchStream batchStream = context.Response.Body as ODataBatchStream;
                     if (batchStream != null)
                     {
-                        batchStream.Release();
+                        batchStream.InternalDispose();
                     }
                 }
             }
         }
+
+        /// <summary>
+        /// Writes the response Synchronously.
+        /// </summary>
+        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
+        public abstract void WriteResponse(ODataBatchWriter writer);
 
         /// <summary>
         /// Writes the response.

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchStream.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchStream.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    // Normally, the stream is closed when the ODataMessageWriter is disposed.
+    // For responses within a batch, we need to read from the stream after the response is
+    // written in order to write it to the batch response stream. So we need to ignore the Close()
+    // and provide an alternate method to release the stream after writing its content to the batch response.
+    internal class BatchStream : MemoryStream
+    {
+        /// <summary>
+        /// Release the batch stream and underlying resources
+        /// </summary>
+        internal void Release()
+        { 
+            base.Flush();
+            base.Close();
+            base.Dispose();
+        }
+
+        /// <summary>
+        /// Override Close() in order to hold the stream open until we are able to
+        /// copy it to the batch response stream.
+        /// </summary>
+        public override void Close()
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchStream.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchStream.cs
@@ -9,16 +9,22 @@ namespace Microsoft.AspNet.OData.Batch
     // For responses within a batch, we need to read from the stream after the response is
     // written in order to write it to the batch response stream. So we need to ignore the Close()
     // and provide an alternate method to release the stream after writing its content to the batch response.
-    internal class BatchStream : MemoryStream
+    internal class ODataBatchStream : MemoryStream
     {
+        private bool isDisposed = false;
+
         /// <summary>
-        /// Release the batch stream and underlying resources
+        /// Dispose the batch stream and underlying resources
         /// </summary>
-        internal void Release()
-        { 
-            base.Flush();
-            base.Close();
-            base.Dispose();
+        internal void InternalDispose()
+        {
+            if (!isDisposed)
+            {
+                base.Flush();
+                base.Close();
+                base.Dispose();
+                isDisposed = true;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Batch/OperationResponseItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/OperationResponseItem.cs
@@ -34,31 +34,18 @@ namespace Microsoft.AspNet.OData.Batch
         public HttpContext Context { get; private set; }
 
         /// <summary>
-        /// Writes the response as an Operation Synchronously.
-        /// </summary>
-        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
-        public override void WriteResponse(ODataBatchWriter writer)
-        {
-            if (writer == null)
-            {
-                throw Error.ArgumentNull("writer");
-            }
-
-            WriteMessage(writer, Context);
-        }
-
-        /// <summary>
         /// Writes the response as an Operation.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
-        public override Task WriteResponseAsync(ODataBatchWriter writer)
+        /// <param name="asyncWriter">Whether or not the writer is in async mode. </param>
+        public override Task WriteResponseAsync(ODataBatchWriter writer, bool asyncWriter)
         {
             if (writer == null)
             {
                 throw Error.ArgumentNull("writer");
             }
 
-            return WriteMessageAsync(writer, Context);
+            return WriteMessageAsync(writer, Context, asyncWriter);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Batch/OperationResponseItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/OperationResponseItem.cs
@@ -34,6 +34,20 @@ namespace Microsoft.AspNet.OData.Batch
         public HttpContext Context { get; private set; }
 
         /// <summary>
+        /// Writes the response as an Operation Synchronously.
+        /// </summary>
+        /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>
+        public override void WriteResponse(ODataBatchWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull("writer");
+            }
+
+            WriteMessage(writer, Context);
+        }
+
+        /// <summary>
         /// Writes the response as an Operation.
         /// </summary>
         /// <param name="writer">The <see cref="ODataBatchWriter"/>.</param>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Batch/Tests/DataServicesClient/DefaultODataBatchHandlerTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Batch/Tests/DataServicesClient/DefaultODataBatchHandlerTests.cs
@@ -241,6 +241,150 @@ Content-Type: application/json;odata.metadata=minimal
             Assert.Equal(3, subResponseCount);
         }
 
+
+        [Fact]
+        public async Task CanHandleAbsoluteAndRelativeUrlsJSON()
+        {
+            // Arrange
+            var requestUri = string.Format("{0}/DefaultBatch/$batch", this.BaseAddress);
+            Uri address = new Uri(this.BaseAddress, UriKind.Absolute);
+
+            string relativeToServiceRootUri = "DefaultBatchCustomer";
+            string relativeToHostUri = address.LocalPath.TrimEnd(new char[] { '/' }) + "/DefaultBatch/DefaultBatchCustomer";
+            string absoluteUri = this.BaseAddress + "/DefaultBatch/DefaultBatchCustomer";
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            HttpContent content = new StringContent(@"
+            {                                                                                                        
+                ""requests"":[                                                                                             
+                    {
+                    ""id"": ""2"",                                                                                               
+                    ""atomicityGroup"": ""transaction"",                                                                         
+                    ""method"": ""post"",                                                                                        
+                    ""url"": """ + relativeToServiceRootUri + @""",                                                                                   
+                    ""headers"": { ""content-type"": ""application/json"", ""Accept"": ""application/json"", ""odata-version"": ""4.0"" }, 
+                    ""body"": {'Id':11,'Name':'MyName11'}
+                    },
+                    {
+                    ""id"": ""3"",                                                                                               
+                    ""atomicityGroup"": ""transaction"",                                                                         
+                    ""method"": ""post"",                                                                                        
+                    ""url"": """ + relativeToHostUri + @""",                                                                                   
+                    ""headers"": { ""content-type"": ""application/json"", ""Accept"": ""application/json"", ""odata-version"": ""4.0"" }, 
+                    ""body"": {'Id':12,'Name':'MyName12'}
+                    },
+                    {
+                    ""id"": ""4"",                                                                                               
+                    ""atomicityGroup"": ""transaction"",                                                                         
+                    ""method"": ""post"",                                                                                        
+                    ""url"": """ + absoluteUri + @""",                                                                                   
+                    ""headers"": { ""content-type"": ""application/json"", ""Accept"": ""application/json"", ""odata-version"": ""4.0"" }, 
+                    ""body"": {'Id':13,'Name':'MyName13'}
+                    }
+                ]
+            }");
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            request.Content = content;
+            HttpResponseMessage response = await Client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var stream = await response.Content.ReadAsStreamAsync();
+            Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType.ToString());
+            IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
+            int subResponseCount = 0;
+            using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), GetEdmModel(new ODataConventionModelBuilder())))
+            {
+                var batchReader = messageReader.CreateODataBatchReader();
+                while (batchReader.Read())
+                {
+                    switch (batchReader.State)
+                    {
+                        case ODataBatchReaderState.Operation:
+                            var operationMessage = batchReader.CreateOperationResponseMessage();
+                            subResponseCount++;
+                            Assert.Equal(201, operationMessage.StatusCode);
+                            break;
+                    }
+                }
+            }
+            Assert.Equal(3, subResponseCount);
+        }
+
+        [Fact]
+        public async Task CanReadDataInBatch()
+        {
+            // Arrange
+            var requestUri = string.Format("{0}/DefaultBatch/$batch", this.BaseAddress);
+            Uri address = new Uri(this.BaseAddress, UriKind.Absolute);
+
+            string relativeToServiceRootUri = "DefaultBatchCustomer";
+            string relativeToHostUri = address.LocalPath.TrimEnd(new char[] { '/' }) + "/DefaultBatch/DefaultBatchCustomer";
+            string absoluteUri = this.BaseAddress + "/DefaultBatch/DefaultBatchCustomer";
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            HttpContent content = new StringContent(@"
+            {                                                                                                        
+                ""requests"":[                                                                                             
+                    {
+                    ""id"": ""2"",                                                                                               
+                    ""method"": ""get"",                                                                                        
+                    ""url"": """ + relativeToServiceRootUri + @""",                                                                                   
+                    ""headers"": { ""Accept"": ""application/json""} 
+                    },
+                    {
+                    ""id"": ""3"",                                                                                               
+                    ""method"": ""get"",                                                                                        
+                    ""url"": """ + relativeToHostUri + @"""                                                                                   
+                    },
+                    {
+                    ""id"": ""4"",                                                                                               
+                    ""method"": ""get"",                                                                                        
+                    ""url"": """ + absoluteUri + @""",                                                                                   
+                    ""headers"": { ""Accept"": ""application/json""}
+                    }
+                ]
+            }");
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            request.Content = content;
+            HttpResponseMessage response = await Client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var stream = await response.Content.ReadAsStreamAsync();
+            Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType.ToString());
+            IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
+            int subResponseCount = 0;
+            var model = GetEdmModel(new ODataConventionModelBuilder());
+            using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), model))
+            {
+                var batchReader = messageReader.CreateODataBatchReader();
+                while (batchReader.Read())
+                {
+                    switch (batchReader.State)
+                    {
+                        case ODataBatchReaderState.Operation:
+                            var operationMessage = batchReader.CreateOperationResponseMessage();
+                            subResponseCount++;
+                            Assert.Equal(200, operationMessage.StatusCode);
+                            using (var innerMessageReader = new ODataMessageReader(operationMessage, new ODataMessageReaderSettings(), model))
+                            {
+                                var innerReader = innerMessageReader.CreateODataResourceSetReader();
+                                while (innerReader.Read()) ;
+                            }
+                            break;
+                    }
+                }
+            }
+            Assert.Equal(3, subResponseCount);
+        }
+
         [Fact]
         public async Task CanHandleAutomicityGroupRequestsAndUngroupedRequest_JsonBatch()
         {
@@ -348,6 +492,59 @@ Content-Type: application/json;odata.metadata=minimal
                 }
             }
             Assert.Equal(4, subResponseCount);
+        }
+
+        [Fact]
+        public async Task CanHandleSingleDeleteInBatch()
+        {
+            // Arrange
+            var requestUri = string.Format("{0}/DefaultBatch/$batch", this.BaseAddress);
+
+            // Act
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            HttpContent content = new StringContent(@"
+            {
+                ""requests"": [
+                    {
+                        ""Id"": ""1"",
+                        ""method"": ""DELETE"",
+                        ""headers"": {
+                            ""odata-version"": ""4.01"",
+                            ""content-type"": ""application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false""
+                        },
+                        ""url"": ""DefaultBatchCustomer(5)"",
+                        ""body"": """"
+                    }
+                ]
+            }");
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            request.Content = content;
+            HttpResponseMessage response = await Client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var stream = await response.Content.ReadAsStreamAsync();
+            Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType.ToString());
+            IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
+            int subResponseCount = 0;
+            using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), GetEdmModel(new ODataConventionModelBuilder())))
+            {
+                var batchReader = messageReader.CreateODataBatchReader();
+
+                while (batchReader.Read())
+                {
+                    switch (batchReader.State)
+                    {
+                        case ODataBatchReaderState.Operation:
+                            var operationMessage = batchReader.CreateOperationResponseMessage();
+                            subResponseCount++;
+                            break;
+                    }
+                }
+            }
+            Assert.Equal(1, subResponseCount);
         }
     }
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Batch/Tests/DataServicesClient/DefaultODataBatchHandlerTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Batch/Tests/DataServicesClient/DefaultODataBatchHandlerTests.cs
@@ -255,7 +255,6 @@ Content-Type: application/json;odata.metadata=minimal
 
             // Act
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
-            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
             HttpContent content = new StringContent(@"
             {                                                                                                        
                 ""requests"":[                                                                                             
@@ -291,9 +290,9 @@ Content-Type: application/json;odata.metadata=minimal
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("application/json", content.Headers.ContentType.MediaType);
 
             var stream = await response.Content.ReadAsStreamAsync();
-            Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType.ToString());
             IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
             int subResponseCount = 0;
             using (var messageReader = new ODataMessageReader(odataResponseMessage, new ODataMessageReaderSettings(), GetEdmModel(new ODataConventionModelBuilder())))
@@ -307,6 +306,7 @@ Content-Type: application/json;odata.metadata=minimal
                             var operationMessage = batchReader.CreateOperationResponseMessage();
                             subResponseCount++;
                             Assert.Equal(201, operationMessage.StatusCode);
+                            Assert.Contains("application/json", operationMessage.Headers.Single(h => String.Equals(h.Key, "Content-Type", StringComparison.OrdinalIgnoreCase)).Value);
                             break;
                     }
                 }
@@ -356,9 +356,9 @@ Content-Type: application/json;odata.metadata=minimal
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
 
             var stream = await response.Content.ReadAsStreamAsync();
-            Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType.ToString());
             IODataResponseMessage odataResponseMessage = new ODataMessageWrapper(stream, response.Content.Headers);
             int subResponseCount = 0;
             var model = GetEdmModel(new ODataConventionModelBuilder());
@@ -373,6 +373,7 @@ Content-Type: application/json;odata.metadata=minimal
                             var operationMessage = batchReader.CreateOperationResponseMessage();
                             subResponseCount++;
                             Assert.Equal(200, operationMessage.StatusCode);
+                            Assert.Contains("application/json", operationMessage.Headers.Single(h => String.Equals(h.Key, "Content-Type", StringComparison.OrdinalIgnoreCase)).Value);
                             using (var innerMessageReader = new ODataMessageReader(operationMessage, new ODataMessageReaderSettings(), model))
                             {
                                 var innerReader = innerMessageReader.CreateODataResourceSetReader();

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ChangeSetResponseItemTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ChangeSetResponseItemTest.cs
@@ -36,16 +36,6 @@ namespace Microsoft.AspNet.OData.Test.Batch
         }
 
         [Fact]
-        public void WriteResponse_NullWriter_Throws()
-        {
-            ChangeSetResponseItem responseItem = new ChangeSetResponseItem(new HttpResponseMessage[0]);
-
-            ExceptionAssert.ThrowsArgumentNull(
-                () => responseItem.WriteResponse(null),
-                "writer");
-        }
-
-        [Fact]
         public async Task WriteResponseAsync_NullWriter_Throws()
         {
             ChangeSetResponseItem responseItem = new ChangeSetResponseItem(new HttpResponseMessage[0]);
@@ -56,7 +46,7 @@ namespace Microsoft.AspNet.OData.Test.Batch
         }
 
         [Fact]
-        public void WriteResponse_WritesChangeSet()
+        public async Task WriteResponse_SynchronouslyWritesChangeSet()
         {
             HttpResponseMessage[] responses = new HttpResponseMessage[]
                 {
@@ -70,7 +60,8 @@ namespace Microsoft.AspNet.OData.Test.Batch
             ODataBatchWriter batchWriter = writer.CreateODataBatchWriter();
             batchWriter.WriteStartBatch();
 
-            responseItem.WriteResponse(batchWriter);
+            // For backward compatibility, default is to assume a synchronous batch writer
+            await responseItem.WriteResponseAsync(batchWriter, CancellationToken.None);
 
             batchWriter.WriteEndBatch();
             memoryStream.Position = 0;
@@ -96,7 +87,7 @@ namespace Microsoft.AspNet.OData.Test.Batch
             ODataBatchWriter batchWriter = await writer.CreateODataBatchWriterAsync();
             await batchWriter.WriteStartBatchAsync();
 
-            await responseItem.WriteResponseAsync(batchWriter, CancellationToken.None);
+            await responseItem.WriteResponseAsync(batchWriter, CancellationToken.None, /*asyncWriter*/ true);
 
             await batchWriter.WriteEndBatchAsync();
             memoryStream.Position = 0;

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchContentTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchContentTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -13,6 +12,7 @@ using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
 #if NETCORE
+using System.IO;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 #endif

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchContentTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchContentTest.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
-#if !NETCORE // TODO #939: Enable these test on AspNetCore.
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -12,12 +12,34 @@ using Microsoft.AspNet.OData.Batch;
 using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
+#if NETCORE
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+#endif
 using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Batch
 {
     public class ODataBatchContentTest
     {
+#if NETCORE
+        [Fact]
+        public void Parameter_Constructor()
+        {
+            const string boundaryHeader = "boundary";
+            ODataBatchContent batchContent = CreateBatchContent(new ODataBatchResponseItem[0]);
+            string contentTypeHeader = batchContent.Headers[HeaderNames.ContentType].FirstOrDefault();
+            string mediaType = contentTypeHeader.Substring(0, contentTypeHeader.IndexOf(';'));
+            int boundaryParamStart = contentTypeHeader.IndexOf(boundaryHeader);
+            string boundary = contentTypeHeader.Substring(boundaryParamStart + boundaryHeader.Length);
+            var odataVersion = batchContent.Headers.FirstOrDefault(h => String.Equals(h.Key, ODataVersionConstraint.ODataServiceVersionHeader, StringComparison.OrdinalIgnoreCase));
+
+            Assert.NotEmpty(boundary);
+            Assert.NotEmpty(odataVersion.Value);
+            Assert.Equal("multipart/mixed", mediaType);
+        }
+
+#else
         [Fact]
         public void Parameter_Constructor()
         {
@@ -31,6 +53,7 @@ namespace Microsoft.AspNet.OData.Test.Batch
             Assert.NotEmpty(odataVersion.Value);
             Assert.Equal("multipart/mixed", contentType.MediaType);
         }
+#endif
 
         [Fact]
         public void Constructor_Throws_WhenResponsesAreNull()
@@ -49,6 +72,38 @@ namespace Microsoft.AspNet.OData.Test.Batch
             Assert.Equal("4.0", odataVersion.Value.FirstOrDefault());
         }
 
+#if NETCORE
+        [Fact]
+        public async Task SerializeToStreamAsync_WritesODataBatchResponseItems()
+        {
+            HttpContext okContext = new DefaultHttpContext();
+            okContext.Response.StatusCode = (int)HttpStatusCode.OK;
+            HttpContext acceptedContext = new DefaultHttpContext();
+            acceptedContext.Response.StatusCode = (int)HttpStatusCode.Accepted;
+            HttpContext badRequestContext = new DefaultHttpContext();
+            badRequestContext.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+
+            ODataBatchContent batchContent = CreateBatchContent(new ODataBatchResponseItem[]
+            {
+                new OperationResponseItem(okContext),
+                new ChangeSetResponseItem(new HttpContext[]
+                {
+                    acceptedContext,
+                    badRequestContext
+                })
+            });
+
+            MemoryStream stream = new MemoryStream();
+            await batchContent.SerializeToStreamAsync(stream);
+            stream.Position = 0;
+            string responseString = await new StreamReader(stream).ReadToEndAsync();
+
+            Assert.Contains("changesetresponse", responseString);
+            Assert.Contains("OK", responseString);
+            Assert.Contains("Accepted", responseString);
+            Assert.Contains("Bad Request", responseString);
+        }
+#else
         [Fact]
         public async Task SerializeToStreamAsync_WritesODataBatchResponseItems()
         {
@@ -104,6 +159,7 @@ namespace Microsoft.AspNet.OData.Test.Batch
                 Assert.True(response.IsDisposed);
             }
         }
+#endif
 
         private static ODataBatchContent CreateBatchContent(IEnumerable<ODataBatchResponseItem> responses)
         {
@@ -111,4 +167,3 @@ namespace Microsoft.AspNet.OData.Test.Batch
         }
     }
 }
-#endif

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/OperationResponseItemTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/OperationResponseItemTest.cs
@@ -35,16 +35,6 @@ namespace Microsoft.AspNet.OData.Test.Batch
         }
 
         [Fact]
-        public void WriteResponse_NullWriter_Throws()
-        {
-            OperationResponseItem responseItem = new OperationResponseItem(new HttpResponseMessage());
-
-            ExceptionAssert.ThrowsArgumentNull(
-                () => responseItem.WriteResponse(null),
-                "writer");
-        }
-
-        [Fact]
         public async Task WriteResponseAsync_NullWriter_Throws()
         {
             OperationResponseItem responseItem = new OperationResponseItem(new HttpResponseMessage());
@@ -55,7 +45,7 @@ namespace Microsoft.AspNet.OData.Test.Batch
         }
 
         [Fact]
-        public void WriteResponse_WritesOperation()
+        public async Task WriteResponseAsync_SynchronouslyWritesOperation()
         {
             OperationResponseItem responseItem = new OperationResponseItem(new HttpResponseMessage(HttpStatusCode.Accepted));
             MemoryStream memoryStream = new MemoryStream();
@@ -64,7 +54,8 @@ namespace Microsoft.AspNet.OData.Test.Batch
             ODataBatchWriter batchWriter = writer.CreateODataBatchWriter();
             batchWriter.WriteStartBatch();
 
-            responseItem.WriteResponse(batchWriter);
+            // For backward compatibility, default is to write to use a synchronous batchWriter.
+            await responseItem.WriteResponseAsync(batchWriter, CancellationToken.None);
 
             batchWriter.WriteEndBatch();
             memoryStream.Position = 0;
@@ -74,7 +65,7 @@ namespace Microsoft.AspNet.OData.Test.Batch
         }
 
         [Fact]
-        public async Task WriteResponseAsync_WritesOperation()
+        public async Task WriteResponseAsync_AsynchronouslyWritesOperation()
         {
             OperationResponseItem responseItem = new OperationResponseItem(new HttpResponseMessage(HttpStatusCode.Accepted));
             MemoryStream memoryStream = new MemoryStream();
@@ -83,7 +74,7 @@ namespace Microsoft.AspNet.OData.Test.Batch
             ODataBatchWriter batchWriter = await writer.CreateODataBatchWriterAsync();
             await batchWriter.WriteStartBatchAsync();
 
-            await responseItem.WriteResponseAsync(batchWriter, CancellationToken.None);
+            await responseItem.WriteResponseAsync(batchWriter, CancellationToken.None, /*writeAsync*/ true);
 
             await batchWriter.WriteEndBatchAsync();
             memoryStream.Position = 0;

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -684,12 +684,14 @@ public abstract class Microsoft.AspNet.OData.Batch.ODataBatchResponseItem : IDis
 	public virtual void Dispose ()
 	protected abstract void Dispose (bool disposing)
 	internal virtual bool IsResponseSuccessful ()
+	public static void WriteMessage (Microsoft.OData.ODataBatchWriter writer, System.Net.Http.HttpResponseMessage response)
 	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, System.Net.Http.HttpResponseMessage response)
 	[
 	AsyncStateMachineAttribute(),
 	]
 	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, System.Net.Http.HttpResponseMessage response, System.Threading.CancellationToken cancellationToken)
 
+	public abstract void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
 	public abstract System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, System.Threading.CancellationToken cancellationToken)
 }
 
@@ -813,6 +815,7 @@ public class Microsoft.AspNet.OData.Batch.ChangeSetResponseItem : ODataBatchResp
 
 	protected virtual void Dispose (bool disposing)
 	internal virtual bool IsResponseSuccessful ()
+	public virtual void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
 	[
 	AsyncStateMachineAttribute(),
 	]
@@ -869,6 +872,7 @@ public class Microsoft.AspNet.OData.Batch.OperationResponseItem : ODataBatchResp
 
 	protected virtual void Dispose (bool disposing)
 	internal virtual bool IsResponseSuccessful ()
+	public virtual void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
 	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, System.Threading.CancellationToken cancellationToken)
 }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -684,15 +684,19 @@ public abstract class Microsoft.AspNet.OData.Batch.ODataBatchResponseItem : IDis
 	public virtual void Dispose ()
 	protected abstract void Dispose (bool disposing)
 	internal virtual bool IsResponseSuccessful ()
-	public static void WriteMessage (Microsoft.OData.ODataBatchWriter writer, System.Net.Http.HttpResponseMessage response)
 	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, System.Net.Http.HttpResponseMessage response)
 	[
 	AsyncStateMachineAttribute(),
 	]
 	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, System.Net.Http.HttpResponseMessage response, System.Threading.CancellationToken cancellationToken)
 
-	public abstract void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
-	public abstract System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, System.Threading.CancellationToken cancellationToken)
+	[
+	AsyncStateMachineAttribute(),
+	]
+	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, System.Net.Http.HttpResponseMessage response, System.Threading.CancellationToken cancellationToken, bool asyncWriter)
+
+	public System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, System.Threading.CancellationToken cancellationToken)
+	public abstract System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, System.Threading.CancellationToken cancellationToken, bool asyncWriter)
 }
 
 [
@@ -815,11 +819,10 @@ public class Microsoft.AspNet.OData.Batch.ChangeSetResponseItem : ODataBatchResp
 
 	protected virtual void Dispose (bool disposing)
 	internal virtual bool IsResponseSuccessful ()
-	public virtual void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
 	[
 	AsyncStateMachineAttribute(),
 	]
-	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, System.Threading.CancellationToken cancellationToken)
+	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, System.Threading.CancellationToken cancellationToken, bool asyncWriter)
 }
 
 public class Microsoft.AspNet.OData.Batch.DefaultODataBatchHandler : ODataBatchHandler, IDisposable {
@@ -872,8 +875,7 @@ public class Microsoft.AspNet.OData.Batch.OperationResponseItem : ODataBatchResp
 
 	protected virtual void Dispose (bool disposing)
 	internal virtual bool IsResponseSuccessful ()
-	public virtual void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
-	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, System.Threading.CancellationToken cancellationToken)
+	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, System.Threading.CancellationToken cancellationToken, bool asyncWriter)
 }
 
 public class Microsoft.AspNet.OData.Batch.UnbufferedODataBatchHandler : ODataBatchHandler, IDisposable {

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -726,14 +726,18 @@ public abstract class Microsoft.AspNet.OData.Batch.ODataBatchResponseItem {
 	protected ODataBatchResponseItem ()
 
 	internal virtual bool IsResponseSuccessful ()
-	public static void WriteMessage (Microsoft.OData.ODataBatchWriter writer, Microsoft.AspNetCore.Http.HttpContext context)
 	[
 	AsyncStateMachineAttribute(),
 	]
 	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, Microsoft.AspNetCore.Http.HttpContext context)
 
-	public abstract void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
-	public abstract System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer)
+	[
+	AsyncStateMachineAttribute(),
+	]
+	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, Microsoft.AspNetCore.Http.HttpContext context, bool asyncWriter)
+
+	public System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer)
+	public abstract System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, bool asyncWriter)
 }
 
 [
@@ -852,11 +856,10 @@ public class Microsoft.AspNet.OData.Batch.ChangeSetResponseItem : ODataBatchResp
 	System.Collections.Generic.IEnumerable`1[[Microsoft.AspNetCore.Http.HttpContext]] Contexts  { public get; }
 
 	internal virtual bool IsResponseSuccessful ()
-	public virtual void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
 	[
 	AsyncStateMachineAttribute(),
 	]
-	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer)
+	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, bool asyncWriter)
 }
 
 public class Microsoft.AspNet.OData.Batch.DefaultODataBatchHandler : ODataBatchHandler {
@@ -885,7 +888,6 @@ public class Microsoft.AspNet.OData.Batch.ODataBatchContent {
 	Microsoft.AspNetCore.Http.HeaderDictionary Headers  { public get; }
 	System.Collections.Generic.IEnumerable`1[[Microsoft.AspNet.OData.Batch.ODataBatchResponseItem]] Responses  { public get; }
 
-	public void SerializeToStream (System.IO.Stream stream)
 	public System.Threading.Tasks.Task SerializeToStreamAsync (System.IO.Stream stream)
 }
 
@@ -922,8 +924,7 @@ public class Microsoft.AspNet.OData.Batch.OperationResponseItem : ODataBatchResp
 	Microsoft.AspNetCore.Http.HttpContext Context  { public get; }
 
 	internal virtual bool IsResponseSuccessful ()
-	public virtual void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
-	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer)
+	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, bool asyncWriter)
 }
 
 public class Microsoft.AspNet.OData.Batch.UnbufferedODataBatchHandler : ODataBatchHandler {

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -726,11 +726,13 @@ public abstract class Microsoft.AspNet.OData.Batch.ODataBatchResponseItem {
 	protected ODataBatchResponseItem ()
 
 	internal virtual bool IsResponseSuccessful ()
+	public static void WriteMessage (Microsoft.OData.ODataBatchWriter writer, Microsoft.AspNetCore.Http.HttpContext context)
 	[
 	AsyncStateMachineAttribute(),
 	]
 	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, Microsoft.AspNetCore.Http.HttpContext context)
 
+	public abstract void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
 	public abstract System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer)
 }
 
@@ -850,6 +852,7 @@ public class Microsoft.AspNet.OData.Batch.ChangeSetResponseItem : ODataBatchResp
 	System.Collections.Generic.IEnumerable`1[[Microsoft.AspNetCore.Http.HttpContext]] Contexts  { public get; }
 
 	internal virtual bool IsResponseSuccessful ()
+	public virtual void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
 	[
 	AsyncStateMachineAttribute(),
 	]
@@ -882,6 +885,7 @@ public class Microsoft.AspNet.OData.Batch.ODataBatchContent {
 	Microsoft.AspNetCore.Http.HeaderDictionary Headers  { public get; }
 	System.Collections.Generic.IEnumerable`1[[Microsoft.AspNet.OData.Batch.ODataBatchResponseItem]] Responses  { public get; }
 
+	public void SerializeToStream (System.IO.Stream stream)
 	public System.Threading.Tasks.Task SerializeToStreamAsync (System.IO.Stream stream)
 }
 
@@ -918,6 +922,7 @@ public class Microsoft.AspNet.OData.Batch.OperationResponseItem : ODataBatchResp
 	Microsoft.AspNetCore.Http.HttpContext Context  { public get; }
 
 	internal virtual bool IsResponseSuccessful ()
+	public virtual void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
 	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer)
 }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -726,14 +726,18 @@ public abstract class Microsoft.AspNet.OData.Batch.ODataBatchResponseItem {
 	protected ODataBatchResponseItem ()
 
 	internal virtual bool IsResponseSuccessful ()
-	public static void WriteMessage (Microsoft.OData.ODataBatchWriter writer, Microsoft.AspNetCore.Http.HttpContext context)
 	[
 	AsyncStateMachineAttribute(),
 	]
 	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, Microsoft.AspNetCore.Http.HttpContext context)
 
-	public abstract void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
-	public abstract System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer)
+	[
+	AsyncStateMachineAttribute(),
+	]
+	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, Microsoft.AspNetCore.Http.HttpContext context, bool asyncWriter)
+
+	public System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer)
+	public abstract System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, bool asyncWriter)
 }
 
 [
@@ -852,11 +856,10 @@ public class Microsoft.AspNet.OData.Batch.ChangeSetResponseItem : ODataBatchResp
 	System.Collections.Generic.IEnumerable`1[[Microsoft.AspNetCore.Http.HttpContext]] Contexts  { public get; }
 
 	internal virtual bool IsResponseSuccessful ()
-	public virtual void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
 	[
 	AsyncStateMachineAttribute(),
 	]
-	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer)
+	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, bool asyncWriter)
 }
 
 public class Microsoft.AspNet.OData.Batch.DefaultODataBatchHandler : ODataBatchHandler {
@@ -885,7 +888,6 @@ public class Microsoft.AspNet.OData.Batch.ODataBatchContent {
 	Microsoft.AspNetCore.Http.HeaderDictionary Headers  { public get; }
 	System.Collections.Generic.IEnumerable`1[[Microsoft.AspNet.OData.Batch.ODataBatchResponseItem]] Responses  { public get; }
 
-	public void SerializeToStream (System.IO.Stream stream)
 	public System.Threading.Tasks.Task SerializeToStreamAsync (System.IO.Stream stream)
 }
 
@@ -922,8 +924,7 @@ public class Microsoft.AspNet.OData.Batch.OperationResponseItem : ODataBatchResp
 	Microsoft.AspNetCore.Http.HttpContext Context  { public get; }
 
 	internal virtual bool IsResponseSuccessful ()
-	public virtual void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
-	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer)
+	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer, bool asyncWriter)
 }
 
 public class Microsoft.AspNet.OData.Batch.UnbufferedODataBatchHandler : ODataBatchHandler {

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -726,11 +726,13 @@ public abstract class Microsoft.AspNet.OData.Batch.ODataBatchResponseItem {
 	protected ODataBatchResponseItem ()
 
 	internal virtual bool IsResponseSuccessful ()
+	public static void WriteMessage (Microsoft.OData.ODataBatchWriter writer, Microsoft.AspNetCore.Http.HttpContext context)
 	[
 	AsyncStateMachineAttribute(),
 	]
 	public static System.Threading.Tasks.Task WriteMessageAsync (Microsoft.OData.ODataBatchWriter writer, Microsoft.AspNetCore.Http.HttpContext context)
 
+	public abstract void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
 	public abstract System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer)
 }
 
@@ -850,6 +852,7 @@ public class Microsoft.AspNet.OData.Batch.ChangeSetResponseItem : ODataBatchResp
 	System.Collections.Generic.IEnumerable`1[[Microsoft.AspNetCore.Http.HttpContext]] Contexts  { public get; }
 
 	internal virtual bool IsResponseSuccessful ()
+	public virtual void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
 	[
 	AsyncStateMachineAttribute(),
 	]
@@ -882,6 +885,7 @@ public class Microsoft.AspNet.OData.Batch.ODataBatchContent {
 	Microsoft.AspNetCore.Http.HeaderDictionary Headers  { public get; }
 	System.Collections.Generic.IEnumerable`1[[Microsoft.AspNet.OData.Batch.ODataBatchResponseItem]] Responses  { public get; }
 
+	public void SerializeToStream (System.IO.Stream stream)
 	public System.Threading.Tasks.Task SerializeToStreamAsync (System.IO.Stream stream)
 }
 
@@ -918,6 +922,7 @@ public class Microsoft.AspNet.OData.Batch.OperationResponseItem : ODataBatchResp
 	Microsoft.AspNetCore.Http.HttpContext Context  { public get; }
 
 	internal virtual bool IsResponseSuccessful ()
+	public virtual void WriteResponse (Microsoft.OData.ODataBatchWriter writer)
 	public virtual System.Threading.Tasks.Task WriteResponseAsync (Microsoft.OData.ODataBatchWriter writer)
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

1) Fix batch dispose issue (error writing to a closed stream)
2) Fix async batch issues (synchronous write to an asynchronous reader error)

### Issues

*This pull request fixes issue #2009*

### Description

In certain batch cases, the stream used to write the response was disposed before all the responses were written, resulting in a closed stream exception.

Also, certain async batch operations called synchronous operations under the covers, resulting in an exception regarding calling synchronous operations after an asynchronous operation.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
