### PR TITLE
Fix client-side evaluation for string comparison queries

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
     /// </summary>
     public abstract class ExpressionBinderBase
     {
-        internal static readonly MethodInfo StringCompareMethodInfo = typeof(string).GetMethod("Compare", new[] { typeof(string), typeof(string), typeof(StringComparison) });
+        internal static readonly MethodInfo StringCompareMethodInfo = typeof(string).GetMethod("Compare", new[] { typeof(string), typeof(string) });
         internal static readonly MethodInfo GuidCompareMethodInfo = typeof(ExpressionBinderBase).GetMethod("GuidCompare", new[] { typeof(Guid), typeof(Guid) });
         internal static readonly string DictionaryStringObjectIndexerName = typeof(Dictionary<string, object>).GetDefaultMembers()[0].Name;
 
@@ -37,7 +37,6 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         internal static readonly Expression FalseConstant = Expression.Constant(false);
         internal static readonly Expression TrueConstant = Expression.Constant(true);
         internal static readonly Expression ZeroConstant = Expression.Constant(0);
-        internal static readonly Expression OrdinalStringComparisonConstant = Expression.Constant(StringComparison.Ordinal);
 
         internal static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethods()
                         .Single(m => m.Name == "TryParse" && m.GetParameters().Length == 2);
@@ -160,7 +159,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 right = ToNullable(right);
             }
 
-            if ((left.Type == typeof(Guid) || right.Type == typeof(Guid)))
+            if (left.Type == typeof(Guid) || right.Type == typeof(Guid))
             {
                 left = ConvertNull(left, typeof(Guid));
                 right = ConvertNull(right, typeof(Guid));
@@ -192,7 +191,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                     case BinaryOperatorKind.GreaterThanOrEqual:
                     case BinaryOperatorKind.LessThan:
                     case BinaryOperatorKind.LessThanOrEqual:
-                        left = Expression.Call(StringCompareMethodInfo, left, right, OrdinalStringComparisonConstant);
+                        left = Expression.Call(StringCompareMethodInfo, left, right);
                         right = ZeroConstant;
                         break;
                     default:


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2043 and fixes issue #2078.*

### Description

Entity Framework Core 3.0 [throws an exception](https://docs.microsoft.com/de-de/ef/core/what-is-new/ef-core-3.0/breaking-changes#linq-queries-are-no-longer-evaluated-on-the-client) when the framework can't translate a linq expression to SQL (called: client-side evaluation). 

This PR fixes the special case of [string comparisons](https://github.com/dotnet/efcore/issues/18020). EF Core can translate `string.Compare(string, string)` to SQL but it can't translate any [overload](https://elanderson.net/2018/12/entity-framework-core-string-filter-tips) of `string.Compare`. This is why the `StringComparison` argument gets removed.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
