### PR TITLE
Fix #2056: opertation returns path for the return entity set or singl…

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataOutputFormatterHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataOutputFormatterHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Runtime.Serialization;
@@ -379,6 +380,8 @@ namespace Microsoft.AspNet.OData.Formatter
 
         private static Microsoft.OData.UriParser.ODataPath GeneratePath(IEdmNavigationSource navigationSource)
         {
+            Contract.Assert(navigationSource != null);
+
             switch (navigationSource.NavigationSourceKind())
             {
                 case EdmNavigationSourceKind.EntitySet:
@@ -389,14 +392,11 @@ namespace Microsoft.AspNet.OData.Formatter
 
                 case EdmNavigationSourceKind.ContainedEntitySet:
                     IEdmContainedEntitySet containedEntitySet = (IEdmContainedEntitySet)navigationSource;
-                    var path = GeneratePath(containedEntitySet.ParentNavigationSource);
+                    Microsoft.OData.UriParser.ODataPath path = GeneratePath(containedEntitySet.ParentNavigationSource);
                     IList<ODataPathSegment> segments = new List<ODataPathSegment>();
-                    if (path != null)
+                    foreach (var item in path)
                     {
-                        foreach (var item in path)
-                        {
-                            segments.Add(item);
-                        }
+                        segments.Add(item);
                     }
 
                     segments.Add(new NavigationPropertySegment(containedEntitySet.NavigationProperty, containedEntitySet.ParentNavigationSource));

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataOutputFormatterHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataOutputFormatterHelper.cs
@@ -174,10 +174,9 @@ namespace Microsoft.AspNet.OData.Formatter
             {
                 ServiceRoot = baseAddress,
 
-                // TODO: 1604 Convert webapi.odata's ODataPath to ODL's ODataPath, or use ODL's ODataPath.
                 SelectAndExpand = internalRequest.Context.ProcessedSelectExpandClause,
                 Apply = internalRequest.Context.ApplyClause,
-                Path = (path == null || IsOperationPath(path)) ? null : path.Path,
+                Path = ConvertPath(path),
             };
 
             ODataMetadataLevel metadataLevel = ODataMetadataLevel.MinimalMetadata;
@@ -348,6 +347,66 @@ namespace Microsoft.AspNet.OData.Formatter
             }
 
             return false;
+        }
+
+        private static Microsoft.OData.UriParser.ODataPath ConvertPath(ODataPath path)
+        {
+            if (path == null)
+            {
+                return null;
+            }
+
+            if (IsOperationPath(path))
+            {
+                var lastSegment = path.Segments.Last();
+                OperationSegment operation = lastSegment as OperationSegment;
+                if (operation != null && operation.EntitySet != null)
+                {
+                    return GeneratePath(operation.EntitySet);
+                }
+
+                OperationImportSegment operationImport = lastSegment as OperationImportSegment;
+                if (operationImport != null && operationImport.EntitySet != null)
+                {
+                    return GeneratePath(operationImport.EntitySet);
+                }
+
+                return null;
+            }
+
+            return path.Path;
+        }
+
+        private static Microsoft.OData.UriParser.ODataPath GeneratePath(IEdmNavigationSource navigationSource)
+        {
+            switch (navigationSource.NavigationSourceKind())
+            {
+                case EdmNavigationSourceKind.EntitySet:
+                    return new Microsoft.OData.UriParser.ODataPath(new EntitySetSegment((IEdmEntitySet)navigationSource));
+
+                case EdmNavigationSourceKind.Singleton:
+                    return new Microsoft.OData.UriParser.ODataPath(new SingletonSegment((IEdmSingleton)navigationSource));
+
+                case EdmNavigationSourceKind.ContainedEntitySet:
+                    IEdmContainedEntitySet containedEntitySet = (IEdmContainedEntitySet)navigationSource;
+                    var path = GeneratePath(containedEntitySet.ParentNavigationSource);
+                    IList<ODataPathSegment> segments = new List<ODataPathSegment>();
+                    if (path != null)
+                    {
+                        foreach (var item in path)
+                        {
+                            segments.Add(item);
+                        }
+                    }
+
+                    segments.Add(new NavigationPropertySegment(containedEntitySet.NavigationProperty, containedEntitySet.ParentNavigationSource));
+                    return new Microsoft.OData.UriParser.ODataPath(segments);
+
+                case EdmNavigationSourceKind.None:
+                case EdmNavigationSourceKind.UnknownEntitySet:
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BoundOperation/BoundOperationContextUriTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BoundOperation/BoundOperationContextUriTest.cs
@@ -1,0 +1,224 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.OData.Edm;
+using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Xunit;
+
+namespace Microsoft.Test.E2E.AspNet.OData.BoundOperation
+{
+    public class BoundOperationContextUriTest : WebHostTestBase
+    {
+        public BoundOperationContextUriTest(WebHostTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            var controllers = new[] { typeof(ProjectsController) };
+            configuration.AddControllers(controllers);
+            configuration.Routes.Clear();
+
+            // for Operation context Uri testing
+            configuration.MapODataServiceRoute("odata", "odata", GetEdmModel());
+        }
+
+        [Fact]
+        public async Task BoundFunctionWithNonContainmentReturnTypeWorksWithCorrectContextUri()
+        {
+            // Arrange
+            var requestUri = string.Format("{0}/odata/Projects/Default.GetProjectTask", BaseAddress);
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            HttpResponseMessage response = await Client.SendAsync(request);
+            string responseString = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            Assert.Contains("odata/$metadata#ProjectTasks/$entity", responseString);
+        }
+
+        [Fact]
+        public async Task BoundFunctionWithContainmentReturnTypeWorksWithCorrectContextUri()
+        {
+            // Arrange
+            var requestUri = string.Format("{0}/odata/Projects/Default.GetAssigments", BaseAddress);
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            HttpResponseMessage response = await Client.SendAsync(request);
+            string responseString = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            Assert.Contains("odata/$metadata#ProjectTasks/Assignments", responseString);
+        }
+
+        [Fact]
+        public async Task BoundActionWorksWithNonContainmentReturnTypeWorksWithCorrectContextUri()
+        {
+            // Arrange
+            var requestUri = string.Format("{0}/odata/Projects/Default.UpdateProjectTasks", BaseAddress);
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+
+            // Act
+            HttpResponseMessage response = await Client.SendAsync(request);
+            string responseString = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+
+            Assert.Contains("odata/$metadata#ProjectTasks", responseString);
+        }
+
+        [Fact]
+        public async Task BoundActionWithContainmentReturnTypeWorksWithCorrectContextUri()
+        {
+            // Arrange
+            var requestUri = string.Format("{0}/odata/Projects/Default.UpdateAssignment", BaseAddress);
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+
+            // Act
+            HttpResponseMessage response = await Client.SendAsync(request);
+            string responseString = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+
+            Assert.Contains("odata/$metadata#ProjectTasks/Assignment/$entity", responseString);
+        }
+
+        private static IEdmModel GetEdmModel()
+        {
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<ProjectTask>("ProjectTasks");
+            builder.EntityType<ProjectTaskAssignment>();
+            var projectsConfig = builder.EntitySet<Project>("Projects").EntityType;
+
+            // Action returns "non-Containment"
+            var updateAction = projectsConfig.Collection.Action("UpdateProjectTasks");
+            updateAction.CollectionEntityParameter<ProjectTask>("projectTasks");
+            updateAction.ReturnsCollectionFromEntitySet<ProjectTask>("ProjectTasks");
+
+            // Function returns "non-Containment"
+            var getFunction = projectsConfig.Collection.Function("GetProjectTask");
+            getFunction.ReturnsFromEntitySet<ProjectTask>("ProjectTasks");
+
+            // Action returns "Containment"
+            var action = projectsConfig.Collection.Action("UpdateAssignment");
+            action.ReturnsEntityViaEntitySetPath<ProjectTaskAssignment>("bindingParameter/Task/Assignment");
+
+            // Function returns "Containment"
+            var function = projectsConfig.Collection.Function("GetAssigments");
+            function.ReturnsEntityViaEntitySetPath<ProjectTaskAssignment>("bindingParameter/Tasks/Assignments");
+
+            return builder.GetEdmModel();
+        }
+    }
+
+    #region Controller
+    public class ProjectsController : TestODataController
+    {
+        [HttpGet]
+        public ITestActionResult GetProjectTask([FromBody]ODataActionParameters parameters)
+        {
+            ProjectTask task = new ProjectTask
+            {
+                Id = "1",
+                ProjectId = "11",
+                Assignments = new ProjectTaskAssignment[]
+                {
+                    new ProjectTaskAssignment { Name = "James", Id = "111" }
+                }
+            };
+
+            return Ok(task);
+        }
+
+        [HttpGet]
+        public ITestActionResult GetAssigments([FromBody]ODataActionParameters parameters)
+        {
+            var assignments = new ProjectTaskAssignment[]
+            {
+                new ProjectTaskAssignment { Name = "Kerry", Id = "1" },
+                new ProjectTaskAssignment { Name = "Xu", Id = "1" }
+            };
+
+            return Ok(assignments);
+        }
+
+        [HttpPost]
+        public ITestActionResult UpdateAssignment([FromBody]ODataActionParameters parameters)
+        {
+            ProjectTaskAssignment assignment = new ProjectTaskAssignment
+            {
+                Id = "2",
+                Name = "Peter",
+            };
+
+            return Ok(assignment);
+        }
+
+        [HttpPost]
+        public ITestActionResult UpdateProjectTasks([FromBody]ODataActionParameters parameters)
+        {
+            var tasks = new ProjectTask[]
+            {
+                new ProjectTask
+                {
+                    Id = "1",
+                    ProjectId = "11",
+                    Assignments = new ProjectTaskAssignment[]
+                    {
+                        new ProjectTaskAssignment { Name = "John", Id = "1" }
+                    }
+                }
+            };
+
+            return Ok(tasks);
+        }
+    }
+    #endregion
+
+    #region ProjectsModel
+
+    public class Project
+    {
+        public string Id { get; set; }
+
+        public ProjectTask Task { get; set; }
+
+        public virtual ICollection<ProjectTask> Tasks { get; set; }
+    }
+
+    public class ProjectTask
+    {
+        public string Id { get; set; }
+
+        public string ProjectId { get; set; }
+
+        [Contained]
+        public ProjectTaskAssignment Assignment { get; set; }
+
+        [Contained]
+        public virtual ICollection<ProjectTaskAssignment> Assignments { get; set; }
+    }
+
+    public class ProjectTaskAssignment
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    #endregion
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -217,6 +217,9 @@
     <Compile Include="..\BoundOperation\BoundOperationTest.cs">
       <Link>BoundOperation\BoundOperationTest.cs</Link>
     </Compile>
+    <Compile Include="..\BoundOperation\BoundOperationContextUriTest.cs">
+      <Link>BoundOperation\BoundOperationContextUriTest.cs</Link>
+    </Compile>
     <Compile Include="..\Cast\CastContext.cs">
       <Link>Cast\CastContext.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -175,6 +175,9 @@
     <Compile Include="..\BoundOperation\BoundOperationTest.cs">
       <Link>BoundOperation\BoundOperationTest.cs</Link>
     </Compile>
+    <Compile Include="..\BoundOperation\BoundOperationContextUriTest.cs">
+      <Link>BoundOperation\BoundOperationContextUriTest.cs</Link>
+    </Compile>
     <Compile Include="..\Cast\CastContext.cs">
       <Link>Cast\CastContext.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
@@ -188,6 +188,9 @@
     <Compile Include="..\BoundOperation\BoundOperationTest.cs">
       <Link>BoundOperation\BoundOperationTest.cs</Link>
     </Compile>
+    <Compile Include="..\BoundOperation\BoundOperationContextUriTest.cs">
+      <Link>BoundOperation\BoundOperationContextUriTest.cs</Link>
+    </Compile>
     <Compile Include="..\Cast\CastContext.cs">
       <Link>Cast\CastContext.cs</Link>
     </Compile>


### PR DESCRIPTION
…eton

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue ##2056.*

### Description

* If Operation returns "entity set". we should set the "Path" on "WriterSetting" for that "entity set".

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
