### PR TITLE
Batch request headers copied to individual requests

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -307,6 +307,7 @@ namespace Microsoft.AspNet.OData.Batch
             {
                 return batchPreferences;
             }
+
             if (string.IsNullOrEmpty(batchPreferences))
             {
                 return individualPreferences;
@@ -314,7 +315,7 @@ namespace Microsoft.AspNet.OData.Batch
             // get the name of each preference to avoid adding duplicates from batch
             IEnumerable<string> individualList = individualPreferences.SplitPreferences().Select(pref => pref.Trim());
             HashSet<string> individualPreferenceNames = new HashSet<string>(individualList.Select(pref => pref.Split('=').FirstOrDefault()));
-            
+
             
             IEnumerable<string> filteredBatchList = batchPreferences.SplitPreferences().Select(pref => pref.Trim())
                 // do not add duplicate preferences from batch

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -293,13 +293,12 @@ namespace Microsoft.AspNet.OData.Batch
         private static string GetPreferencesToInheritFromBatch(string batchPreferences)
         {
             IEnumerable<string> preferencesToInherit = SplitPreferences(batchPreferences)
-                .Where(value => 
+                .Where(value =>
                     !nonInheritablePreferences.Any(
-                        prefToIgnore => 
-                        value.Trim().ToLowerInvariant().StartsWith(prefToIgnore)
+                        prefToIgnore =>
+                        value.ToLowerInvariant().StartsWith(prefToIgnore)
                     )
-                )
-                .Select(value => value.Trim());
+                );
             return string.Join(", ", preferencesToInherit);
         }
 
@@ -323,11 +322,11 @@ namespace Microsoft.AspNet.OData.Batch
                 return individualPreferences;
             }
             // get the name of each preference to avoid adding duplicates from batch
-            IEnumerable<string> individualList = SplitPreferences(individualPreferences).Select(pref => pref.Trim());
+            IEnumerable<string> individualList = SplitPreferences(individualPreferences);
             HashSet<string> individualPreferenceNames = new HashSet<string>(individualList.Select(pref => pref.Split('=').FirstOrDefault()));
 
             
-            IEnumerable<string> filteredBatchList = SplitPreferences(batchPreferences).Select(pref => pref.Trim())
+            IEnumerable<string> filteredBatchList = SplitPreferences(batchPreferences)
                 // do not add duplicate preferences from batch
                 .Where(pref => !individualPreferenceNames.Contains(pref.Split('=').FirstOrDefault()));
             string filteredBatchPreferences = string.Join(", ", filteredBatchList);
@@ -369,8 +368,8 @@ namespace Microsoft.AspNet.OData.Batch
                 }
                 else if (c == ',' && !insideQuotedValue)
                 {
-                    string result = preferences.Substring(preferenceStartIndex, currentIndex - preferenceStartIndex);
-                    string prefName = result.Split('=')[0];
+                    string result = preferences.Substring(preferenceStartIndex, currentIndex - preferenceStartIndex).Trim();
+                    string prefName = result.Split('=')[0].Trim();
                     // do not add duplicate preference
                     if (!addedPreferences.Contains(prefName))
                     {
@@ -384,7 +383,7 @@ namespace Microsoft.AspNet.OData.Batch
 
             if (preferences.Length > preferenceStartIndex + 1)
             {
-                yield return preferences.Substring(preferenceStartIndex);
+                yield return preferences.Substring(preferenceStartIndex).Trim();
             }
         }
     }

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.OData.Common;
@@ -27,6 +26,8 @@ namespace Microsoft.AspNet.OData.Batch
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class ODataBatchReaderExtensions
     {
+        private static readonly string[] NonInHeritableHeaders = new string[] { "content-length", "content-type" };
+
         /// <summary>
         /// Reads a ChangeSet request.
         /// </summary>
@@ -251,8 +252,7 @@ namespace Microsoft.AspNet.OData.Batch
             {
                 var headerKey = header.Key.ToLowerInvariant();
                 // do not copy over headers that should not be inherited from batch to individual requests
-                if (headerKey == "content-length" ||
-                    headerKey == "content-type")
+                if (NonInHeritableHeaders.Contains(headerKey))
                 {
                     continue;
                 }

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -299,7 +299,7 @@ namespace Microsoft.AspNet.OData.Batch
                         value.ToLowerInvariant().StartsWith(prefToIgnore)
                     )
                 );
-            return string.Join(", ", preferencesToInherit);
+            return string.Join(",", preferencesToInherit);
         }
 
         /// <summary>
@@ -329,9 +329,9 @@ namespace Microsoft.AspNet.OData.Batch
             IEnumerable<string> filteredBatchList = SplitPreferences(batchPreferences)
                 // do not add duplicate preferences from batch
                 .Where(pref => !individualPreferenceNames.Contains(pref.Split('=').FirstOrDefault()));
-            string filteredBatchPreferences = string.Join(", ", filteredBatchList);
+            string filteredBatchPreferences = string.Join(",", filteredBatchList);
 
-            return string.Join(", ", individualPreferences, filteredBatchPreferences);
+            return string.Join(",", individualPreferences, filteredBatchPreferences);
         }
 
         /// <summary>

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
@@ -608,27 +608,27 @@ Accept-Charset: UTF-8
                         )
                     },
                     {
-                        // should correctly handle preferences using ; as separator
+                        // should correctly handle preferences that contain parameters
                         new Dictionary<string, string>()
                         {
-                            { "Prefer", "allow-entityreferences; respond-async; include-annotations=\"display.*\"; continue-on-error; wait=200" }
+                            { "Prefer", "allow-entityreferences, respond-async, foo; param=paramValue, include-annotations=\"display.*\", continue-on-error, wait=200" }
                         },
                         (
-                        "GET,ContentType=,ContentLength=,Prefer=allow-entityreferences, include-annotations=\\\"display.*\\\", wait=200",
-                        "DELETE,ContentType=,ContentLength=,Prefer=wait=100, handling=lenient, allow-entityreferences, include-annotations=\\\"display.*\\\"",
-                        "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences, include-annotations=\\\"display.*\\\", wait=200"
+                        "GET,ContentType=,ContentLength=,Prefer=allow-entityreferences, foo; param=paramValue, include-annotations=\\\"display.*\\\", wait=200",
+                        "DELETE,ContentType=,ContentLength=,Prefer=wait=100, handling=lenient, allow-entityreferences, foo; param=paramValue, include-annotations=\\\"display.*\\\"",
+                        "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences, foo; param=paramValue, include-annotations=\\\"display.*\\\", wait=200"
                         )
                     },
                     {
                         // should correctly parse preferences with commas in their quoted values
                         new Dictionary<string, string>()
                         {
-                            { "Prefer", @"allow-entityreferences; respond-async; include-annotations=""display.*,foo""; continue-on-error; wait=""200;\""300""" }
+                            { "Prefer", @"allow-entityreferences, respond-async, include-annotations=""display.*,foo"", continue-on-error, wait=""200,\""300""" }
                         },
                         (
-                        @"GET,ContentType=,ContentLength=,Prefer=allow-entityreferences, include-annotations=\""display.*,foo\"", wait=\""200;\\\""300\""",
+                        @"GET,ContentType=,ContentLength=,Prefer=allow-entityreferences, include-annotations=\""display.*,foo\"", wait=\""200,\\\""300\""",
                         @"DELETE,ContentType=,ContentLength=,Prefer=wait=100, handling=lenient, allow-entityreferences, include-annotations=\""display.*,foo\""",
-                        @"POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences, include-annotations=\""display.*,foo\"", wait=\""200;\\\""300\"""
+                        @"POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences, include-annotations=\""display.*,foo\"", wait=\""200,\\\""300\"""
                         )
                     }
                 };

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,12 +13,12 @@ using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
 using Xunit;
-using Newtonsoft.Json;
 #if !NETCORE
 using System.Web.Http;
 using System.Web.Http.Routing;
 #else
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 #endif
 
 namespace Microsoft.AspNet.OData.Test.Batch

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
@@ -548,7 +548,7 @@ Accept-Charset: UTF-8
                 // should not copy over content type and content length headers to individual request
                 Enumerable.Empty<string>(),
                 "GET,ContentType=,ContentLength=,Prefer=",
-                "DELETE,ContentType=,ContentLength=,Prefer=wait=100, handling=lenient",
+                "DELETE,ContentType=,ContentLength=,Prefer=wait=100,handling=lenient",
                 "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer="
             },
             {
@@ -558,7 +558,7 @@ Accept-Charset: UTF-8
                     "respond-async, odata.continue-on-error"
                 },
                 "GET,ContentType=,ContentLength=,Prefer=",
-                "DELETE,ContentType=,ContentLength=,Prefer=wait=100, handling=lenient",
+                "DELETE,ContentType=,ContentLength=,Prefer=wait=100,handling=lenient",
                 "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer="
             },
             {
@@ -568,9 +568,9 @@ Accept-Charset: UTF-8
                 {
                     "allow-entityreferences, include-annotations=\"display.*\""
                 },
-                "GET,ContentType=,ContentLength=,Prefer=allow-entityreferences, include-annotations=\\\"display.*\\\"",
-                "DELETE,ContentType=,ContentLength=,Prefer=wait=100, handling=lenient, allow-entityreferences, include-annotations=\\\"display.*\\\"",
-                "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences, include-annotations=\\\"display.*\\\""
+                "GET,ContentType=,ContentLength=,Prefer=allow-entityreferences,include-annotations=\\\"display.*\\\"",
+                "DELETE,ContentType=,ContentLength=,Prefer=wait=100,handling=lenient,allow-entityreferences,include-annotations=\\\"display.*\\\"",
+                "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences,include-annotations=\\\"display.*\\\""
             },
             {
                 // if batch Prefer header contains both inheritable and non-inheritable preferences,
@@ -579,9 +579,9 @@ Accept-Charset: UTF-8
                 {
                     "allow-entityreferences, respond-async, include-annotations=\"display.*\", continue-on-error"
                 },
-                "GET,ContentType=,ContentLength=,Prefer=allow-entityreferences, include-annotations=\\\"display.*\\\"",
-                "DELETE,ContentType=,ContentLength=,Prefer=wait=100, handling=lenient, allow-entityreferences, include-annotations=\\\"display.*\\\"",
-                "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences, include-annotations=\\\"display.*\\\""
+                "GET,ContentType=,ContentLength=,Prefer=allow-entityreferences,include-annotations=\\\"display.*\\\"",
+                "DELETE,ContentType=,ContentLength=,Prefer=wait=100,handling=lenient,allow-entityreferences,include-annotations=\\\"display.*\\\"",
+                "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences,include-annotations=\\\"display.*\\\""
             },
             {
                 // if batch and individual request define the same preference, then the one from the individual request should be retained
@@ -589,9 +589,9 @@ Accept-Charset: UTF-8
                 {
                    "allow-entityreferences, respond-async, include-annotations=\"display.*\", continue-on-error, wait=200"
                 },
-                "GET,ContentType=,ContentLength=,Prefer=allow-entityreferences, include-annotations=\\\"display.*\\\", wait=200",
-                "DELETE,ContentType=,ContentLength=,Prefer=wait=100, handling=lenient, allow-entityreferences, include-annotations=\\\"display.*\\\"",
-                "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences, include-annotations=\\\"display.*\\\", wait=200"
+                "GET,ContentType=,ContentLength=,Prefer=allow-entityreferences,include-annotations=\\\"display.*\\\",wait=200",
+                "DELETE,ContentType=,ContentLength=,Prefer=wait=100,handling=lenient,allow-entityreferences,include-annotations=\\\"display.*\\\"",
+                "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences,include-annotations=\\\"display.*\\\",wait=200"
             },
             {
                 // should correctly handle preferences that contain parameters
@@ -599,9 +599,9 @@ Accept-Charset: UTF-8
                 {
                     "allow-entityreferences, respond-async, foo; param=paramValue,include-annotations=\"display.*\", continue-on-error, wait=200"
                 },
-                "GET,ContentType=,ContentLength=,Prefer=allow-entityreferences, foo; param=paramValue, include-annotations=\\\"display.*\\\", wait=200",
-                "DELETE,ContentType=,ContentLength=,Prefer=wait=100, handling=lenient, allow-entityreferences, foo; param=paramValue, include-annotations=\\\"display.*\\\"",
-                "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences, foo; param=paramValue, include-annotations=\\\"display.*\\\", wait=200"
+                "GET,ContentType=,ContentLength=,Prefer=allow-entityreferences,foo; param=paramValue,include-annotations=\\\"display.*\\\",wait=200",
+                "DELETE,ContentType=,ContentLength=,Prefer=wait=100,handling=lenient,allow-entityreferences,foo; param=paramValue,include-annotations=\\\"display.*\\\"",
+                "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences,foo; param=paramValue,include-annotations=\\\"display.*\\\",wait=200"
             },
             {
                 // should correctly parse preferences with commas in their quoted values
@@ -609,9 +609,9 @@ Accept-Charset: UTF-8
                 {
                     @"allow-entityreferences, respond-async, include-annotations=""display.*,foo"", continue-on-error, wait=""200,\""300"""
                 },
-                @"GET,ContentType=,ContentLength=,Prefer=allow-entityreferences, include-annotations=\""display.*,foo\"", wait=\""200,\\\""300\""",
-                @"DELETE,ContentType=,ContentLength=,Prefer=wait=100, handling=lenient, allow-entityreferences, include-annotations=\""display.*,foo\""",
-                @"POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences, include-annotations=\""display.*,foo\"", wait=\""200,\\\""300\"""
+                @"GET,ContentType=,ContentLength=,Prefer=allow-entityreferences,include-annotations=\""display.*,foo\"",wait=\""200,\\\""300\""",
+                @"DELETE,ContentType=,ContentLength=,Prefer=wait=100,handling=lenient,allow-entityreferences,include-annotations=\""display.*,foo\""",
+                @"POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences,include-annotations=\""display.*,foo\"",wait=\""200,\\\""300\"""
             },
             {
                 // should correctly handle batch request with multiple Prefer headers and should not copy duplicate references
@@ -620,9 +620,9 @@ Accept-Charset: UTF-8
                     @"allow-entityreferences, respond-async, wait=300",
                     @"continue-on-error, wait=250, include-annotations=display"
                 },
-                @"GET,ContentType=,ContentLength=,Prefer=allow-entityreferences, wait=300, include-annotations=display",
-                @"DELETE,ContentType=,ContentLength=,Prefer=wait=100, handling=lenient, allow-entityreferences, include-annotations=display",
-                @"POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences, wait=300, include-annotations=display"
+                @"GET,ContentType=,ContentLength=,Prefer=allow-entityreferences,wait=300,include-annotations=display",
+                @"DELETE,ContentType=,ContentLength=,Prefer=wait=100,handling=lenient,allow-entityreferences,include-annotations=display",
+                @"POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer=allow-entityreferences,wait=300,include-annotations=display"
             }
         };
 
@@ -678,7 +678,7 @@ OData-Version: 4.0
 OData-MaxVersion: 4.0
 Accept: application/json;odata.metadata=minimal
 Accept-Charset: UTF-8
-Prefer: wait=100, handling=lenient
+Prefer: wait=100,handling=lenient
 
 
 --{batchRef}

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
@@ -467,7 +467,7 @@ namespace Microsoft.AspNet.OData.Test.Batch
             const string acceptJsonFullMetadata = "application/json;odata.metadata=minimal";
             const string acceptJson = "application/json";
 
-            Type[] controllers = new[] { typeof(BatchTestHeadersCustomersController), typeof(BatchTestOrdersController), };
+            Type[] controllers = new[] { typeof(BatchTestCustomersController), typeof(BatchTestOrdersController), };
             var server = TestServerFactory.Create(controllers, (config) =>
             {
                 var builder = ODataConventionModelBuilderFactory.Create(config);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2055. *

The batch request handler in AspNetCore WebApi copies headers from the overall batch request to each individual request inside the batch, unless the individual request specify the same headers, in which case they replace the inherited ones.
However, not all headers should be copied, in particular: `Content-Length`, `Content-Type`, some preferences from the `Prefer` header such as `respond-async`, `continue-on-error` and `odata.continue-on-error`.

### Description

I've added some restrictions on how headers are copied from a batch request to individual requests inside the batch:
- `Content-Length` and `Content-Type` headers are no longer copied to individual requests
- I've implemented the following rules for the `Prefer` header:
  - Preferences from the `Prefer` header are copied to individual requests except for `respond-async`, `continue-on-error` and `odata.continue-on-error` preferences.
  - If the individual request already had a `Prefer` header, then the individual request will end up with its own preferences merged with those inherited from the batch request 
  - The individual request will not receive a preference from the batch that is already defined in the individual request

Here's a concrete example to demonstrate how preference headers from the batch and individual requests are merged:

If the overal batch request define the following prefer header:
```http
Prefer: allow-entityreferences, respond-async, include-annotations="display.*,foo", continue-on-error; wait="200;\"300"
```
And an individual request inside the batch specifies the following:
```http
Prefer: wait=100, handling=lenient
```
then the final preference header for the individual request will be:
```http
Prefer: wait=100, handling=lenient, allow-entityreferences; include-annotations="display.*,foo"
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary


This implementation has the following issues:
- In the case that the batch had defined multiple `Prefer` headers, only the first one is considered. How should this case be handled?

This PR implements the rules only for AspNetCore. AspNet does not copy headers from the batch to the individual requests.