### PR TITLE
Fix some building problems

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -127,9 +127,9 @@ ForEach ($directory in $SysDirectory::EnumerateDirectories($PROGRAMFILESX86 + "\
 
     # remove the last char 'A'
     $directoryName = $directoryName.substring(0, $directoryName.LastIndexOf('A'))
-
+    
     # parse to double "10.0"
-    $versionNo = [System.Double]::Parse($directoryName)
+    $versionNo = [System.Double]::Parse($directoryName, [System.Globalization.CultureInfo]::InvariantCulture)
 
     $fileobject = $null
     $fileobject = New-Object System.Object

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.0" />
     <PackageReference Include="Microsoft.OData.Client" Version="7.6.1" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="4.7.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Minor build process fixes

### Description

- build.ps1: problem with build in international system environment
- Microsoft.Test.E2E.AspNetCore3x.OData.csproj - missing PackageReference added (see build errors below)
     4>C:\ProjectsG\Attis\Labs\OData\Github\WebApi\test\E2ETest\Microsoft.Test.E2E.AspNet.OData\QueryComposition\ServerTypeTests.cs(89,25): error CS1069: The type name 'EventLog' could not be found in the namespace 'System.Diagnostics'. This type has been forwarded to assembly 'System.Diagnostics.EventLog, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' Consider adding a reference to that assembly. [C:\ProjectsG\Attis\Labs\OData\Github\WebApi\test\E2ETest\Microsoft.Test.E2E.AspNet.OData\Build.AspNetCore3x\Microsoft.Test.E2E.AspNetCore3x.OData.csproj]
     4>C:\ProjectsG\Attis\Labs\OData\Github\WebApi\test\E2ETest\Microsoft.Test.E2E.AspNet.OData\QueryComposition\ServerTypeTests.cs(89,47): error CS1069: The type name 'EventLog' could not be found in the namespace 'System.Diagnostics'. This type has been forwarded to assembly 'System.Diagnostics.EventLog, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' Consider adding a reference to that assembly. [C:\ProjectsG\Attis\Labs\OData\Github\WebApi\test\E2ETest\Microsoft.Test.E2E.AspNet.OData\Build.AspNetCore3x\Microsoft.Test.E2E.AspNetCore3x.OData.csproj]
     4>C:\ProjectsG\Attis\Labs\OData\Github\WebApi\test\E2ETest\Microsoft.Test.E2E.AspNet.OData\QueryComposition\ServerTypeTests.cs(93,29): error CS0103: The name 'EventLogEntryType' does not exist in the current context [C:\ProjectsG\Attis\Labs\OData\Github\WebApi\test\E2ETest\Microsoft.Test.E2E.AspNet.OData\Build.AspNetCore3x\Microsoft.Test.E2E.AspNetCore3x.OData.csproj]
     4>C:\ProjectsG\Attis\Labs\OData\Github\WebApi\test\E2ETest\Microsoft.Test.E2E.AspNet.OData\QueryComposition\ServerTypeTests.cs(115,61): error CS0103: The name 'EventLogEntryType' does not exist in the current context [C:\ProjectsG\Attis\Labs\OData\Github\WebApi\test\E2ETest\Microsoft.Test.E2E.AspNet.OData\Build.AspNetCore3x\Microsoft.Test.E2E.AspNetCore3x.OData.csproj]
     4>Done Building Project "C:\ProjectsG\Attis\Labs\OData\Github\WebApi\test\E2ETest\Microsoft.Test.E2E.AspNet.OData\Build.AspNetCore3x\Microsoft.Test.E2E.AspNetCore3x.OData.csproj" (default targets) -- FAILED.

### Checklist (Uncheck if it is not completed)

- NOT applicable: [ ] *Test cases added*
- NOT applicable: [ ] *Build and test with one-click build and test script passed*

### Additional work necessary
NONE