### PR TITLE
Added default count support in accordance with http://docs.oasis-open…

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
@@ -947,8 +947,7 @@ namespace Microsoft.AspNet.OData.Query
                         RawValues.Select = kvp.Value;
                         break;
                     case "$count":
-                        ThrowIfEmpty(kvp.Value, "$count");
-                        RawValues.Count = kvp.Value;
+                        RawValues.Count = kvp.Value ?? "true";
                         Count = new CountQueryOption(kvp.Value, Context, _queryOptionParser);
                         break;
                     case "$expand":

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/ODataQueryOptionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/ODataQueryOptionTest.cs
@@ -219,7 +219,6 @@ namespace Microsoft.AspNet.OData.Test.Query
 
         [Theory]
         [InlineData("$filter")]
-        [InlineData("$count")]
         [InlineData("$orderby")]
         [InlineData("$skip")]
         [InlineData("$top")]


### PR DESCRIPTION
….org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#_Toc31360944

<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #2091.

### Description

Removed ThrowIfEmptyCheck for count operation in BuildQueryOptions. 
Added a default value of true to provide compliance with the odata specificiation.
Removed inline["$count"] data checks on the unit tests

### Checklist (Uncheck if it is not completed)

- [N/A ] *Test cases added*
- [ X] *Build and test with one-click build and test script passed*

