### PR TITLE
Add the parameter name when create the parameter expression

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         {
             Type elementType = selectExpandQuery.Context.ElementClrType;
             IEdmNavigationSource navigationSource = selectExpandQuery.Context.NavigationSource;
-            ParameterExpression source = Expression.Parameter(elementType);
+            ParameterExpression source = Expression.Parameter(elementType, "$it");
 
             // expression looks like -> new Wrapper { Instance = source , Properties = "...", Container = new PropertyContainer { ... } }
             Expression projectionExpression = ProjectElement(source, selectExpandQuery.SelectExpandClause, _context.ElementType as IEdmStructuredType, navigationSource);
@@ -961,7 +961,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         {
             // structuralType could be null, because it can be primitive collection.
 
-            ParameterExpression element = Expression.Parameter(elementType);
+            ParameterExpression element = Expression.Parameter(elementType, "$it");
 
             Expression projection;
             // expression

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
@@ -133,9 +133,9 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             var unaryExpression = (UnaryExpression)((MethodCallExpression)queryable.Expression).Arguments.Single(a => a is UnaryExpression);
             var expressionString = unaryExpression.Operand.ToString();
 #if NETCORE
-            Assert.Contains("IsNull = (Convert(Param_1.Customer.Id, Nullable`1) == null)}", expressionString);
+            Assert.Contains("IsNull = (Convert($it.Customer.Id, Nullable`1) == null)}", expressionString);
 #else
-            Assert.Contains("IsNull = (Convert(Param_1.Customer.Id) == null)}", expressionString);
+            Assert.Contains("IsNull = (Convert($it.Customer.Id) == null)}", expressionString);
 #endif
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2080.*

### Description

#### Expression.Parameter(...):
https://docs.microsoft.com/en-us/dotnet/api/system.linq.expressions.expression.parameter?f1url=https%3A%2F%2Fmsdn.microsoft.com%2Fquery%2Fdev16.query%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(System.Linq.Expressions.Expression.Parameter);k(SolutionItemsProject);k(DevLang-csharp)%26rd%3Dtrue&view=netframework-4.8

**_name
String
The name of the parameter or variable,  used for debugging or printing purpose only. _**

#### EF core 3.x

https://github.com/dotnet/efcore/blob/release/3.1/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs#L940-L941

It simply access the Parameter.Name

#### EF core 2.x 

https://github.com/dotnet/efcore/blob/release/2.1/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
There's no codes related EF Core 3.1

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
