### PR TITLE
Revert the default null propagation to false for EF Core

### DIFF
--- a/sln/WebApiOData.E2E.AspNetCore.sln
+++ b/sln/WebApiOData.E2E.AspNetCore.sln
@@ -22,6 +22,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Test.E2E.AspNetCo
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\src\Microsoft.AspNet.OData.Shared\Microsoft.AspNet.OData.Shared.projitems*{3571a6b6-b859-4fa2-a96f-40956bfc3837}*SharedItemsImports = 5
 		..\src\Microsoft.AspNet.OData.Shared\Microsoft.AspNet.OData.Shared.projitems*{b6b951b6-c3f0-4b8e-8955-e039145e7dec}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Microsoft.AspNet.OData.Shared/Query/HandleNullPropagationOptionHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/HandleNullPropagationOptionHelper.cs
@@ -46,13 +46,16 @@ namespace Microsoft.AspNet.OData.Query
                 case Linq2SqlQueryProviderNamespace:
                 case ObjectContextQueryProviderNamespaceEF5:
                 case ObjectContextQueryProviderNamespaceEF6:
-             
+
+                // EF Core before 3.0 does a lot of client evaluations and has InMemory support which is the same as Linq2Objects
+                // We have to keep the null propagation for EF Core 3.0, otherwise, there's some issues for example:
+                // $expand=Collection, $select=Collection
+                case ObjectContextQueryProviderNamespaceEFCore2:
                     options = HandleNullPropagationOption.False;
                     break;
-                
+
                 case Linq2ObjectsQueryProviderNamespace:
-                // EF Core before 3.0 does a lot of client evaluations and has InMemory support which is the same as Linq2Objects
-                case ObjectContextQueryProviderNamespaceEFCore2: 
+                
                 default:
                     options = HandleNullPropagationOption.True;
                     break;

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Aggregation/AggregationTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Aggregation/AggregationTests.cs
@@ -683,7 +683,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Aggregation
             string queryUrl =
                 string.Format(
                     AggregationTestBaseUrl + "?$apply=groupby((Name), aggregate(Order/Price with sum as TotalAmount))"
-                    + "/compute(TotalAmount mul 2 as DoubleAmount, length(Name) as NameLen)"
+                    + "/filter(Name ne null)/compute(TotalAmount mul 2 as DoubleAmount, length(Name) as NameLen)"
                     + "&$orderby=TotalAmount",
                     BaseAddress);
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
@@ -699,19 +699,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.Aggregation
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             var results = result["value"] as JArray;
-            Assert.Equal(3, results.Count);
-            Assert.Equal("0", results[0]["TotalAmount"].ToString());
-            Assert.Equal("0", results[0]["DoubleAmount"].ToString());
-            Assert.Equal(JValue.CreateNull(), results[0]["NameLen"]);
-            Assert.Equal(JValue.CreateNull(), results[0]["Name"]);
-            Assert.Equal("2000", results[1]["TotalAmount"].ToString());
-            Assert.Equal("4000", results[1]["DoubleAmount"].ToString());
+            Assert.Equal(2, results.Count);
+            Assert.Equal("2000", results[0]["TotalAmount"].ToString());
+            Assert.Equal("4000", results[0]["DoubleAmount"].ToString());
+            Assert.Equal("9", results[0]["NameLen"].ToString());
+            Assert.Equal("Customer0", results[0]["Name"].ToString());
+            Assert.Equal("2500", results[1]["TotalAmount"].ToString());
+            Assert.Equal("5000", results[1]["DoubleAmount"].ToString());
             Assert.Equal("9", results[1]["NameLen"].ToString());
-            Assert.Equal("Customer0", results[1]["Name"].ToString());
-            Assert.Equal("2500", results[2]["TotalAmount"].ToString());
-            Assert.Equal("5000", results[2]["DoubleAmount"].ToString());
-            Assert.Equal("9", results[2]["NameLen"].ToString());
-            Assert.Equal("Customer1", results[2]["Name"].ToString());
+            Assert.Equal("Customer1", results[1]["Name"].ToString());
         }
 
         [Fact]
@@ -720,7 +716,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Aggregation
             // Arrange
             string queryUrl =
                 string.Format(
-                    AggregationTestBaseUrl + "?$apply=compute(length(Name) as NameLen)/groupby((Name), aggregate(Id with sum as TotalId, NameLen with max as NameLen))"
+                    AggregationTestBaseUrl + "?$apply=filter(Name ne null)/compute(length(Name) as NameLen)/groupby((Name), aggregate(Id with sum as TotalId, NameLen with max as NameLen))"
                     + "&$orderby=TotalId",
                     BaseAddress);
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
@@ -736,16 +732,13 @@ namespace Microsoft.Test.E2E.AspNet.OData.Aggregation
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             var results = result["value"] as JArray;
-            Assert.Equal(3, results.Count);
-            Assert.Equal("10", results[0]["TotalId"].ToString());
-            Assert.Equal(JValue.CreateNull(), results[0]["NameLen"]);
-            Assert.Equal(JValue.CreateNull(), results[0]["Name"]);
-            Assert.Equal("20", results[1]["TotalId"].ToString());
+            Assert.Equal(2, results.Count);
+            Assert.Equal("20", results[0]["TotalId"].ToString());
+            Assert.Equal("9", results[0]["NameLen"].ToString());
+            Assert.Equal("Customer0", results[0]["Name"].ToString());
+            Assert.Equal("25", results[1]["TotalId"].ToString());
             Assert.Equal("9", results[1]["NameLen"].ToString());
-            Assert.Equal("Customer0", results[1]["Name"].ToString());
-            Assert.Equal("25", results[2]["TotalId"].ToString());
-            Assert.Equal("9", results[2]["NameLen"].ToString());
-            Assert.Equal("Customer1", results[2]["Name"].ToString());
+            Assert.Equal("Customer1", results[1]["Name"].ToString());
         }
 
         [Fact]
@@ -754,7 +747,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Aggregation
             // Arrange
             string queryUrl =
                 string.Format(
-                    AggregationTestBaseUrl + "?$apply=compute(length(Name) as NameLen)",
+                    AggregationTestBaseUrl + "?$apply=compute(length(Name) as NameLen)&$filter=Name ne null",
                     BaseAddress);
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
@@ -769,7 +762,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Aggregation
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             var results = result["value"] as JArray;
-            Assert.Equal(10, results.Count);
+            Assert.Equal(9, results.Count);
             foreach (var customer in results)
             {
                 Assert.NotNull(customer["Id"]);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2080 .*

### Description

The following change makes $select=Collection and $expand=Collection scenarios failing within EF Core 3.x

![image](https://user-images.githubusercontent.com/9426627/78837996-157aec00-79aa-11ea-83c5-0d326659f2b2.png)

This PR is to revert the default behavior of Null propagation to false for EF Core. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
