### PR TITLE
Remove the null check, fix issue #1755

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -786,8 +786,6 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 return;
             }
 
-            Expression nullCheck = GetNullCheckExpression(structuralProperty, propertyValue, subSelectExpandClause);
-
             Expression countExpression = CreateTotalCountExpression(propertyValue, pathSelectItem.CountOption);
 
             // be noted: the property structured type could be null, because the property maybe not a complex property.
@@ -808,11 +806,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             NamedPropertyExpression propertyExpression = new NamedPropertyExpression(propertyName, propertyValue);
             if (subSelectExpandClause != null)
             {
-                if (!structuralProperty.Type.IsCollection())
-                {
-                     propertyExpression.NullCheck = nullCheck;
-                }
-                else if (_settings.PageSize.HasValue)
+                if (structuralProperty.Type.IsCollection() && _settings.PageSize.HasValue)
                 {
                     propertyExpression.PageSize = _settings.PageSize.Value;
                 }
@@ -902,23 +896,6 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             }
 
             return source;
-        }
-
-        private static Expression GetNullCheckExpression(IEdmStructuralProperty propertyToInclude, Expression propertyValue,
-            SelectExpandClause projection)
-        {
-            if (projection == null || propertyToInclude.Type.IsCollection())
-            {
-                return null;
-            }
-
-            if (IsSelectAll(projection) && propertyToInclude.Type.IsComplex())
-            {
-                // for Collections (Primitive, Enum, Complex collection), that's check above.
-                return Expression.Equal(propertyValue, Expression.Constant(null));
-            }
-
-            return null;
         }
 
         private Expression GetNullCheckExpression(IEdmNavigationProperty propertyToExpand, Expression propertyValue,

--- a/src/Microsoft.AspNet.OData.Shared/Query/HandleNullPropagationOptionHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/HandleNullPropagationOptionHelper.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNet.OData.Query
                     break;
 
                 case Linq2ObjectsQueryProviderNamespace:
-                
+
                 default:
                     options = HandleNullPropagationOption.True;
                     break;
@@ -63,5 +63,47 @@ namespace Microsoft.AspNet.OData.Query
 
             return options;
         }
+
+        public static DataSourceProviderKind GetDataSourceProviderKind(this IQueryable query)
+        {
+            string queryProviderNamespace = query.Provider.GetType().Namespace;
+            switch (queryProviderNamespace)
+            {
+                case ObjectContextQueryProviderNamespaceEF5:
+                    return DataSourceProviderKind.EF5;
+
+                case ObjectContextQueryProviderNamespaceEF6:
+                    return DataSourceProviderKind.EF6;
+
+                case ObjectContextQueryProviderNamespaceEFCore2:
+                    return DataSourceProviderKind.EFCore;
+
+                default:
+                    return DataSourceProviderKind.None;
+            }
+        }
+    }
+
+    internal enum DataSourceProviderKind
+    {
+        /// <summary>
+        /// None Data source provider
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// EF 5 Data source provider
+        /// </summary>
+        EF5,
+
+        /// <summary>
+        /// EF 6 Data source provider
+        /// </summary>
+        EF6,
+
+        /// <summary>
+        /// EF Core Data source provider
+        /// </summary>
+        EFCore
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue https://github.com/OData/odata.net/issues/1755.*

https://github.com/OData/WebApi/issues/2281


### Description

* SelectExpandBinder generates the "Null" expression can't work for "EntityFramework6".

```
IsNull = .If ($$it == null) {
            null
        } .Else {
            $$it.Description
        } == null
```

However, it seems we don't need the "IsNull" check for the complex. So, let's remove this.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
