### PR TITLE
Fix #2144 and #2141: the context Uri and location wrong with PathBase setting

### DIFF
--- a/samples/AspNetCore3xEndpointSample.Web/Controllers/CustomersController.cs
+++ b/samples/AspNetCore3xEndpointSample.Web/Controllers/CustomersController.cs
@@ -86,5 +86,21 @@ namespace AspNetCore3xEndpointSample.Web.Controllers
         {
             return Ok(_context.Customers.FirstOrDefault(c => c.Id == key));
         }
+
+        /// <summary>
+        /// If testing in IISExpress with the POST request to: http://localhost:2087/test/my/a/Customers
+        /// Content-Type : application/json
+        /// {
+        ///    "Name": "Jonier","
+        /// }
+        /// 
+        /// Check the reponse header, you can see 
+        /// "Location" : "http://localhost:2087/test/my/a/Customers(0)"
+        /// </summary>
+        [EnableQuery]
+        public IActionResult Post([FromBody]Customer customer)
+        {
+            return Created(customer);
+        }
     }
 }

--- a/samples/AspNetCore3xEndpointSample.Web/Properties/launchSettings.json
+++ b/samples/AspNetCore3xEndpointSample.Web/Properties/launchSettings.json
@@ -1,13 +1,13 @@
-﻿{
-  "$schema": "http://json.schemastore.org/launchsettings.json",
+{
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:2087",
+      "applicationUrl": "http://localhost:2087/test/",
       "sslPort": 0
     }
   },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
@@ -19,12 +19,11 @@
     },
     "AspNetCore3xEndpointSample.Web": {
       "commandName": "Project",
-      "launchBrowser": false,
       "launchUrl": "odata/Customers",
-      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "applicationUrl": "http://localhost:5000/"
     }
   }
 }

--- a/sln/WebApiOData.AspNetCore.sln
+++ b/sln/WebApiOData.AspNetCore.sln
@@ -21,10 +21,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.OData.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore3xODataSample.Web", "..\samples\AspNetCore3xODataSample.Web\AspNetCore3xODataSample.Web.csproj", "{C5DD33B7-A5C9-431C-93D1-C2176C20F12B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCore3xEndpointSample.Web", "..\samples\AspNetCore3xEndpointSample.Web\AspNetCore3xEndpointSample.Web.csproj", "{7E23621F-31D5-4A0D-AFDA-987B1866B8AF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore3xEndpointSample.Web", "..\samples\AspNetCore3xEndpointSample.Web\AspNetCore3xEndpointSample.Web.csproj", "{7E23621F-31D5-4A0D-AFDA-987B1866B8AF}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\src\Microsoft.AspNet.OData.Shared\Microsoft.AspNet.OData.Shared.projitems*{0fc1bf5e-f882-43d8-9451-ed9fa90dea4c}*SharedItemsImports = 5
+		..\test\UnitTest\Microsoft.AspNet.OData.Test.Shared\Microsoft.AspNet.OData.Test.Shared.projitems*{2b8085f7-3625-489e-a963-e29c2bd1aa76}*SharedItemsImports = 5
 		..\src\Microsoft.AspNet.OData.Shared\Microsoft.AspNet.OData.Shared.projitems*{b6b951b6-c3f0-4b8e-8955-e039145e7dec}*SharedItemsImports = 13
 		..\test\UnitTest\Microsoft.AspNet.OData.Test.Shared\Microsoft.AspNet.OData.Test.Shared.projitems*{d909e7ab-3281-46ea-929b-f35fe7e94b0f}*SharedItemsImports = 13
 	EndGlobalSection

--- a/src/Microsoft.AspNetCore.OData/Extensions/Endpoint/ODataEndpointLinkGenerator.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/Endpoint/ODataEndpointLinkGenerator.cs
@@ -54,6 +54,16 @@ namespace Microsoft.AspNet.OData.Extensions
                     }
                     string link = CombinePathSegments(routePrefix, odataPath);
                     link = UriEncode(link);
+
+                    // A workaround to include the PathBase, a good solution is to use ASP.NET Core provided the APIs
+                    // at https://github.com/dotnet/aspnetcore/blob/master/src/Http/Http.Extensions/src/UriHelper.cs#L48
+                    // to build the absolute Uri. But, here only needs the "PathBase + Path (without OData path)",
+                    HttpRequest request = httpContext.Request;
+                    if (request != null && request.PathBase != null && request.PathBase.HasValue)
+                    {
+                        return request.PathBase.Value + "/" + link;
+                    }
+
                     return link;
                 }
             }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointLinkGeneratorTests.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointLinkGeneratorTests.cs
@@ -57,6 +57,42 @@ namespace Microsoft.AspNet.OData.Test.Extensions
             Assert.Equal("ms/2", path);
         }
 
+        [Theory]
+        [InlineData("/test")]
+        [InlineData("/test/other")]
+        public void GetPathByAddressReturnsCorrectODataPathWithPathBase(string pathBase)
+        {
+            // Arrange
+            int address = 1;
+            IPerRouteContainer container = new PerRouteContainer();
+            container.AddRoute("odata", "ms/{data}");
+
+            IServiceProvider serviceProvider = new ServiceCollection()
+                .AddSingleton<IPerRouteContainer>(container)
+                .BuildServiceProvider();
+
+            HttpContext httpContext = new DefaultHttpContext
+            {
+                RequestServices = serviceProvider
+            };
+
+            httpContext.Request.PathBase = pathBase;
+            httpContext.ODataFeature().RouteName = "odata";
+            RouteValueDictionary values = new RouteValueDictionary();
+            values["odataPath"] = "";
+
+            RouteValueDictionary ambientValues = new RouteValueDictionary();
+            ambientValues["data"] = 2;
+
+            // Act
+            Mock<LinkGenerator> mock = new Mock<LinkGenerator>();
+            ODataEndpointLinkGenerator linkGenerator = new ODataEndpointLinkGenerator(mock.Object);
+            string path = linkGenerator.GetPathByAddress(httpContext, address, values, ambientValues);
+
+            // Assert
+            Assert.Equal(pathBase + "/ms/2", path);
+        }
+
         [Fact]
         public void GetPathByAddressCallInnerLinkGeneratorGetPathByAddress()
         {


### PR DESCRIPTION
… setting

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2141 & #2144.*

### Description

The base link generate doesn't take the Pathbase into consideration in the old MVC urihelper.
So, this PR is to add the PathBase into the base address for OData request.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
