### PR TITLE
OData/WebApi#1837: SetDefaultODataOptions doesn't work/has dead code

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/ODataServiceProviderConfigExtenions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ODataServiceProviderConfigExtenions.cs
@@ -218,7 +218,10 @@ namespace Microsoft.AspNet.OData.Extensions
                 throw Error.InvalidOperation(SRResources.MissingODataServices, nameof(ODataOptions));
             }
 
-            options = defaultOptions;
+            options.CompatibilityOptions = defaultOptions.CompatibilityOptions;
+            options.EnableContinueOnErrorHeader = defaultOptions.EnableContinueOnErrorHeader;
+            options.NullDynamicPropertyIsEnabled = defaultOptions.NullDynamicPropertyIsEnabled;
+            options.UrlKeyDelimiter = defaultOptions.UrlKeyDelimiter;
         }
 
         public static ODataOptions GetDefaultODataOptions(this IServiceProvider serviceProvider)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/ODataConfigurationExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/ODataConfigurationExtensionsTest.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData;
+using Xunit;
+
+namespace Microsoft.AspNet.OData.Test.Extensions
+{
+    public class ODataConfigurationExtensionsTest
+    {
+        [Fact]
+        public void SetDefaultODataOptions()
+        {
+            var defaultOptions = new ODataOptions
+            {
+                NullDynamicPropertyIsEnabled = false,
+                EnableContinueOnErrorHeader = false,
+                CompatibilityOptions = CompatibilityOptions.AllowNextLinkWithNonPositiveTopValue,
+                UrlKeyDelimiter = ODataUrlKeyDelimiter.Slash
+            };
+            var services = new ServiceCollection();
+            services.Insert(0, ServiceDescriptor.Singleton(new ODataOptions
+            {
+                NullDynamicPropertyIsEnabled = true,
+                EnableContinueOnErrorHeader = true,
+                CompatibilityOptions = CompatibilityOptions.None,
+                UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses
+            }));
+            ODataOptions updatedOptions;
+            using (var serviceProvider = services.BuildServiceProvider())
+            {
+                serviceProvider.SetDefaultODataOptions(defaultOptions);
+                updatedOptions = serviceProvider.GetRequiredService<ODataOptions>();
+            }
+
+            Assert.Equal(defaultOptions.NullDynamicPropertyIsEnabled, updatedOptions.NullDynamicPropertyIsEnabled);
+            Assert.Equal(defaultOptions.EnableContinueOnErrorHeader, updatedOptions.EnableContinueOnErrorHeader);
+            Assert.Equal(defaultOptions.CompatibilityOptions, updatedOptions.CompatibilityOptions);
+            Assert.Equal(defaultOptions.UrlKeyDelimiter, updatedOptions.UrlKeyDelimiter);
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Closes #1837

### Description

Change to manually set properties on the `ODataOptions` object.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

N/A