### PR TITLE
Fix logic for patching structured type with complex type dynamic property

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
@@ -116,6 +116,29 @@ namespace Microsoft.AspNet.OData
         /// <inheritdoc/>
         public override bool TrySetPropertyValue(string name, object value)
         {
+            if (name == null)
+            {
+                throw Error.ArgumentNull("name");
+            }
+
+            if (_dynamicDictionaryPropertyinfo != null)
+            {
+                // Dynamic property can have the same name as the dynamic property dictionary.
+                if (name == _dynamicDictionaryPropertyinfo.Name ||
+                    !_allProperties.ContainsKey(name))
+                {
+                    if (_dynamicDictionaryCache == null)
+                    {
+                        _dynamicDictionaryCache =
+                            GetDynamicPropertyDictionary(_dynamicDictionaryPropertyinfo, _instance, create: true);
+                    }
+
+                    _dynamicDictionaryCache[name] = value;
+                    _changedDynamicProperties.Add(name);
+                    return true;
+                }
+            }
+
             if (value is IDelta)
             {
                 return TrySetNestedResourceInternal(name, value);
@@ -589,24 +612,6 @@ namespace Microsoft.AspNet.OData
             if (name == null)
             {
                 throw Error.ArgumentNull("name");
-            }
-
-            if (_dynamicDictionaryPropertyinfo != null)
-            {
-                // Dynamic property can have the same name as the dynamic property dictionary.
-                if (name == _dynamicDictionaryPropertyinfo.Name ||
-                    !_allProperties.ContainsKey(name))
-                {
-                    if (_dynamicDictionaryCache == null)
-                    {
-                        _dynamicDictionaryCache =
-                            GetDynamicPropertyDictionary(_dynamicDictionaryPropertyinfo, _instance, create: true);
-                    }
-
-                    _dynamicDictionaryCache[name] = value;
-                    _changedDynamicProperties.Add(name);
-                    return true;
-                }
             }
 
             if (!_updatableProperties.Contains(name))

--- a/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
@@ -557,7 +557,18 @@ namespace Microsoft.AspNet.OData
                 }
                 else
                 {
-                    tempDictionary[dynamicPropertyName] = dynamicPropertyValue;
+                    if (dynamicPropertyValue is IDelta)
+                    {
+                        dynamic deltaObject = dynamicPropertyValue;
+                        dynamic instance = deltaObject.GetInstance();
+
+                        deltaObject.CopyChangedValues(instance);
+                        tempDictionary[dynamicPropertyName] = instance;
+                    }
+                    else
+                    {
+                        tempDictionary[dynamicPropertyName] = dynamicPropertyValue;
+                    }
                 }
             }
 

--- a/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNet.OData
         /// <inheritdoc/>
         public override bool TrySetPropertyValue(string name, object value)
         {
-            if (name == null)
+            if (string.IsNullOrWhiteSpace(name))
             {
                 throw Error.ArgumentNull("name");
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2126 and #1780*

### Description

Logic for patching an structured type containing a complex type dynamic property is currently broken. This appears to have happened in a refactor done in [this](https://github.com/OData/WebApi/pull/1445/files#diff-da4fb05d65976a67ce2a8a1eb8ef0c8fL117) PR. Two helper methods were created: `TrySetPropertyValueInternal` and `TrySetNestedResourceInternal`. The first helper method ended up with the logic for handling dynamic properties in the delta. However, a complex type property (including dynamic) is routed to `TrySetNestedResourceInternal` that does not bother with dynamic properties at all. This PR fixes the issue by moving the logic for processing dynamic properties in the delta back to the `TrySetPropertyValue` public method

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
