### PR TITLE
Fix EfCore memory leak when query contains collection constant

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -1360,7 +1360,12 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 castedList.Add(member);
             }
 
-            return Expression.Constant(castedList);
+            if (QuerySettings.EnableConstantParameterization)
+            {
+                return LinqParameterContainer.Parameterize(listType, castedList);
+            }
+
+            return Expression.Constant(castedList, listType);
         }
 
         private Expression BindCastSingleValue(SingleValueFunctionCallNode node)

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -1642,7 +1642,6 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Contains($it.SimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            // expression tree is guaranteed by expression string above
             var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
             var values = (IList<SimpleEnum>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new[] {SimpleEnum.First, SimpleEnum.Second}, values);
@@ -1664,7 +1663,6 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Contains($it.NullableSimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            // expression tree is guaranteed by expression string above\
             var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
             var values = (IList<SimpleEnum?>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new SimpleEnum?[] {SimpleEnum.First, SimpleEnum.Second}, values);
@@ -1678,7 +1676,6 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Contains($it.NullableSimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            // expression tree is guaranteed by expression string above
             var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
             var values = (IList<SimpleEnum?>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new SimpleEnum?[] {SimpleEnum.First, null}, values);
@@ -2876,6 +2873,50 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 });
 
             Assert.Equal("$it => ($it.ProductName == \"1\")", (filters.WithoutNullPropagation as Expression).ToString());
+        }
+
+        [Fact]
+        public void CollectionConstants_Are_Parameterized()
+        {
+            var result = VerifyQueryDeserialization("ProductName in ('Prod1', 'Prod2')",
+                "$it => System.Collections.Generic.List`1[System.String].Contains($it.ProductName)");
+
+            Expression<Func<Product, bool>> expression = result.WithNullPropagation;
+
+            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+            var values = (IList<string>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
+            Assert.Equal(new[] { "Prod1", "Prod2" }, values);
+        }
+
+        [Fact]
+        public void CollectionConstants_Are_Not_Parameterized_If_Disabled()
+        {
+            var result = VerifyQueryDeserialization("ProductName in ('Prod1', 'Prod2')",
+                "$it => System.Collections.Generic.List`1[System.String].Contains($it.ProductName)",
+                settingsCustomizer: (settings) =>
+                {
+                    settings.EnableConstantParameterization = false;
+                });
+
+            Expression<Func<Product, bool>> expression = result.WithNullPropagation;
+            var values = (IList<string>)((ConstantExpression)((MethodCallExpression)expression.Body).Arguments[0]).Value;
+            Assert.Equal(new[] { "Prod1", "Prod2" }, values);
+        }
+
+        [Fact]
+        public void CollectionConstants_OfEnums_Are_Not_Parameterized_If_Disabled()
+        {
+            var result = VerifyQueryDeserialization<DataTypes>(
+                "SimpleEnumProp in ('First', 'Second')",
+                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Contains($it.SimpleEnumProp)",
+                settingsCustomizer: (settings) =>
+                {
+                    settings.EnableConstantParameterization = false;
+                });
+
+            Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
+            var values = (IList<SimpleEnum>)((ConstantExpression)((MethodCallExpression)expression.Body).Arguments[0]).Value;
+            Assert.Equal(new[] { SimpleEnum.First, SimpleEnum.Second }, values);
         }
 
         [Fact]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -1643,7 +1643,8 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
             // expression tree is guaranteed by expression string above
-            var values = (IList<SimpleEnum>)((ConstantExpression)((MethodCallExpression) expression.Body).Arguments[0]).Value;
+            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+            var values = (IList<SimpleEnum>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new[] {SimpleEnum.First, SimpleEnum.Second}, values);
         }
 
@@ -1663,8 +1664,9 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Contains($it.NullableSimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            // expression tree is guaranteed by expression string above
-            var values = (IList<SimpleEnum?>)((ConstantExpression)((MethodCallExpression) expression.Body).Arguments[0]).Value;
+            // expression tree is guaranteed by expression string above\
+            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+            var values = (IList<SimpleEnum?>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new SimpleEnum?[] {SimpleEnum.First, SimpleEnum.Second}, values);
         }
         
@@ -1677,7 +1679,8 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
             // expression tree is guaranteed by expression string above
-            var values = (IList<SimpleEnum?>)((ConstantExpression)((MethodCallExpression) expression.Body).Arguments[0]).Value;
+            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+            var values = (IList<SimpleEnum?>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new SimpleEnum?[] {SimpleEnum.First, null}, values);
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #2089 

### Description

EF core caches compiled queries so it doesn't have to re-compile the same query twice. The compiled queries are usually parameterized so that if the same query is made with different input values, the same cached query will be re-used. However, if a constant expression is inside a lambda, it's not parameterized, this means the same query with different values will result in queries being compiled and cache (see https://github.com/dotnet/efcore/issues/10535#issuecomment-375116203). If such queries are made frequently, then the size of the cache quickly grows over time unnecessarily (see https://dzone.com/articles/investigating-a-memory-leak-in-entity-framework-co).

WebApi has a setting `EnableConstantParameterization` which is enabled by default to prevent this issue. It uses `LinqParameterContainer.ParameterizeConstant()` to wrap the constant value in a property of a class instance and replaces the `ConstantExpression` with a `PropertyExpression`. This mimics how the compiler handles closures. This parameterization was applied to Uri Parser's `ConstantNode` but not to `CollectionConstantNode`. This PR simply applies it to `CollectionConstanNode`.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
