### PR TITLE
Add cast operation to FilterBinder.BindIn

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/ExpressionHelperMethods.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ExpressionHelperMethods.cs
@@ -25,12 +25,15 @@ namespace Microsoft.AspNet.OData
         private static MethodInfo _thenByDescendingMethod = GenericMethodOf(_ => Queryable.ThenByDescending<int, int>(default(IOrderedQueryable<int>), default(Expression<Func<int, int>>)));
         private static MethodInfo _enumerableThenByDescendingMethod = GenericMethodOf(_ => Enumerable.ThenByDescending<int, int>(default(IOrderedEnumerable<int>), default(Func<int, int>)));
         private static MethodInfo _countMethod = GenericMethodOf(_ => Queryable.LongCount<int>(default(IQueryable<int>)));
-        private static MethodInfo _enumerableGroupByMethod = GenericMethodOf(_ => Enumerable.GroupBy<int, int>(default(IQueryable<int>), default(Func<int, int>)));        
+        private static MethodInfo _enumerableGroupByMethod = GenericMethodOf(_ => Enumerable.GroupBy<int, int>(default(IQueryable<int>), default(Func<int, int>)));
         private static MethodInfo _groupByMethod = GenericMethodOf(_ => Queryable.GroupBy<int, int>(default(IQueryable<int>), default(Expression<Func<int, int>>)));
         private static MethodInfo _aggregateMethod = GenericMethodOf(_ => Queryable.Aggregate<int, int>(default(IQueryable<int>), default(int), default(Expression<Func<int, int, int>>)));
         private static MethodInfo _skipMethod = GenericMethodOf(_ => Queryable.Skip<int>(default(IQueryable<int>), default(int)));
         private static MethodInfo _enumerableSkipMethod = GenericMethodOf(_ => Enumerable.Skip<int>(default(IEnumerable<int>), default(int)));
         private static MethodInfo _whereMethod = GenericMethodOf(_ => Queryable.Where<int>(default(IQueryable<int>), default(Expression<Func<int, bool>>)));
+
+        private static MethodInfo _queryableCastMethod = GenericMethodOf(_ => Queryable.Cast<int>(default(IQueryable<int>)));
+        private static MethodInfo _enumerableCastMethod = GenericMethodOf(_ => Enumerable.Cast<int>(default(IEnumerable<int>)));
 
         private static MethodInfo _queryableContainsMethod = GenericMethodOf(_ => Queryable.Contains<int>(default(IQueryable<int>), default(int)));
         private static MethodInfo _enumerableContainsMethod = GenericMethodOf(_ => Enumerable.Contains<int>(default(IEnumerable<int>), default(int)));
@@ -71,7 +74,7 @@ namespace Microsoft.AspNet.OData
         private static MethodInfo _queryableMaxMethod = GenericMethodOf(_ => Queryable.Max<int, int>(default(IQueryable<int>), default(Expression<Func<int, int>>)));
 
         private static MethodInfo _queryableDistinctMethod = GenericMethodOf(_ => Queryable.Distinct<int>(default(IQueryable<int>)));
-        
+
         private static MethodInfo _createQueryGenericMethod = GetCreateQueryGenericMethod();
 
         //Unlike the Sum method, the return types are not unique and do not match the input type of the expression.
@@ -253,6 +256,16 @@ namespace Microsoft.AspNet.OData
             get { return _whereMethod; }
         }
 
+        public static MethodInfo QueryableCastGeneric
+        {
+            get { return _queryableCastMethod; }
+        }
+
+        public static MethodInfo EnumerableCastGeneric
+        {
+            get { return _enumerableCastMethod; }
+        }
+
         public static MethodInfo QueryableContainsGeneric
         {
             get { return _queryableContainsMethod; }
@@ -272,7 +285,7 @@ namespace Microsoft.AspNet.OData
         {
             get { return _enumerableSelectMethod; }
         }
-        
+
         public static MethodInfo QueryableSelectManyGeneric
         {
             get { return _queryableSelectManyMethod; }
@@ -371,7 +384,7 @@ namespace Microsoft.AspNet.OData
             {
                 return (decimal?)Convert.ChangeType(value, typeof(decimal), CultureInfo.InvariantCulture);
             }
-            
+
             return null;
         }
 
@@ -390,7 +403,7 @@ namespace Microsoft.AspNet.OData
 
             return (lambdaExpression.Body as MethodCallExpression).Method.GetGenericMethodDefinition();
         }
-       
+
         private static Dictionary<Type, MethodInfo> GetQueryableAggregationMethods(string methodName)
         {
             //Sum to not have generic by property method return type so have to generate a table

--- a/src/Microsoft.AspNet.OData.Shared/ExpressionHelperMethods.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ExpressionHelperMethods.cs
@@ -25,15 +25,12 @@ namespace Microsoft.AspNet.OData
         private static MethodInfo _thenByDescendingMethod = GenericMethodOf(_ => Queryable.ThenByDescending<int, int>(default(IOrderedQueryable<int>), default(Expression<Func<int, int>>)));
         private static MethodInfo _enumerableThenByDescendingMethod = GenericMethodOf(_ => Enumerable.ThenByDescending<int, int>(default(IOrderedEnumerable<int>), default(Func<int, int>)));
         private static MethodInfo _countMethod = GenericMethodOf(_ => Queryable.LongCount<int>(default(IQueryable<int>)));
-        private static MethodInfo _enumerableGroupByMethod = GenericMethodOf(_ => Enumerable.GroupBy<int, int>(default(IQueryable<int>), default(Func<int, int>)));
+        private static MethodInfo _enumerableGroupByMethod = GenericMethodOf(_ => Enumerable.GroupBy<int, int>(default(IQueryable<int>), default(Func<int, int>)));        
         private static MethodInfo _groupByMethod = GenericMethodOf(_ => Queryable.GroupBy<int, int>(default(IQueryable<int>), default(Expression<Func<int, int>>)));
         private static MethodInfo _aggregateMethod = GenericMethodOf(_ => Queryable.Aggregate<int, int>(default(IQueryable<int>), default(int), default(Expression<Func<int, int, int>>)));
         private static MethodInfo _skipMethod = GenericMethodOf(_ => Queryable.Skip<int>(default(IQueryable<int>), default(int)));
         private static MethodInfo _enumerableSkipMethod = GenericMethodOf(_ => Enumerable.Skip<int>(default(IEnumerable<int>), default(int)));
         private static MethodInfo _whereMethod = GenericMethodOf(_ => Queryable.Where<int>(default(IQueryable<int>), default(Expression<Func<int, bool>>)));
-
-        private static MethodInfo _queryableCastMethod = GenericMethodOf(_ => Queryable.Cast<int>(default(IQueryable<int>)));
-        private static MethodInfo _enumerableCastMethod = GenericMethodOf(_ => Enumerable.Cast<int>(default(IEnumerable<int>)));
 
         private static MethodInfo _queryableContainsMethod = GenericMethodOf(_ => Queryable.Contains<int>(default(IQueryable<int>), default(int)));
         private static MethodInfo _enumerableContainsMethod = GenericMethodOf(_ => Enumerable.Contains<int>(default(IEnumerable<int>), default(int)));
@@ -74,7 +71,7 @@ namespace Microsoft.AspNet.OData
         private static MethodInfo _queryableMaxMethod = GenericMethodOf(_ => Queryable.Max<int, int>(default(IQueryable<int>), default(Expression<Func<int, int>>)));
 
         private static MethodInfo _queryableDistinctMethod = GenericMethodOf(_ => Queryable.Distinct<int>(default(IQueryable<int>)));
-
+        
         private static MethodInfo _createQueryGenericMethod = GetCreateQueryGenericMethod();
 
         //Unlike the Sum method, the return types are not unique and do not match the input type of the expression.
@@ -256,16 +253,6 @@ namespace Microsoft.AspNet.OData
             get { return _whereMethod; }
         }
 
-        public static MethodInfo QueryableCastGeneric
-        {
-            get { return _queryableCastMethod; }
-        }
-
-        public static MethodInfo EnumerableCastGeneric
-        {
-            get { return _enumerableCastMethod; }
-        }
-
         public static MethodInfo QueryableContainsGeneric
         {
             get { return _queryableContainsMethod; }
@@ -285,7 +272,7 @@ namespace Microsoft.AspNet.OData
         {
             get { return _enumerableSelectMethod; }
         }
-
+        
         public static MethodInfo QueryableSelectManyGeneric
         {
             get { return _queryableSelectManyMethod; }
@@ -384,7 +371,7 @@ namespace Microsoft.AspNet.OData
             {
                 return (decimal?)Convert.ChangeType(value, typeof(decimal), CultureInfo.InvariantCulture);
             }
-
+            
             return null;
         }
 
@@ -403,7 +390,7 @@ namespace Microsoft.AspNet.OData
 
             return (lambdaExpression.Body as MethodCallExpression).Method.GetGenericMethodDefinition();
         }
-
+       
         private static Dictionary<Type, MethodInfo> GetQueryableAggregationMethods(string methodName)
         {
             //Sum to not have generic by property method return type so have to generate a table

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -1332,7 +1332,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             }
 
             Type constantType = RetrieveClrTypeForConstant(node.ItemType, ref value);
-            Type nullableConstantType = node.ItemType.IsNullable && constantType.IsValueType
+            Type nullableConstantType = node.ItemType.IsNullable && Nullable.GetUnderlyingType(constantType) == null
                 ? typeof(Nullable<>).MakeGenericType(constantType)
                 : constantType;
             Type listType = typeof(List<>).MakeGenericType(nullableConstantType);

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -1332,7 +1332,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             }
 
             Type constantType = RetrieveClrTypeForConstant(node.ItemType, ref value);
-            Type nullableConstantType = node.ItemType.IsNullable && Nullable.GetUnderlyingType(constantType) == null
+            Type nullableConstantType = node.ItemType.IsNullable && constantType.IsValueType && Nullable.GetUnderlyingType(constantType) == null
                 ? typeof(Nullable<>).MakeGenericType(constantType)
                 : constantType;
             Type listType = typeof(List<>).MakeGenericType(nullableConstantType);

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -514,13 +514,13 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
             if (IsIQueryable(collection.Type))
             {
-                var castedToSingleValueType = Expression.Call(null, ExpressionHelperMethods.QueryableCastGeneric.MakeGenericMethod(singleValue.Type), collection);
-                return Expression.Call(null, ExpressionHelperMethods.QueryableContainsGeneric.MakeGenericMethod(singleValue.Type), castedToSingleValueType, singleValue);
+                Expression containsExpression = singleValue.Type != collection.Type.GetGenericArguments()[0] ? Expression.Call(null, ExpressionHelperMethods.QueryableCastGeneric.MakeGenericMethod(singleValue.Type), collection) : collection;
+                return Expression.Call(null, ExpressionHelperMethods.QueryableContainsGeneric.MakeGenericMethod(singleValue.Type), containsExpression, singleValue);
             }
             else
             {
-                var castedToSingleValueType = Expression.Call(null, ExpressionHelperMethods.EnumerableCastGeneric.MakeGenericMethod(singleValue.Type), collection);
-                return Expression.Call(null, ExpressionHelperMethods.EnumerableContainsGeneric.MakeGenericMethod(singleValue.Type), castedToSingleValueType, singleValue);
+                Expression containsExpression = singleValue.Type != collection.Type.GetGenericArguments()[0] ? Expression.Call(null, ExpressionHelperMethods.EnumerableCastGeneric.MakeGenericMethod(singleValue.Type), collection) : collection;
+                return Expression.Call(null, ExpressionHelperMethods.EnumerableContainsGeneric.MakeGenericMethod(singleValue.Type), containsExpression, singleValue);
             }
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -514,11 +514,13 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
             if (IsIQueryable(collection.Type))
             {
-                return Expression.Call(null, ExpressionHelperMethods.QueryableContainsGeneric.MakeGenericMethod(singleValue.Type), collection, singleValue);
+                var castedToSingleValueType = Expression.Call(null, ExpressionHelperMethods.QueryableCastGeneric.MakeGenericMethod(singleValue.Type), collection);
+                return Expression.Call(null, ExpressionHelperMethods.QueryableContainsGeneric.MakeGenericMethod(singleValue.Type), castedToSingleValueType, singleValue);
             }
             else
             {
-                return Expression.Call(null, ExpressionHelperMethods.EnumerableContainsGeneric.MakeGenericMethod(singleValue.Type), collection, singleValue);
+                var castedToSingleValueType = Expression.Call(null, ExpressionHelperMethods.EnumerableCastGeneric.MakeGenericMethod(singleValue.Type), collection);
+                return Expression.Call(null, ExpressionHelperMethods.EnumerableContainsGeneric.MakeGenericMethod(singleValue.Type), castedToSingleValueType, singleValue);
             }
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -514,13 +514,11 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
             if (IsIQueryable(collection.Type))
             {
-                var castedToSingleValueType = Expression.Call(null, ExpressionHelperMethods.QueryableCastGeneric.MakeGenericMethod(singleValue.Type), collection);
-                return Expression.Call(null, ExpressionHelperMethods.QueryableContainsGeneric.MakeGenericMethod(singleValue.Type), castedToSingleValueType, singleValue);
+                return Expression.Call(null, ExpressionHelperMethods.QueryableContainsGeneric.MakeGenericMethod(singleValue.Type), collection, singleValue);
             }
             else
             {
-                var castedToSingleValueType = Expression.Call(null, ExpressionHelperMethods.EnumerableCastGeneric.MakeGenericMethod(singleValue.Type), collection);
-                return Expression.Call(null, ExpressionHelperMethods.EnumerableContainsGeneric.MakeGenericMethod(singleValue.Type), castedToSingleValueType, singleValue);
+                return Expression.Call(null, ExpressionHelperMethods.EnumerableContainsGeneric.MakeGenericMethod(singleValue.Type), collection, singleValue);
             }
         }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/DataModel.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/DataModel.cs
@@ -43,9 +43,6 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         public Date DateProperty { get; set; }
         public Date? NullableDateProperty { get; set; }
 
-        public Guid GuidProperty { get; set; }
-        public Guid? NullableGuidProperty { get; set; }
-
         public TimeOfDay TimeOfDayProperty { get; set; }
         public TimeOfDay? NullableTimeOfDayProperty { get; set; }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/DataModel.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/DataModel.cs
@@ -43,6 +43,9 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         public Date DateProperty { get; set; }
         public Date? NullableDateProperty { get; set; }
 
+        public Guid GuidProperty { get; set; }
+        public Guid? NullableGuidProperty { get; set; }
+
         public TimeOfDay TimeOfDayProperty { get; set; }
         public TimeOfDay? NullableTimeOfDayProperty { get; set; }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -610,12 +610,13 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Theory]
-        [InlineData("Category/QueryableProducts/any(P: P/ProductID in (1))", "$it => ($it.NullableIntProp == null)")]
+        [InlineData("QueryableProducts/any(P: P/ProductID in (1))", "$it => $it.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
+        [InlineData("EnumerableProducts/any(P: P/ProductID in (1))", "$it => $it.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
         public void Test(string filter, string expectedResult)
         {
             // Arrange
             IEdmModel model = GetModel<Category>();
-            IEdmType targetEdmType = model.FindType("Microsoft.AspNet.OData.Test.Query.Expressions.DataTypes");
+            IEdmType targetEdmType = model.FindType("Microsoft.AspNet.OData.Test.Query.Expressions.Category");
             IEdmNavigationSource targetNavigationSource = model.FindDeclaredEntitySet("Microsoft.AspNet.OData.Test.Query.Expressions.Products");
             IDictionary<string, string> queryOptions = new Dictionary<string, string> { { "$filter", filter } };
             ODataQueryOptionParser parser = new ODataQueryOptionParser(model, targetEdmType, targetNavigationSource, queryOptions);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -599,20 +599,16 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Theory]
-        [InlineData("Category/QueryableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Contains(P.ProductID))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.QueryableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.QueryableProducts).Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(IIF((P == null), null, Convert(P.ProductID)))))) == True)")]
-        [InlineData("Category/EnumerableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Contains(P.ProductID))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.EnumerableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.EnumerableProducts).Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(IIF((P == null), null, Convert(P.ProductID)))))) == True)")]
-        [InlineData("Category/QueryableProducts/any(P: P/GuidProperty in (dc75698b-581d-488b-9638-3e28dd51d8f7))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Guid].Contains(P.GuidProperty))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.QueryableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.QueryableProducts).Any(P => System.Collections.Generic.List`1[System.Guid].Cast().Contains(IIF((P == null), null, Convert(P.GuidProperty)))))) == True)")]
-        [InlineData("Category/EnumerableProducts/any(P: P/GuidProperty in (dc75698b-581d-488b-9638-3e28dd51d8f7))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Guid].Contains(P.GuidProperty))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.EnumerableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.EnumerableProducts).Any(P => System.Collections.Generic.List`1[System.Guid].Cast().Contains(IIF((P == null), null, Convert(P.GuidProperty)))))) == True)")]
-        [InlineData("Category/QueryableProducts/any(P: P/NullableGuidProperty in (dc75698b-581d-488b-9638-3e28dd51d8f7))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Guid]].Contains(P.NullableGuidProperty))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.QueryableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.QueryableProducts).Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Guid]].Contains(IIF((P == null), null, P.NullableGuidProperty))))) == True)")]
-        [InlineData("Category/EnumerableProducts/any(P: P/NullableGuidProperty in (dc75698b-581d-488b-9638-3e28dd51d8f7))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Guid]].Contains(P.NullableGuidProperty))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.EnumerableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.EnumerableProducts).Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Guid]].Contains(IIF((P == null), null, P.NullableGuidProperty))))) == True)")]
-        [InlineData("Category/QueryableProducts/any(P: P/Discontinued in (false, null))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Contains(P.Discontinued))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.QueryableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.QueryableProducts).Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Contains(IIF((P == null), null, P.Discontinued))))) == True)")]
-        [InlineData("Category/EnumerableProducts/any(P: P/Discontinued in (false, null))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Contains(P.Discontinued))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.EnumerableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.EnumerableProducts).Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Contains(IIF((P == null), null, P.Discontinued))))) == True)")]
-        public void AnyInOnNavigation(string filter, string expression, string expressionWithNullPropagation)
+        [InlineData("Category/QueryableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
+        [InlineData("Category/EnumerableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
+        [InlineData("Category/QueryableProducts/any(P: P/Discontinued in (false))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Cast().Contains(P.Discontinued))")]
+        [InlineData("Category/EnumerableProducts/any(P: P/Discontinued in (false))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Cast().Contains(P.Discontinued))")]
+        public void AnyInOnNavigation(string filter, string expression)
         {
             var filters = VerifyQueryDeserialization(
                filter,
                expression,
-               expressionWithNullPropagation);
+               NotTesting);
         }
 
         [Theory]
@@ -1656,10 +1652,10 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             var result = VerifyQueryDeserialization<DataTypes>(
                 "SimpleEnumProp in ('First', 'Second')",
-                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Contains($it.SimpleEnumProp)");
+                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Cast().Contains($it.SimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+            var memberAccess = (MemberExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0];
             var values = (IList<SimpleEnum>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new[] {SimpleEnum.First, SimpleEnum.Second}, values);
         }
@@ -1677,10 +1673,10 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             var result = VerifyQueryDeserialization<DataTypes>(
                 "NullableSimpleEnumProp in ('First', 'Second')",
-                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Contains($it.NullableSimpleEnumProp)");
+                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Cast().Contains($it.NullableSimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+            var memberAccess = (MemberExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0];
             var values = (IList<SimpleEnum?>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new SimpleEnum?[] {SimpleEnum.First, SimpleEnum.Second}, values);
         }
@@ -1690,10 +1686,10 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             var result = VerifyQueryDeserialization<DataTypes>(
                 "NullableSimpleEnumProp in ('First', null)",
-                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Contains($it.NullableSimpleEnumProp)");
+                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Cast().Contains($it.NullableSimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+            var memberAccess = (MemberExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0];
             var values = (IList<SimpleEnum?>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new SimpleEnum?[] {SimpleEnum.First, null}, values);
         }
@@ -2873,18 +2869,6 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 new { WithNullPropagation = false, WithoutNullPropagation = typeof(InvalidOperationException) });
         }
 
-        [Theory]
-        [InlineData("Category/Product/ProductID in (1)", "$it => System.Collections.Generic.List`1[System.Int32].Contains($it.Category.Product.ProductID)", "$it => System.Collections.Generic.List`1[System.Int32].Cast().Contains(IIF((IIF(($it.Category == null), null, $it.Category.Product) == null), null, Convert($it.Category.Product.ProductID)))")]
-        [InlineData("Category/Product/GuidProperty in (dc75698b-581d-488b-9638-3e28dd51d8f7)", "$it => System.Collections.Generic.List`1[System.Guid].Contains($it.Category.Product.GuidProperty)", "$it => System.Collections.Generic.List`1[System.Guid].Cast().Contains(IIF((IIF(($it.Category == null), null, $it.Category.Product) == null), null, Convert($it.Category.Product.GuidProperty)))")]
-        [InlineData("Category/Product/NullableGuidProperty in (dc75698b-581d-488b-9638-3e28dd51d8f7)", "$it => System.Collections.Generic.List`1[System.Nullable`1[System.Guid]].Contains($it.Category.Product.NullableGuidProperty)", "$it => System.Collections.Generic.List`1[System.Nullable`1[System.Guid]].Contains(IIF((IIF(($it.Category == null), null, $it.Category.Product) == null), null, $it.Category.Product.NullableGuidProperty))")]
-        public void InOnNavigation(string filter, string expression, string expressionWithNullPropagation)
-        {
-            var filters = VerifyQueryDeserialization(
-               filter,
-               expression,
-               expressionWithNullPropagation);
-        }
-
         [Fact]
         public void MultipleConstants_Are_Parameterized()
         {
@@ -2908,11 +2892,11 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         public void CollectionConstants_Are_Parameterized()
         {
             var result = VerifyQueryDeserialization("ProductName in ('Prod1', 'Prod2')",
-                "$it => System.Collections.Generic.List`1[System.String].Contains($it.ProductName)");
+                "$it => System.Collections.Generic.List`1[System.String].Cast().Contains($it.ProductName)");
 
             Expression<Func<Product, bool>> expression = result.WithNullPropagation;
 
-            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+            var memberAccess = (MemberExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0];
             var values = (IList<string>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new[] { "Prod1", "Prod2" }, values);
         }
@@ -2921,14 +2905,14 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         public void CollectionConstants_Are_Not_Parameterized_If_Disabled()
         {
             var result = VerifyQueryDeserialization("ProductName in ('Prod1', 'Prod2')",
-                "$it => System.Collections.Generic.List`1[System.String].Contains($it.ProductName)",
+                "$it => System.Collections.Generic.List`1[System.String].Cast().Contains($it.ProductName)",
                 settingsCustomizer: (settings) =>
                 {
                     settings.EnableConstantParameterization = false;
                 });
 
             Expression<Func<Product, bool>> expression = result.WithNullPropagation;
-            var values = (IList<string>)((ConstantExpression)((MethodCallExpression)expression.Body).Arguments[0]).Value;
+            var values = (IList<string>)((ConstantExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0]).Value;
             Assert.Equal(new[] { "Prod1", "Prod2" }, values);
         }
 
@@ -2937,14 +2921,14 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             var result = VerifyQueryDeserialization<DataTypes>(
                 "SimpleEnumProp in ('First', 'Second')",
-                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Contains($it.SimpleEnumProp)",
+                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Cast().Contains($it.SimpleEnumProp)",
                 settingsCustomizer: (settings) =>
                 {
                     settings.EnableConstantParameterization = false;
                 });
 
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
-            var values = (IList<SimpleEnum>)((ConstantExpression)((MethodCallExpression)expression.Body).Arguments[0]).Value;
+            var values = (IList<SimpleEnum>)((ConstantExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0]).Value;
             Assert.Equal(new[] { SimpleEnum.First, SimpleEnum.Second }, values);
         }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -1652,10 +1652,10 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             var result = VerifyQueryDeserialization<DataTypes>(
                 "SimpleEnumProp in ('First', 'Second')",
-                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Contains($it.SimpleEnumProp)");
+                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Cast().Contains($it.SimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+            var memberAccess = (MemberExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0];
             var values = (IList<SimpleEnum>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new[] {SimpleEnum.First, SimpleEnum.Second}, values);
         }
@@ -1676,7 +1676,7 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Cast().Contains($it.NullableSimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+            var memberAccess = (MemberExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0];
             var values = (IList<SimpleEnum?>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new SimpleEnum?[] {SimpleEnum.First, SimpleEnum.Second}, values);
         }
@@ -1689,7 +1689,7 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Cast().Contains($it.NullableSimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+            var memberAccess = (MemberExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0];
             var values = (IList<SimpleEnum?>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new SimpleEnum?[] {SimpleEnum.First, null}, values);
         }
@@ -2892,11 +2892,11 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         public void CollectionConstants_Are_Parameterized()
         {
             var result = VerifyQueryDeserialization("ProductName in ('Prod1', 'Prod2')",
-                "$it => System.Collections.Generic.List`1[System.String].Contains($it.ProductName)");
+                "$it => System.Collections.Generic.List`1[System.String].Cast().Contains($it.ProductName)");
 
             Expression<Func<Product, bool>> expression = result.WithNullPropagation;
 
-            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
+            var memberAccess = (MemberExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0];
             var values = (IList<string>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new[] { "Prod1", "Prod2" }, values);
         }
@@ -2905,14 +2905,14 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         public void CollectionConstants_Are_Not_Parameterized_If_Disabled()
         {
             var result = VerifyQueryDeserialization("ProductName in ('Prod1', 'Prod2')",
-                "$it => System.Collections.Generic.List`1[System.String].Contains($it.ProductName)",
+                "$it => System.Collections.Generic.List`1[System.String].Cast().Contains($it.ProductName)",
                 settingsCustomizer: (settings) =>
                 {
                     settings.EnableConstantParameterization = false;
                 });
 
             Expression<Func<Product, bool>> expression = result.WithNullPropagation;
-            var values = (IList<string>)((ConstantExpression)((MethodCallExpression)expression.Body).Arguments[0]).Value;
+            var values = (IList<string>)((ConstantExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0]).Value;
             Assert.Equal(new[] { "Prod1", "Prod2" }, values);
         }
 
@@ -2921,14 +2921,14 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             var result = VerifyQueryDeserialization<DataTypes>(
                 "SimpleEnumProp in ('First', 'Second')",
-                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Contains($it.SimpleEnumProp)",
+                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Cast().Contains($it.SimpleEnumProp)",
                 settingsCustomizer: (settings) =>
                 {
                     settings.EnableConstantParameterization = false;
                 });
 
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
-            var values = (IList<SimpleEnum>)((ConstantExpression)((MethodCallExpression)expression.Body).Arguments[0]).Value;
+            var values = (IList<SimpleEnum>)((ConstantExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0]).Value;
             Assert.Equal(new[] { SimpleEnum.First, SimpleEnum.Second }, values);
         }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -1673,7 +1673,7 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             var result = VerifyQueryDeserialization<DataTypes>(
                 "NullableSimpleEnumProp in ('First', 'Second')",
-                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Contains($it.NullableSimpleEnumProp)");
+                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Cast().Contains($it.NullableSimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
             var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
@@ -1686,7 +1686,7 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             var result = VerifyQueryDeserialization<DataTypes>(
                 "NullableSimpleEnumProp in ('First', null)",
-                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Contains($it.NullableSimpleEnumProp)");
+                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Cast().Contains($it.NullableSimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
             var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -599,41 +599,14 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Theory]
-        [InlineData("Category/QueryableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
-        [InlineData("Category/EnumerableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
+        [InlineData("Category/QueryableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Contains(P.ProductID))")]
+        [InlineData("Category/EnumerableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Contains(P.ProductID))")]
         public void AnyInOnNavigation(string filter, string expression)
         {
             var filters = VerifyQueryDeserialization(
                filter,
                expression,
                NotTesting);
-        }
-
-        [Theory]
-        [InlineData("QueryableProducts/any(P: P/ProductID in (1))", "$it => $it.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
-        [InlineData("EnumerableProducts/any(P: P/ProductID in (1))", "$it => $it.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
-        public void Test(string filter, string expectedResult)
-        {
-            // Arrange
-            IEdmModel model = GetModel<Category>();
-            IEdmType targetEdmType = model.FindType("Microsoft.AspNet.OData.Test.Query.Expressions.Category");
-            IEdmNavigationSource targetNavigationSource = model.FindDeclaredEntitySet("Microsoft.AspNet.OData.Test.Query.Expressions.Products");
-            IDictionary<string, string> queryOptions = new Dictionary<string, string> { { "$filter", filter } };
-            ODataQueryOptionParser parser = new ODataQueryOptionParser(model, targetEdmType, targetNavigationSource, queryOptions);
-            ODataQueryContext context = new ODataQueryContext(model, typeof(Category));
-            context.RequestContainer = new MockContainer();
-            FilterClause filterClause = new FilterQueryOption(filter, context, parser).FilterClause;
-
-            // Act
-            Expression actualExpression = FilterBinder.Bind(
-                filterClause,
-                typeof(Category),
-                model,
-                WebApiAssembliesResolverFactory.Create(),
-                new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False });
-
-            // Assert
-            VerifyExpression(actualExpression, expectedResult);
         }
 
         [Theory]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -599,6 +599,17 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Theory]
+        [InlineData("Category/QueryableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
+        [InlineData("Category/EnumerableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
+        public void AnyInOnNavigation(string filter, string expression)
+        {
+            var filters = VerifyQueryDeserialization(
+               filter,
+               expression,
+               NotTesting);
+        }
+
+        [Theory]
         [InlineData("Category/QueryableProducts/any(P: false)", "$it => False")]
         [InlineData("Category/QueryableProducts/any(P: false and P/ProductName eq 'Snacks')", "$it => $it.Category.QueryableProducts.Any(P => (False AndAlso (P.ProductName == \"Snacks\")))")]
         [InlineData("Category/QueryableProducts/any(P: true)", "$it => $it.Category.QueryableProducts.Any()")]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -599,16 +599,20 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Theory]
-        [InlineData("Category/QueryableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
-        [InlineData("Category/EnumerableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
-        [InlineData("Category/QueryableProducts/any(P: P/Discontinued in (false))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Cast().Contains(P.Discontinued))")]
-        [InlineData("Category/EnumerableProducts/any(P: P/Discontinued in (false))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Cast().Contains(P.Discontinued))")]
-        public void AnyInOnNavigation(string filter, string expression)
+        [InlineData("Category/QueryableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Contains(P.ProductID))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.QueryableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.QueryableProducts).Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(IIF((P == null), null, Convert(P.ProductID)))))) == True)")]
+        [InlineData("Category/EnumerableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Contains(P.ProductID))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.EnumerableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.EnumerableProducts).Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(IIF((P == null), null, Convert(P.ProductID)))))) == True)")]
+        [InlineData("Category/QueryableProducts/any(P: P/GuidProperty in (dc75698b-581d-488b-9638-3e28dd51d8f7))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Guid].Contains(P.GuidProperty))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.QueryableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.QueryableProducts).Any(P => System.Collections.Generic.List`1[System.Guid].Cast().Contains(IIF((P == null), null, Convert(P.GuidProperty)))))) == True)")]
+        [InlineData("Category/EnumerableProducts/any(P: P/GuidProperty in (dc75698b-581d-488b-9638-3e28dd51d8f7))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Guid].Contains(P.GuidProperty))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.EnumerableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.EnumerableProducts).Any(P => System.Collections.Generic.List`1[System.Guid].Cast().Contains(IIF((P == null), null, Convert(P.GuidProperty)))))) == True)")]
+        [InlineData("Category/QueryableProducts/any(P: P/NullableGuidProperty in (dc75698b-581d-488b-9638-3e28dd51d8f7))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Guid]].Contains(P.NullableGuidProperty))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.QueryableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.QueryableProducts).Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Guid]].Contains(IIF((P == null), null, P.NullableGuidProperty))))) == True)")]
+        [InlineData("Category/EnumerableProducts/any(P: P/NullableGuidProperty in (dc75698b-581d-488b-9638-3e28dd51d8f7))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Guid]].Contains(P.NullableGuidProperty))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.EnumerableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.EnumerableProducts).Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Guid]].Contains(IIF((P == null), null, P.NullableGuidProperty))))) == True)")]
+        [InlineData("Category/QueryableProducts/any(P: P/Discontinued in (false, null))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Contains(P.Discontinued))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.QueryableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.QueryableProducts).Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Contains(IIF((P == null), null, P.Discontinued))))) == True)")]
+        [InlineData("Category/EnumerableProducts/any(P: P/Discontinued in (false, null))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Contains(P.Discontinued))", "$it => (IIF((IIF(($it.Category == null), null, $it.Category.EnumerableProducts) == null), null, Convert(IIF(($it.Category == null), null, $it.Category.EnumerableProducts).Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Contains(IIF((P == null), null, P.Discontinued))))) == True)")]
+        public void AnyInOnNavigation(string filter, string expression, string expressionWithNullPropagation)
         {
             var filters = VerifyQueryDeserialization(
                filter,
                expression,
-               NotTesting);
+               expressionWithNullPropagation);
         }
 
         [Theory]
@@ -1652,10 +1656,10 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             var result = VerifyQueryDeserialization<DataTypes>(
                 "SimpleEnumProp in ('First', 'Second')",
-                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Cast().Contains($it.SimpleEnumProp)");
+                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Contains($it.SimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            var memberAccess = (MemberExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0];
+            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
             var values = (IList<SimpleEnum>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new[] {SimpleEnum.First, SimpleEnum.Second}, values);
         }
@@ -1673,10 +1677,10 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             var result = VerifyQueryDeserialization<DataTypes>(
                 "NullableSimpleEnumProp in ('First', 'Second')",
-                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Cast().Contains($it.NullableSimpleEnumProp)");
+                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Contains($it.NullableSimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            var memberAccess = (MemberExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0];
+            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
             var values = (IList<SimpleEnum?>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new SimpleEnum?[] {SimpleEnum.First, SimpleEnum.Second}, values);
         }
@@ -1686,10 +1690,10 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             var result = VerifyQueryDeserialization<DataTypes>(
                 "NullableSimpleEnumProp in ('First', null)",
-                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Cast().Contains($it.NullableSimpleEnumProp)");
+                "$it => System.Collections.Generic.List`1[System.Nullable`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum]].Contains($it.NullableSimpleEnumProp)");
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
 
-            var memberAccess = (MemberExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0];
+            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
             var values = (IList<SimpleEnum?>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new SimpleEnum?[] {SimpleEnum.First, null}, values);
         }
@@ -2869,6 +2873,18 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 new { WithNullPropagation = false, WithoutNullPropagation = typeof(InvalidOperationException) });
         }
 
+        [Theory]
+        [InlineData("Category/Product/ProductID in (1)", "$it => System.Collections.Generic.List`1[System.Int32].Contains($it.Category.Product.ProductID)", "$it => System.Collections.Generic.List`1[System.Int32].Cast().Contains(IIF((IIF(($it.Category == null), null, $it.Category.Product) == null), null, Convert($it.Category.Product.ProductID)))")]
+        [InlineData("Category/Product/GuidProperty in (dc75698b-581d-488b-9638-3e28dd51d8f7)", "$it => System.Collections.Generic.List`1[System.Guid].Contains($it.Category.Product.GuidProperty)", "$it => System.Collections.Generic.List`1[System.Guid].Cast().Contains(IIF((IIF(($it.Category == null), null, $it.Category.Product) == null), null, Convert($it.Category.Product.GuidProperty)))")]
+        [InlineData("Category/Product/NullableGuidProperty in (dc75698b-581d-488b-9638-3e28dd51d8f7)", "$it => System.Collections.Generic.List`1[System.Nullable`1[System.Guid]].Contains($it.Category.Product.NullableGuidProperty)", "$it => System.Collections.Generic.List`1[System.Nullable`1[System.Guid]].Contains(IIF((IIF(($it.Category == null), null, $it.Category.Product) == null), null, $it.Category.Product.NullableGuidProperty))")]
+        public void InOnNavigation(string filter, string expression, string expressionWithNullPropagation)
+        {
+            var filters = VerifyQueryDeserialization(
+               filter,
+               expression,
+               expressionWithNullPropagation);
+        }
+
         [Fact]
         public void MultipleConstants_Are_Parameterized()
         {
@@ -2892,11 +2908,11 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         public void CollectionConstants_Are_Parameterized()
         {
             var result = VerifyQueryDeserialization("ProductName in ('Prod1', 'Prod2')",
-                "$it => System.Collections.Generic.List`1[System.String].Cast().Contains($it.ProductName)");
+                "$it => System.Collections.Generic.List`1[System.String].Contains($it.ProductName)");
 
             Expression<Func<Product, bool>> expression = result.WithNullPropagation;
 
-            var memberAccess = (MemberExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0];
+            var memberAccess = (MemberExpression)((MethodCallExpression)expression.Body).Arguments[0];
             var values = (IList<string>)ExpressionBinderBase.ExtractParameterizedConstant(memberAccess);
             Assert.Equal(new[] { "Prod1", "Prod2" }, values);
         }
@@ -2905,14 +2921,14 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         public void CollectionConstants_Are_Not_Parameterized_If_Disabled()
         {
             var result = VerifyQueryDeserialization("ProductName in ('Prod1', 'Prod2')",
-                "$it => System.Collections.Generic.List`1[System.String].Cast().Contains($it.ProductName)",
+                "$it => System.Collections.Generic.List`1[System.String].Contains($it.ProductName)",
                 settingsCustomizer: (settings) =>
                 {
                     settings.EnableConstantParameterization = false;
                 });
 
             Expression<Func<Product, bool>> expression = result.WithNullPropagation;
-            var values = (IList<string>)((ConstantExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0]).Value;
+            var values = (IList<string>)((ConstantExpression)((MethodCallExpression)expression.Body).Arguments[0]).Value;
             Assert.Equal(new[] { "Prod1", "Prod2" }, values);
         }
 
@@ -2921,14 +2937,14 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         {
             var result = VerifyQueryDeserialization<DataTypes>(
                 "SimpleEnumProp in ('First', 'Second')",
-                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Cast().Contains($it.SimpleEnumProp)",
+                "$it => System.Collections.Generic.List`1[Microsoft.AspNet.OData.Test.Common.Types.SimpleEnum].Contains($it.SimpleEnumProp)",
                 settingsCustomizer: (settings) =>
                 {
                     settings.EnableConstantParameterization = false;
                 });
 
             Expression<Func<DataTypes, bool>> expression = result.WithNullPropagation;
-            var values = (IList<SimpleEnum>)((ConstantExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Arguments[0]).Arguments[0]).Value;
+            var values = (IList<SimpleEnum>)((ConstantExpression)((MethodCallExpression)expression.Body).Arguments[0]).Value;
             Assert.Equal(new[] { SimpleEnum.First, SimpleEnum.Second }, values);
         }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -599,8 +599,10 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Theory]
-        [InlineData("Category/QueryableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Contains(P.ProductID))")]
-        [InlineData("Category/EnumerableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Contains(P.ProductID))")]
+        [InlineData("Category/QueryableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
+        [InlineData("Category/EnumerableProducts/any(P: P/ProductID in (1))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Int32].Cast().Contains(P.ProductID))")]
+        [InlineData("Category/QueryableProducts/any(P: P/Discontinued in (false))", "$it => $it.Category.QueryableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Cast().Contains(P.Discontinued))")]
+        [InlineData("Category/EnumerableProducts/any(P: P/Discontinued in (false))", "$it => $it.Category.EnumerableProducts.Any(P => System.Collections.Generic.List`1[System.Nullable`1[System.Boolean]].Cast().Contains(P.Discontinued))")]
         public void AnyInOnNavigation(string filter, string expression)
         {
             var filters = VerifyQueryDeserialization(


### PR DESCRIPTION
This pull request fixes issue https://github.com/OData/WebApi/issues/1596. It also fixes issue https://github.com/OData/WebApi/issues/2135 when the type is already nullable in ExpressionBinderBase.BindCollectionConstantNode, the check should be `node.ItemType.IsNullable && constantType.IsValueType && Nullable.GetUnderlyingType(constantType) == null` instead of `node.ItemType.IsNullable && constantType.IsValueType` as IsValueType returns true for any value type, including nullable value types.

The issue is that when HandleNullPropagation is set to true ExpressionBinderBase.CreatePropertyAccessExpression modifies the type of the singleValue in FilterBinder.BindInNode to a nullable type. This type then no longer matches with the type of collection in FilterBinder.BindInNode leading to a cast error as evidenced by the code below.

```csharp
	Guid? singleValue = Guid.NewGuid();
	List<Guid> collection = new List<Guid>();
	
	collection.Contains(singleValue);
```

Adds a cast operation to the FilterBinder.BindIn method to resolve this.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*