### PR TITLE
Fix NullReferenceException using $select on null value type array

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -1050,6 +1050,23 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 }
             }
 
+            // Avoid calling source.Select($it => $it).ToList() on array types.
+            if (source.Type.IsArray)
+            {
+                if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
+                {
+                    // source == null ? null : projectedCollection
+                    return Expression.Condition(
+                           test: Expression.Equal(source, Expression.Constant(null)),
+                           ifTrue: Expression.Constant(null, source.Type),
+                           ifFalse: source);
+                }
+                else
+                {
+                    return source;
+                }
+            }
+
             // expression
             //      source.Select((ElementType element) => new Wrapper { })
             var selectMethod = GetSelectMethod(elementType, projection.Type);

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -1050,20 +1050,23 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 }
             }
 
-            // Avoid calling source.Select($it => $it) and source.Select($it => $it).ToList() on array types.
+            // Avoid calling source.Select($it => $it) and source.Select($it => $it).ToList() on arrays with value types.
             if (source.Type.IsArray)
             {
-                if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
+                if (elementType.IsValueType || elementType == typeof(string))
                 {
-                    // source == null ? null : projectedCollection
-                    return Expression.Condition(
-                           test: Expression.Equal(source, Expression.Constant(null)),
-                           ifTrue: Expression.Constant(null, source.Type),
-                           ifFalse: source);
-                }
-                else
-                {
-                    return source;
+                    if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
+                    {
+                        // source == null ? null : projectedCollection
+                        return Expression.Condition(
+                               test: Expression.Equal(source, Expression.Constant(null)),
+                               ifTrue: Expression.Constant(null, source.Type),
+                               ifFalse: source);
+                    }
+                    else
+                    {
+                        return source;
+                    }
                 }
             }
 

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -1050,7 +1050,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 }
             }
 
-            // Avoid calling source.Select($it => $it).ToList() on array types.
+            // Avoid calling source.Select($it => $it) and source.Select($it => $it).ToList() on array types.
             if (source.Type.IsArray)
             {
                 if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
@@ -220,6 +220,27 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Fact]
+        public void ProjectAsWrapper_Element_ProjectedValueWithNull_DoesNotThrow()
+        {
+            // Arrange
+            QueryOrder order = new QueryOrder
+            {
+                Strings = null,
+            };
+            Expression source = Expression.Constant(order);
+            SelectExpandClause selectExpandClause = ParseSelectExpand("Strings", null, _model, _order, _orders);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _order, _orders);
+
+            // Assert
+            SelectExpandWrapper<QueryOrder> orderWrapper = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryOrder>;
+            string[] strings = orderWrapper.Container.ToDictionary(PropertyMapper)["Strings"] as string[];
+            Assert.Equal(order.Strings, strings);
+        }
+
+        [Fact]
         public void ProjectAsWrapper_Collection_AppliesPageSize_AndOrderBy()
         {
             // Arrange
@@ -1862,6 +1883,8 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         public QueryCustomer Customer { get; set; }
 
         public IDictionary<string, object> OrderProperties { get; set; }
+
+        public string[] Strings { get; set; }
     }
 
     public class QueryCustomer


### PR DESCRIPTION
### Issues

When calling $select on arrays with a value type (or string), and its value is null, an error is thrown. This is due to the fact that null.Select(it => it).ToList() obviously throws a NullReferenceException. Null values for arrays of these types are common when dealing with navigation properties which are null (e.g. $expand=parent where parent is null).
This pull request avoids Expression.Call for Select and Expression.Call for ToList on arrays of these types, as they are not necessary anyway.

### Description

A check is added whether the collection currently being projected is an array with a value type (or string). If that is the case, then Expression.Call for Select and Expression.Call for ToList are avoided.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
