### PR TITLE
Enhance batch accept header decision

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs
@@ -198,7 +198,7 @@ namespace Microsoft.AspNet.OData.Batch
             IEnumerable<MediaTypeHeaderValue> acceptHeaders = MediaTypeHeaderValue.ParseList(request.Headers.GetCommaSeparatedValues("Accept"));
             string responseContentType = null;
 
-            foreach (var acceptHeader in acceptHeaders.OrderByDescending(h => h.Quality))
+            foreach (var acceptHeader in acceptHeaders.OrderByDescending(h => h.Quality == null ? 1 : h.Quality))
             {
                 if (acceptHeader.MediaType.Equals(ODataBatchHttpRequestExtensions.BatchMediaTypeMime, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs
@@ -198,7 +198,7 @@ namespace Microsoft.AspNet.OData.Batch
             IEnumerable<MediaTypeHeaderValue> acceptHeaders = MediaTypeHeaderValue.ParseList(request.Headers.GetCommaSeparatedValues("Accept"));
             string responseContentType = null;
 
-            foreach (var acceptHeader in acceptHeaders.OrderByDescending(h => h.Quality == null ? 1 : h.Quality))
+            foreach (MediaTypeHeaderValue acceptHeader in acceptHeaders.OrderByDescending(h => h.Quality == null ? 1 : h.Quality))
             {
                 if (acceptHeader.MediaType.Equals(ODataBatchHttpRequestExtensions.BatchMediaTypeMime, StringComparison.OrdinalIgnoreCase))
                 {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchReaderExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchReaderExtensionsTest.cs
@@ -3,12 +3,14 @@
 
 #if !NETCORE // TODO #939: Enable these test on AspNetCore.
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.OData.Batch;
+using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
 using Microsoft.OData;
 using Xunit;
@@ -75,6 +77,81 @@ namespace Microsoft.AspNet.OData.Test.Batch
                 () => ODataBatchReaderExtensions.ReadChangeSetOperationRequestAsync(reader.CreateODataBatchReader(),
                     Guid.NewGuid(), Guid.NewGuid(), false, CancellationToken.None),
                 "The current batch reader state 'Initial' is invalid. The expected state is 'Operation'.");
+        }
+
+        private static ODataMessageQuotas _odataMessageQuotas = new ODataMessageQuotas { MaxReceivedMessageSize = Int64.MaxValue };
+
+        [Theory]
+        // if no accept header, return multipart/mixed
+        [InlineData(null, "multipart/mixed")]
+
+        // if accept is multipart/mixed, return multipart/mixed
+        [InlineData(new[] { "multipart/mixed" }, "multipart/mixed")]
+
+        // if accept is application/json, return application/json
+        [InlineData(new[] { "application/json" }, "application/json")]
+
+        // if accept is application/json with charset, return application/json
+        [InlineData(new[] { "application/json; charset=utf-8" }, "application/json")]
+
+        // if multipart/mixed is high proprity, return multipart/mixed
+        [InlineData(new[] { "multipart/mixed;q=0.9", "application/json;q=0.5" }, "multipart/mixed")]
+        [InlineData(new[] { "application/json;q=0.5", "multipart/mixed;q=0.9" }, "multipart/mixed")]
+
+        // if application/json is high proprity, return application/json
+        [InlineData(new[] { "application/json;q=0.9", "multipart/mixed;q=0.5" }, "application/json")]
+        [InlineData(new[] { "multipart/mixed;q=0.5", "application/json;q=0.9" }, "application/json")]
+
+        // if priorities are same, return first
+        [InlineData(new[] { "multipart/mixed;q=0.9", "application/json;q=0.9" }, "multipart/mixed")]
+        [InlineData(new[] { "multipart/mixed", "application/json" }, "multipart/mixed")]
+
+        // if priorities are same, return first
+        [InlineData(new[] { "application/json;q=0.9", "multipart/mixed;q=0.9" }, "application/json")]
+        [InlineData(new[] { "application/json", "multipart/mixed" }, "application/json")]
+
+        // no priority has q=1.0
+        [InlineData(new[] { "application/json", "multipart/mixed;q=0.9" }, "application/json")]
+        [InlineData(new[] { "application/json;q=0.9", "multipart/mixed" }, "multipart/mixed")]
+
+        public async Task CreateODataBatchResponseAsync(string[] accept, string expected)
+        {
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/$batch");
+            var responses = new[] { new ChangeSetResponseItem(Enumerable.Empty<HttpResponseMessage>()) };
+
+            if (accept != null)
+            {
+                request.Headers.Add("Accept", accept);
+            }
+
+            var response = await request.CreateODataBatchResponseAsync(responses, _odataMessageQuotas);
+
+            Assert.StartsWith(expected, response.Content.Headers.ContentType.MediaType);
+        }
+
+        [Theory]
+        // if no contentType, return multipart/mixed
+        [InlineData(null, "multipart/mixed")]
+        // if contentType is application/json, return application/json
+        [InlineData("application/json", "application/json")]
+        [InlineData("application/json; charset=utf-8", "application/json")]
+        // if contentType is multipart/mixed, return multipart/mixed
+        [InlineData("multipart/mixed", "multipart/mixed")]
+        public async Task CreateODataBatchResponseAsyncWhenNoAcceptHeader(string contentType, string expected)
+        {
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/$batch");
+            var responses = new[] { new ChangeSetResponseItem(Enumerable.Empty<HttpResponseMessage>()) };
+
+            if (contentType != null)
+            {
+                request.Content = new ByteArrayContent(new byte[] { });
+                request.Content.Headers.Add("Content-Type", contentType);
+            }
+
+            var response = await request.CreateODataBatchResponseAsync(responses, _odataMessageQuotas);
+
+            Assert.False(request.Headers.Contains("Accept")); // check no accept header
+            Assert.StartsWith(expected, response.Content.Headers.ContentType.MediaType);
         }
     }
 }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Batch/ODataBatchHttpRequestMessageExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Batch/ODataBatchHttpRequestMessageExtensionsTest.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Batch;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Test.Abstraction;
+using Microsoft.AspNetCore.Http;
+using Microsoft.OData;
+using Xunit;
+
+namespace Microsoft.AspNet.OData.Test.Batch
+{
+    public class ODataBatchHttpRequestMessageExtensionsTest
+    {
+        private static ODataMessageQuotas _odataMessageQuotas = new ODataMessageQuotas { MaxReceivedMessageSize = Int64.MaxValue };
+
+        [Theory]
+        // if no accept header, return multipart/mixed
+        [InlineData(null, "multipart/mixed")]
+
+        // if accept is multipart/mixed, return multipart/mixed
+        [InlineData(new[] { "multipart/mixed" }, "multipart/mixed")]
+        
+        // if accept is application/json, return application/json
+        [InlineData(new[] { "application/json" }, "application/json")]
+        
+        // if accept is application/json with charset, return application/json
+        [InlineData(new[] { "application/json; charset=utf-8" }, "application/json")]
+        
+        // if multipart/mixed is high proprity, return multipart/mixed
+        [InlineData(new[] { "multipart/mixed;q=0.9", "application/json;q=0.5" }, "multipart/mixed")]
+        [InlineData(new[] { "application/json;q=0.5", "multipart/mixed;q=0.9" }, "multipart/mixed")]
+        
+        // if application/json is high proprity, return application/json
+        [InlineData(new[] { "application/json;q=0.9", "multipart/mixed;q=0.5" }, "application/json")]
+        [InlineData(new[] { "multipart/mixed;q=0.5", "application/json;q=0.9" }, "application/json")]
+        
+        // if proprities are same, return first
+        [InlineData(new[] { "multipart/mixed;q=0.9", "application/json;q=0.9" }, "multipart/mixed")]
+        [InlineData(new[] { "multipart/mixed", "application/json" }, "multipart/mixed")]
+        
+        // if proprities are same, return first
+        [InlineData(new[] { "application/json;q=0.9", "multipart/mixed;q=0.9" }, "application/json")]
+        [InlineData(new[] { "application/json", "multipart/mixed" }, "application/json")]
+
+        public async Task CreateODataBatchResponseAsync(string[] accept, string expected)
+        {
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/$batch");
+            var responses = new[] { new ChangeSetResponseItem(Enumerable.Empty<HttpContext>()) };
+
+            if (accept != null)
+            {
+                request.Headers.Add("Accept", accept);
+            }
+
+            await request.CreateODataBatchResponseAsync(responses, _odataMessageQuotas);
+
+            Assert.StartsWith(expected, request.HttpContext.Response.ContentType);
+        }
+
+        [Theory]
+        // if no contentType, return multipart/mixed
+        [InlineData(null, "multipart/mixed")]
+        // if contentType is application/json, return application/json
+        [InlineData("application/json", "application/json")]
+        [InlineData("application/json; charset=utf-8", "application/json")]
+        // if contentType is multipart/mixed, return multipart/mixed
+        [InlineData("multipart/mixed", "multipart/mixed")]
+
+        public async Task CreateODataBatchResponseAsyncWhenNoAcceptHeader(string contentType, string expected)
+        {
+            var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/$batch");
+            var responses = new[] { new ChangeSetResponseItem(Enumerable.Empty<HttpContext>()) };
+
+            if (contentType != null)
+            {
+                request.ContentType = contentType;
+            }
+            
+            await request.CreateODataBatchResponseAsync(responses, _odataMessageQuotas);
+
+            Assert.False(request.Headers.ContainsKey("Accept")); // check no accept header
+            Assert.StartsWith(expected, request.HttpContext.Response.ContentType);
+        }
+    }
+}

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Batch/ODataBatchHttpRequestMessageExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Batch/ODataBatchHttpRequestMessageExtensionsTest.cs
@@ -36,12 +36,12 @@ namespace Microsoft.AspNet.OData.Test.Batch
         // if application/json is high proprity, return application/json
         [InlineData(new[] { "application/json;q=0.9", "multipart/mixed;q=0.5" }, "application/json")]
         [InlineData(new[] { "multipart/mixed;q=0.5", "application/json;q=0.9" }, "application/json")]
-        
-        // if proprities are same, return first
+
+        // if priorities are same, return first
         [InlineData(new[] { "multipart/mixed;q=0.9", "application/json;q=0.9" }, "multipart/mixed")]
         [InlineData(new[] { "multipart/mixed", "application/json" }, "multipart/mixed")]
-        
-        // if proprities are same, return first
+
+        // if priorities are same, return first
         [InlineData(new[] { "application/json;q=0.9", "multipart/mixed;q=0.9" }, "application/json")]
         [InlineData(new[] { "application/json", "multipart/mixed" }, "application/json")]
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Batch/ODataBatchHttpRequestMessageExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Batch/ODataBatchHttpRequestMessageExtensionsTest.cs
@@ -48,7 +48,6 @@ namespace Microsoft.AspNet.OData.Test.Batch
         // no priority has q=1.0
         [InlineData(new[] { "application/json", "multipart/mixed;q=0.9" }, "application/json")]
         [InlineData(new[] { "application/json;q=0.9", "multipart/mixed" }, "multipart/mixed")]
-
         public async Task CreateODataBatchResponseAsync(string[] accept, string expected)
         {
             var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/$batch");
@@ -72,7 +71,6 @@ namespace Microsoft.AspNet.OData.Test.Batch
         [InlineData("application/json; charset=utf-8", "application/json")]
         // if contentType is multipart/mixed, return multipart/mixed
         [InlineData("multipart/mixed", "multipart/mixed")]
-
         public async Task CreateODataBatchResponseAsyncWhenNoAcceptHeader(string contentType, string expected)
         {
             var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/$batch");

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Batch/ODataBatchHttpRequestMessageExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Batch/ODataBatchHttpRequestMessageExtensionsTest.cs
@@ -45,6 +45,10 @@ namespace Microsoft.AspNet.OData.Test.Batch
         [InlineData(new[] { "application/json;q=0.9", "multipart/mixed;q=0.9" }, "application/json")]
         [InlineData(new[] { "application/json", "multipart/mixed" }, "application/json")]
 
+        // no priority has q=1.0
+        [InlineData(new[] { "application/json", "multipart/mixed;q=0.9" }, "application/json")]
+        [InlineData(new[] { "application/json;q=0.9", "multipart/mixed" }, "multipart/mixed")]
+
         public async Task CreateODataBatchResponseAsync(string[] accept, string expected)
         {
             var request = RequestFactory.Create(HttpMethod.Get, "http://localhost/$batch");


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Enhance batch content type decision.  
*This pull request fixes issue #xxx.*

### Description

 `CreateODataBatchResponseAsync`'s content type decision is uncertain.

Currently

| Request Accept | Request Content-Type | Response Content-Type |
|:------------------|:-------------------------|:---------------------------|
|                           |  application/json          |application/json             |
|                           |  *                                  | multipart/mixed             |
|  multipart/mixed   |  *                                  | multipart/mixed             |
|   application/json  |  *                                  |  application/json            |
|  multipart/mixed, application/json   |  *                                  | application/json              |
|  application/json, multipart/mixed   |  *                                  | application/json              |
|  multipart/mixed; q=0.8, application/json; q=0.8   |  *                                  | application/json              |
|  application/json; q=0.8, multipart/mixed; q=0.8   |  *                                  | application/json              |
|  multipart/mixed; q=0.9, application/json; q=0.5   |  *                                  | application/json              |
|  application/json; q=0.5, multipart/mixed; q=0.9   |  *                                  | application/json              |
|  multipart/mixed; q=0.5, application/json; q=0.9   |  *                                  | application/json              |
|  application/json; q=0.9, multipart/mixed; q=0.5   |  *                                  | application/json              |


Expected

| Request Accept | Request Content-Type | Response Content-Type |
|:------------------|:-------------------------|:---------------------------|
|                           |  application/json          |application/json             |
|                           |  *                                  | multipart/mixed             |
|  multipart/mixed   |  *                                  | multipart/mixed             |
|   application/json  |  *                                  |  application/json            |
|  multipart/mixed, application/json   |  *                                  | multipart/mixed              |
|  application/json, multipart/mixed   |  *                                  | application/json              |
|  multipart/mixed; q=0.8, application/json; q=0.8   |  *                                  | multipart/mixed             |
|  application/json; q=0.8, multipart/mixed; q=0.8   |  *                                  | application/json              |
|  multipart/mixed; q=0.9, application/json; q=0.5   |  *                                  | multipart/mixed              |
|  application/json; q=0.5, multipart/mixed; q=0.9   |  *                                  | multipart/mixed             |
|  multipart/mixed; q=0.5, application/json; q=0.9   |  *                                  | application/json              |
|  application/json; q=0.9, multipart/mixed; q=0.5   |  *                                  | application/json              |

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
