### PR TITLE
Fix AspNetCore Resolving of Batch ContentId for AddRelatedObject (#2071)

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.Contracts;
 using System.Threading.Tasks;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 
 namespace Microsoft.AspNet.OData.Batch
 {
@@ -35,19 +36,12 @@ namespace Microsoft.AspNet.OData.Batch
 
             if (contentIdToLocationMapping != null)
             {
-                string queryString = context.Request.QueryString.HasValue ? context.Request.QueryString.Value : String.Empty;
-                string resolvedRequestUrl = ContentIdHelpers.ResolveContentId(queryString, contentIdToLocationMapping);
+                string displayUrl = context.Request.GetDisplayUrl();
+                string resolvedRequestUrl = ContentIdHelpers.ResolveContentId(displayUrl, contentIdToLocationMapping);
                 if (!string.IsNullOrEmpty(resolvedRequestUrl))
                 {
-                    Uri resolvedUri = new Uri(resolvedRequestUrl, UriKind.RelativeOrAbsolute);
-                    if (resolvedUri.IsAbsoluteUri)
-                    {
-                        context.Request.CopyAbsoluteUrl(resolvedUri);
-                    }
-                    else
-                    {
-                        context.Request.QueryString = new QueryString(resolvedRequestUrl);
-                    }
+                    Uri resolvedUri = new Uri(resolvedRequestUrl, UriKind.Absolute);
+                    context.Request.CopyAbsoluteUrl(resolvedUri);
                 }
 
                 context.Request.SetODataContentIdMapping(contentIdToLocationMapping);

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs
@@ -36,11 +36,12 @@ namespace Microsoft.AspNet.OData.Batch
 
             if (contentIdToLocationMapping != null)
             {
-                string displayUrl = context.Request.GetDisplayUrl();
-                string resolvedRequestUrl = ContentIdHelpers.ResolveContentId(displayUrl, contentIdToLocationMapping);
-                if (!string.IsNullOrEmpty(resolvedRequestUrl))
-                {
-                    Uri resolvedUri = new Uri(resolvedRequestUrl, UriKind.Absolute);
+                string encodedUrl = context.Request.GetEncodedUrl();
+                string resolvedRequestUrl = ContentIdHelpers.ResolveContentId(encodedUrl, contentIdToLocationMapping);
+                Uri resolvedUri;
+                if (!string.IsNullOrEmpty(resolvedRequestUrl)
+                    && Uri.TryCreate(resolvedRequestUrl, UriKind.Absolute, out resolvedUri))
+                { 
                     context.Request.CopyAbsoluteUrl(resolvedUri);
                 }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchRequestItemTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchRequestItemTest.cs
@@ -81,8 +81,8 @@ namespace Microsoft.AspNet.OData.Test.Batch
         [Fact]
         public async Task SendMessageAsync_Resolves_Uri_From_ContentId()
         {
-			// Arrange
-			DefaultHttpContext context = new DefaultHttpContext();
+            // Arrange
+            DefaultHttpContext context = new DefaultHttpContext();
             HttpResponseMessage response = new HttpResponseMessage();
             RequestDelegate handler = (c) => { return Task.FromResult(response); };
             Dictionary<string, string> contentIdLocationMappings = new Dictionary<string, string>();
@@ -90,7 +90,7 @@ namespace Microsoft.AspNet.OData.Test.Batch
             Uri unresolvedUri = new Uri("http://localhost:12345/odata/$1/Orders");
             context.Request.CopyAbsoluteUrl(unresolvedUri);
 			
-			// Act
+            // Act
             await ODataBatchRequestItem.SendRequestAsync(handler, context, contentIdLocationMappings);
 
             // Assert


### PR DESCRIPTION
AspNetCore.OData ODataBatchRequestItem does not properly call ContentIdHelpers.ResolveContentId() with a url but instead passes querystring.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2071 .*

### Description

*During a migration of a project from .NET Framework to .NET Core 3.1 I found that Microsoft.AspNetCore.OData's handling of batch ContentId paths behave differently than the framework version of the library. The result being a server response of 404 on an inner request when a client calls AddRelatedObject(). I have created complete samples of this behavior for [aspnet](https://github.com/AdamCaviness/ODataAddRelatedObject) and [aspnetcore](https://github.com/AdamCaviness/ODataCoreAddRelatedObject). You can observe that only aspnetcore is broken.*

*I found that [ODataBatchRequestItem](https://github.com/OData/WebApi/blob/d02bc61ea7b31ada1e54abbeebbecb3c5df0e3ac/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs#L25) was improperly calling [ContentIdHelpers.ResolveContentId()](https://github.com/OData/WebApi/blob/d02bc61ea7b31ada1e54abbeebbecb3c5df0e3ac/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs#L39) with a querystring instead of a url.*

*The [existing unit tests for ODataBatchRequestItem](https://github.com/OData/WebApi/blob/d02bc61ea7b31ada1e54abbeebbecb3c5df0e3ac/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchRequestItemTest.cs#L4) were commented out for aspnetcore so I copied the aspnet version and updated them for aspnetcore while adding a new test for my changes as well.*

### Checklist

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*