### PR TITLE
Fix Delta<TStructuralType>.GetInstance() method

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
@@ -666,6 +666,12 @@ namespace Microsoft.AspNet.OData
                 return false;
             }
 
+            PropertyAccessor<TStructuralType> cacheHit = _allProperties[name];
+            // Get the Delta<{NestedResourceType}>._instance using Reflection.
+            FieldInfo field = deltaNestedResource.GetType().GetField("_instance", BindingFlags.NonPublic | BindingFlags.Instance);
+            Contract.Assert(field != null, "field != null");
+            cacheHit.SetValue(_instance, field.GetValue(deltaNestedResource));
+
             // Add the nested resource in the hierarchy.
             // Note: We shouldn't add the structural properties to the <code>_changedProperties</code>, which
             // is used for keeping track of changed non-structural properties at current level.

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/OpenComplexTypeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/OpenComplexTypeTest.cs
@@ -271,6 +271,24 @@ namespace Microsoft.AspNet.OData.Test
             await ExecutePatchRequest(payload);
         }
 
+        [Fact]
+        public async Task OpenComplexType_PatchNestedComplexTypeProperty_GetInstance()
+        {
+            string payload = @"{
+                ""Street"":""UpdatedStreet"",
+                ""Token@odata.type"":""#Guid"",
+                ""Token"":""3CA243CF-460A-4144-B6EB-F5E1180ABDC8"",
+                ""BirthDay@odata.type"":""#Date"",
+                ""BirthDay"":""2016-01-29"",
+                ""LineA"": {
+                    ""Description"": ""DescriptionA"",
+                    ""PhoneInfo"" : {""ContactName"":""ContactNameA"", ""PhoneNumber"": 7654321}
+                }
+            }";
+
+            await ExecutePatchRequest(payload);
+        }
+
         private async Task ExecutePatchRequest(string payload)
         {
             // Arrange
@@ -563,7 +581,25 @@ namespace Microsoft.AspNet.OData.Test
                     Assert.NotNull(phone.Spec);
                     Assert.Equal(5, phone.Spec.ScreenSize);
                     break;
+                case "3CA243CF-460A-4144-B6EB-F5E1180ABDC8":
+                    OpenAddress addressInstance = address.GetInstance();
+                    Assert.NotNull(addressInstance);
 
+                    // Complex property
+                    Assert.NotNull(addressInstance.LineA);
+                    Assert.NotNull(addressInstance.LineA.PhoneInfo);
+                    Assert.Equal(7654321, addressInstance.LineA.PhoneInfo.PhoneNumber);
+
+                    object lineAValue;
+                    // Fetch LineA property using TryGetPropertyValue
+                    Assert.True(address.TryGetPropertyValue("LineA", out lineAValue));
+                    LineDetails lineA = lineAValue as LineDetails;
+                    Assert.NotNull(lineA);
+
+                    // Nested complex property
+                    Assert.NotNull(lineA.PhoneInfo);
+                    Assert.Equal(7654321, lineA.PhoneInfo.PhoneNumber);
+                    break;
                 default:
                     // Error
                     Assert.True(false, "Unexpected token value " + dynamicPropertyToken);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2193.*

### Description

Based on the docstring for `Delta<TStructuralType>.GetInstance()` , the method _**Returns the instance that holds all the changes (and original values) being tracked by this Delta.**_ A regression was introduced in [this](https://github.com/OData/WebApi/pull/1445) PR such that changed complex type properties are currently not added to that instance. Consequently, changed complex type properties are absent from the `GetInstance()` response value. The bug also indirectly affects the `TryGetPropertyValue(string name, out object value)` when the target property is of complex type

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
