### PR TITLE
Fix invalid location header generated when key property for a model contains unicode chars

### DIFF
--- a/src/Microsoft.AspNet.OData/Results/ResultHelpers.cs
+++ b/src/Microsoft.AspNet.OData/Results/ResultHelpers.cs
@@ -60,7 +60,8 @@ namespace Microsoft.AspNet.OData.Results
         {
             if (response.StatusCode == HttpStatusCode.NoContent)
             {
-                response.Headers.TryAddWithoutValidation(EntityIdHeaderName, entityId().ToString());
+                Uri location = entityId();
+                response.Headers.TryAddWithoutValidation(EntityIdHeaderName, location.AbsoluteUri);
             }
         }
 

--- a/src/Microsoft.AspNetCore.OData/Results/CreatedODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/CreatedODataResult.cs
@@ -54,8 +54,9 @@ namespace Microsoft.AspNet.OData.Results
             HttpRequest request = context.HttpContext.Request;
             HttpResponse response = context.HttpContext.Response;
             IActionResult result = GetInnerActionResult(request);
-            response.Headers["Location"] = GenerateLocationHeader(request).ToString();
+            Uri location = GenerateLocationHeader(request);
 
+            response.Headers["Location"] = location.AbsoluteUri;
             // Since AddEntityId relies on the response, make sure to execute the result
             // before calling AddEntityId() to ensure the response code is set correctly.
             await result.ExecuteResultAsync(context);

--- a/src/Microsoft.AspNetCore.OData/Results/ResultHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/ResultHelpers.cs
@@ -59,8 +59,7 @@ namespace Microsoft.AspNet.OData.Results
         {
             if (response.StatusCode == (int)HttpStatusCode.NoContent)
             {
-                Uri location = entityId();
-                response.Headers.Add(EntityIdHeaderName, location.AbsoluteUri);
+                response.Headers.Add(EntityIdHeaderName, entityId().AbsoluteUri);
             }
         }
 

--- a/src/Microsoft.AspNetCore.OData/Results/ResultHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/ResultHelpers.cs
@@ -59,7 +59,8 @@ namespace Microsoft.AspNet.OData.Results
         {
             if (response.StatusCode == (int)HttpStatusCode.NoContent)
             {
-                response.Headers.Add(EntityIdHeaderName, entityId().ToString());
+                Uri location = entityId();
+                response.Headers.Add(EntityIdHeaderName, location.AbsoluteUri);
             }
         }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
@@ -404,6 +404,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)SelectExpandNestedDollarCountTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SelectExpandTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeHelperTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UnicodeCharactersTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Resources\ArrayOfBoolean.json" />

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/UnicodeCharactersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/UnicodeCharactersTest.cs
@@ -1,31 +1,21 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
-#if NETCORE
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using Microsoft.AspNet.OData.Builder;
-using Microsoft.AspNet.OData.Extensions;
-using Microsoft.AspNet.OData.Test.Abstraction;
-using Microsoft.AspNetCore.Mvc;
-using Xunit;
-#else
-using System;
-using System.ComponentModel.DataAnnotations;
-using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Threading.Tasks;
+#if !NETCORE
 using System.Web.Http;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using Microsoft.AspNet.OData.Builder;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Test.Abstraction;
 using Xunit;
-#endif
 
 namespace Microsoft.AspNet.OData.Test
 {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/UnicodeCharactersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/UnicodeCharactersTest.cs
@@ -33,6 +33,7 @@ namespace Microsoft.AspNet.OData.Test
 				"}";
 
 			const string uri = "http://localhost/odata/UnicodeCharUsers";
+			const string expectedLocation = "http://localhost/odata/UnicodeCharUsers('%C3%84rne%20Bj%C3%B8rn')";
 
 			HttpClient client = GetClient();
 			HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
@@ -45,7 +46,7 @@ namespace Microsoft.AspNet.OData.Test
 			// Assert
 			Assert.True(response.IsSuccessStatusCode);
 			Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-			Assert.Equal(new Uri("http://localhost/odata/UnicodeCharUsers('Ärne Bjørn')"), response.Headers.Location);
+			Assert.Equal(expectedLocation, response.Headers.Location.AbsoluteUri);
 		}
 
 		[Fact]
@@ -58,11 +59,12 @@ namespace Microsoft.AspNet.OData.Test
 				"}";
 
 			const string uri = "http://localhost/odata/UnicodeCharUsers";
-			const string preferNoContentHeaderValue = "return=minimal";
-
+			const string preferNoContent = "return=minimal";
+			const string expectedLocation = "http://localhost/odata/UnicodeCharUsers('%C3%84rne%20Bj%C3%B8rn')";
+			
 			HttpClient client = GetClient();
 			HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
-			request.Headers.TryAddWithoutValidation("Prefer", preferNoContentHeaderValue);
+			request.Headers.TryAddWithoutValidation("Prefer", preferNoContent);
 
 			request.Content = new StringContent(payload);
 			request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
@@ -73,11 +75,11 @@ namespace Microsoft.AspNet.OData.Test
 			// Assert
 			Assert.True(response.IsSuccessStatusCode);
 			Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-			Assert.Equal(new Uri("http://localhost/odata/UnicodeCharUsers('Ärne Bjørn')"), response.Headers.Location);
+			Assert.Equal(expectedLocation, response.Headers.Location.AbsoluteUri);
 			IEnumerable<string> values;
 			Assert.True(response.Headers.TryGetValues("OData-EntityId", out values));
 			Assert.Single(values);
-			Assert.Equal("http://localhost/odata/UnicodeCharUsers('%C3%84rne%20Bj%C3%B8rn')", values.First());
+			Assert.Equal(expectedLocation, values.First());
         }
 
 		private static HttpClient GetClient()

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/UnicodeCharactersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/UnicodeCharactersTest.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+#if NETCORE
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Test.Abstraction;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+#else
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Test.Abstraction;
+using Xunit;
+#endif
+
+namespace Microsoft.AspNet.OData.Test
+{
+    public class UnicodeCharactersTest
+    {
+		[Fact]
+		public async Task PostEntity_WithUnicodeCharactersInKey()
+		{
+			// Arrange
+			const string payload = "{" +
+				"\"LogonName\":\"Ärne Bjørn\"," +
+				"\"Email\":\"ärnebjørn@test.com\"" +
+				"}";
+
+			const string uri = "http://localhost/odata/UnicodeCharUsers";
+
+			HttpClient client = GetClient();
+			HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
+			request.Content = new StringContent(payload);
+			request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+
+			// Act
+			HttpResponseMessage response = await client.SendAsync(request);
+
+			// Assert
+			Assert.True(response.IsSuccessStatusCode);
+			Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+			Assert.Equal(new Uri("http://localhost/odata/UnicodeCharUsers('Ärne Bjørn')"), response.Headers.Location);
+		}
+
+		private static HttpClient GetClient()
+		{
+			ODataConventionModelBuilder modelBuilder = ODataConventionModelBuilderFactory.Create();
+			modelBuilder.EntitySet<UnicodeCharUser>("UnicodeCharUsers");
+
+			var controllers = new[] { typeof(MetadataController), typeof(UnicodeCharUsersController) };
+			var server = TestServerFactory.Create(controllers, (config) => {
+				config.Select().OrderBy().Filter().Expand().Count().MaxTop(null);
+				config.MapODataServiceRoute("odata", "odata", modelBuilder.GetEdmModel());
+			});
+
+			return TestServerFactory.CreateClient(server);
+		}
+	}
+
+	public class UnicodeCharUsersController : TestODataController
+	{
+		public ITestActionResult Post([FromBody] UnicodeCharUser user)
+		{
+			return Created(user);
+		}
+	}
+
+	public class UnicodeCharUser
+	{
+		[Key]
+		public string LogonName { get; set; }
+		public string Email { get; set; }
+	}
+}

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/UnicodeCharactersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/UnicodeCharactersTest.cs
@@ -23,92 +23,93 @@ namespace Microsoft.AspNet.OData.Test
 {
     public class UnicodeCharactersTest
     {
-		[Fact]
-		public async Task PostEntity_WithUnicodeCharactersInKey()
-		{
-			// Arrange
-			const string payload = "{" +
-				"\"LogonName\":\"Ärne Bjørn\"," +
-				"\"Email\":\"ärnebjørn@test.com\"" +
-				"}";
+        [Fact]
+        public async Task PostEntity_WithUnicodeCharactersInKey()
+        {
+            // Arrange
+            const string payload = "{" +
+                "\"LogonName\":\"Ärne Bjørn\"," +
+                "\"Email\":\"ärnebjørn@test.com\"" +
+                "}";
 
-			const string uri = "http://localhost/odata/UnicodeCharUsers";
-			const string expectedLocation = "http://localhost/odata/UnicodeCharUsers('%C3%84rne%20Bj%C3%B8rn')";
+            const string uri = "http://localhost/odata/UnicodeCharUsers";
+            const string expectedLocation = "http://localhost/odata/UnicodeCharUsers('%C3%84rne%20Bj%C3%B8rn')";
 
-			HttpClient client = GetClient();
-			HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
-			request.Content = new StringContent(payload);
-			request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+            HttpClient client = GetClient();
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
+            request.Content = new StringContent(payload);
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
 
-			// Act
-			HttpResponseMessage response = await client.SendAsync(request);
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
 
-			// Assert
-			Assert.True(response.IsSuccessStatusCode);
-			Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-			Assert.Equal(expectedLocation, response.Headers.Location.AbsoluteUri);
-		}
-
-		[Fact]
-		public async Task PostEntity_WithUnicodeCharactersInKey_PreferNoContent()
-		{
-			// Arrange
-			const string payload = "{" +
-				"\"LogonName\":\"Ärne Bjørn\"," +
-				"\"Email\":\"ärnebjørn@test.com\"" +
-				"}";
-
-			const string uri = "http://localhost/odata/UnicodeCharUsers";
-			const string preferNoContent = "return=minimal";
-			const string expectedLocation = "http://localhost/odata/UnicodeCharUsers('%C3%84rne%20Bj%C3%B8rn')";
-			
-			HttpClient client = GetClient();
-			HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
-			request.Headers.TryAddWithoutValidation("Prefer", preferNoContent);
-
-			request.Content = new StringContent(payload);
-			request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
-
-			// Act
-			HttpResponseMessage response = await client.SendAsync(request);
-
-			// Assert
-			Assert.True(response.IsSuccessStatusCode);
-			Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-			Assert.Equal(expectedLocation, response.Headers.Location.AbsoluteUri);
-			IEnumerable<string> values;
-			Assert.True(response.Headers.TryGetValues("OData-EntityId", out values));
-			Assert.Single(values);
-			Assert.Equal(expectedLocation, values.First());
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+            Assert.Equal(expectedLocation, response.Headers.Location.AbsoluteUri);
         }
 
-		private static HttpClient GetClient()
-		{
-			ODataConventionModelBuilder modelBuilder = ODataConventionModelBuilderFactory.Create();
-			modelBuilder.EntitySet<UnicodeCharUser>("UnicodeCharUsers");
+        [Fact]
+        public async Task PostEntity_WithUnicodeCharactersInKey_PreferNoContent()
+        {
+            // Arrange
+            const string payload = "{" +
+                "\"LogonName\":\"Ärne Bjørn\"," +
+                "\"Email\":\"ärnebjørn@test.com\"" +
+                "}";
 
-			var controllers = new[] { typeof(MetadataController), typeof(UnicodeCharUsersController) };
-			var server = TestServerFactory.Create(controllers, (config) => {
-				config.Select().OrderBy().Filter().Expand().Count().MaxTop(null);
-				config.MapODataServiceRoute("odata", "odata", modelBuilder.GetEdmModel());
-			});
+            const string uri = "http://localhost/odata/UnicodeCharUsers";
+            const string preferNoContent = "return=minimal";
+            const string expectedLocation = "http://localhost/odata/UnicodeCharUsers('%C3%84rne%20Bj%C3%B8rn')";
 
-			return TestServerFactory.CreateClient(server);
-		}
-	}
+            HttpClient client = GetClient();
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
+            request.Headers.TryAddWithoutValidation("Prefer", preferNoContent);
 
-	public class UnicodeCharUsersController : TestODataController
-	{
-		public ITestActionResult Post([FromBody] UnicodeCharUser user)
-		{
-			return Created(user);
-		}
-	}
+            request.Content = new StringContent(payload);
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
 
-	public class UnicodeCharUser
-	{
-		[Key]
-		public string LogonName { get; set; }
-		public string Email { get; set; }
-	}
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            Assert.Equal(expectedLocation, response.Headers.Location.AbsoluteUri);
+            IEnumerable<string> values;
+            Assert.True(response.Headers.TryGetValues("OData-EntityId", out values));
+            Assert.Single(values);
+            Assert.Equal(expectedLocation, values.First());
+        }
+
+        private static HttpClient GetClient()
+        {
+            ODataConventionModelBuilder modelBuilder = ODataConventionModelBuilderFactory.Create();
+            modelBuilder.EntitySet<UnicodeCharUser>("UnicodeCharUsers");
+
+            var controllers = new[] { typeof(MetadataController), typeof(UnicodeCharUsersController) };
+            var server = TestServerFactory.Create(controllers, (config) =>
+            {
+                config.Select().OrderBy().Filter().Expand().Count().MaxTop(null);
+                config.MapODataServiceRoute("odata", "odata", modelBuilder.GetEdmModel());
+            });
+
+            return TestServerFactory.CreateClient(server);
+        }
+    }
+
+    public class UnicodeCharUsersController : TestODataController
+    {
+        public ITestActionResult Post([FromBody] UnicodeCharUser user)
+        {
+            return Created(user);
+        }
+    }
+
+    public class UnicodeCharUser
+    {
+        [Key]
+        public string LogonName { get; set; }
+        public string Email { get; set; }
+    }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/UnicodeCharactersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/UnicodeCharactersTest.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNet.OData.Test
 			Assert.True(response.Headers.TryGetValues("OData-EntityId", out values));
 			Assert.Single(values);
 			Assert.Equal("http://localhost/odata/UnicodeCharUsers('%C3%84rne%20Bj%C3%B8rn')", values.First());
-		}
+        }
 
 		private static HttpClient GetClient()
 		{


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2240 .*

### Description

When the key property of a model is of type string and unicode characters are used (e.g. umlaut), the generated URL will contain chars that are not valid in headers.

For instance, for key equals **Ärne Bjørn**, the generated location is
```
/EntitySet('Ã�rne BjÃ¸rn')
```
instead of
```
/EntitySet(%C3%84rne%20Bj%C3%B8rn)
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed
### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
