### PR TITLE
Fix/2247 Allow case insensitive request binding

### DIFF
--- a/src/Microsoft.AspNet.OData/Adapters/WebApiRequestMessage.cs
+++ b/src/Microsoft.AspNet.OData/Adapters/WebApiRequestMessage.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.OData.Adapters
         /// <summary>
         /// The inner request wrapped by this instance.
         /// </summary>
-        private HttpRequestMessage innerRequest;
+        internal HttpRequestMessage innerRequest;
 
         /// <summary>
         /// Initializes a new instance of the WebApiRequestMessage class.

--- a/src/Microsoft.AspNet.OData/Extensions/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.AspNet.OData/Extensions/HttpConfigurationExtensions.cs
@@ -53,6 +53,8 @@ namespace Microsoft.AspNet.OData.Extensions
 
         private const string CompatibilityOptionsKey = "Microsoft.AspNet.OData.CompatibilityOptionsKey";
 
+        private const string EnableCaseInsensitiveModelBindingKey = "Microsoft.AspNet.OData.EnableCaseInsensitiveModelBindingKey";
+
         /// <summary>
         /// Enables query support for actions with an <see cref="IQueryable" /> or <see cref="IQueryable{T}" /> return
         /// type. To avoid processing unexpected or malicious queries, use the validation settings on
@@ -264,6 +266,39 @@ namespace Microsoft.AspNet.OData.Extensions
             }
 
             configuration.Services.Add(typeof(IFilterProvider), new QueryFilterProvider(queryFilter));
+        }
+
+        /// <summary>
+        /// Enables support for case insensitive model binding.
+        /// </summary>
+        /// <param name="configuration">The server configuration.</param>
+        public static void EnableODataCaseInsensitiveModelBinding(this HttpConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw Error.ArgumentNull("configuration");
+            }
+
+            configuration.Properties[EnableCaseInsensitiveModelBindingKey] = true;
+        }
+
+        /// <summary>
+        /// Check the CaseInsensitiveModelBinding is enabled or not.
+        /// </summary>
+        /// <returns>True if CaseInsensitiveModelBinding is enabled; false otherwise</returns>
+        internal static bool HasEnabledCaseInsensitiveModelBinding(this HttpConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw Error.ArgumentNull("configuration");
+            }
+
+            object value;
+            if (configuration.Properties.TryGetValue(EnableCaseInsensitiveModelBindingKey, out value))
+            {
+                return (bool)value;
+            }
+            return false;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/Extensions/ODataServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ODataServiceCollectionExtensions.cs
@@ -114,6 +114,33 @@ namespace Microsoft.AspNet.OData.Extensions
         }
 
         /// <summary>
+        /// Enables case-insensitive model binding.
+        /// </summary>
+        /// <param name="builder">Odata Builder.</param>
+        public static IODataBuilder EnableODataCaseInsensitiveModelBinding(this IODataBuilder builder)
+        {
+            return EnableODataCaseInsensitiveModelBinding(builder, true);
+        }
+
+        /// <summary>
+        /// Enables case-insensitive model binding.
+        /// </summary>
+        /// <param name="builder">Odata Builder.</param>
+        /// <param name="enable">Whether to enable case-insensitive model binding.</param>
+        public static IODataBuilder EnableODataCaseInsensitiveModelBinding(this IODataBuilder builder, bool enable)
+        {
+            if (builder == null)
+            {
+                throw Error.ArgumentNull("builder");
+            }
+
+            var odataOptions = builder.Services.First(s => s.ServiceType == typeof(ODataOptions) && s.ImplementationType == typeof(ODataOptions));
+            builder.Services.Remove(odataOptions);
+            builder.Services.AddSingleton(new ODataOptions() { EnableCaseInsensitiveModelBinding = enable });
+            return builder;
+        }
+
+        /// <summary>
         /// Enables query support for actions with an <see cref="IQueryable" /> or <see cref="IQueryable{T}" /> return
         /// type. To avoid processing unexpected or malicious queries, use the validation settings on
         /// <see cref="EnableQueryAttribute"/> to validate incoming queries. For more information, visit

--- a/src/Microsoft.AspNetCore.OData/Extensions/ODataServiceProviderConfigExtenions.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/ODataServiceProviderConfigExtenions.cs
@@ -222,6 +222,7 @@ namespace Microsoft.AspNet.OData.Extensions
             options.EnableContinueOnErrorHeader = defaultOptions.EnableContinueOnErrorHeader;
             options.NullDynamicPropertyIsEnabled = defaultOptions.NullDynamicPropertyIsEnabled;
             options.UrlKeyDelimiter = defaultOptions.UrlKeyDelimiter;
+            options.EnableCaseInsensitiveModelBinding = defaultOptions.EnableCaseInsensitiveModelBinding;
         }
 
         public static ODataOptions GetDefaultODataOptions(this IServiceProvider serviceProvider)

--- a/src/Microsoft.AspNetCore.OData/ODataOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataOptions.cs
@@ -31,5 +31,10 @@ namespace Microsoft.AspNet.OData
         /// Gets or Sets the set of flags that have options for backward compatibility
         /// </summary>
         public CompatibilityOptions CompatibilityOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether request body binding should be case insensitive.
+        /// </summary>
+        public bool EnableCaseInsensitiveModelBinding { get; set; }
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/HttpConfigurationExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/HttpConfigurationExtensionsTest.cs
@@ -193,6 +193,21 @@ namespace Microsoft.AspNet.OData.Test
         }
 
         [Fact]
+        public void EnableODataCaseInsensitiveModelBinding_Sets_CaseInsensitiveModelBindingKeyFlag()
+        {
+            // Arrange
+            HttpConfiguration config = new HttpConfiguration();
+            bool initialConfig = config.HasEnabledCaseInsensitiveModelBinding();
+
+            // Act
+            config.EnableODataCaseInsensitiveModelBinding();
+
+            // Assert
+            Assert.False(initialConfig);
+            Assert.True(config.HasEnabledCaseInsensitiveModelBinding());
+        }
+
+        [Fact]
         public void SetUrlKeyDelimiter_Sets_UrlKeyDelimiter()
         {
             // Arrange

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -1874,6 +1874,11 @@ public sealed class Microsoft.AspNet.OData.Extensions.HttpConfigurationExtension
 	[
 	ExtensionAttribute(),
 	]
+	public static void EnableODataCaseInsensitiveModelBinding (System.Web.Http.HttpConfiguration configuration)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static System.Web.Http.HttpConfiguration Expand (System.Web.Http.HttpConfiguration configuration)
 
 	[

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/RequestFactory.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/RequestFactory.cs
@@ -4,11 +4,9 @@
 using System;
 using System.Linq;
 using System.Net.Http;
-using Microsoft.AspNet.OData;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/RoutingConfigurationFactory.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/RoutingConfigurationFactory.cs
@@ -14,8 +14,8 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 #if NETCOREAPP2_0
-    using Microsoft.AspNetCore.Builder.Internal;
-    using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Builder.Internal;
+using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -156,6 +156,67 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
             applicationPartManager.ApplicationParts.Add(part);
 
             return builder;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the routing configuration class.
+        /// </summary>
+        /// <returns>A new instance of the routing configuration class.</returns>
+        public static IRouteBuilder CreateWithCaseInsensitiveModelBinding()
+        {
+            IServiceCollection serviceCollection = new ServiceCollection();
+            serviceCollection.AddMvc();
+            serviceCollection.AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
+            serviceCollection.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+            serviceCollection.AddOData();
+            serviceCollection.AddSingleton(new ODataOptions(){ EnableCaseInsensitiveModelBinding = true});
+
+            // For routing tests, add an IActionDescriptorCollectionProvider.
+            serviceCollection.AddSingleton<IActionDescriptorCollectionProvider, TestActionDescriptorCollectionProvider>();
+
+            // Add an action select to return a default descriptor.
+            var mockAction = new Mock<ActionDescriptor>();
+            ActionDescriptor actionDescriptor = mockAction.Object;
+
+            var mockActionSelector = new Mock<IActionSelector>();
+            mockActionSelector
+                .Setup(a => a.SelectCandidates(It.IsAny<RouteContext>()))
+                .Returns(new ActionDescriptor[] { actionDescriptor });
+
+            mockActionSelector
+                .Setup(a => a.SelectBestCandidate(It.IsAny<RouteContext>(), It.IsAny<IReadOnlyList<ActionDescriptor>>()))
+                .Returns(actionDescriptor);
+
+            // Add a mock action invoker & factory.
+            var mockInvoker = new Mock<IActionInvoker>();
+            mockInvoker.Setup(i => i.InvokeAsync())
+                .Returns(Task.FromResult(true));
+
+            var mockInvokerFactory = new Mock<IActionInvokerFactory>();
+            mockInvokerFactory.Setup(f => f.CreateInvoker(It.IsAny<ActionContext>()))
+                .Returns(mockInvoker.Object);
+
+            // Create a logger, diagnostic source and app builder.
+            var mockLoggerFactory = new Mock<ILoggerFactory>();
+            var diagnosticSource = new DiagnosticListener("Microsoft.AspNetCore");
+            IApplicationBuilder appBuilder = new ApplicationBuilder(serviceCollection.BuildServiceProvider());
+
+            // Create a route build with a default path handler.
+            IRouteBuilder routeBuilder = new RouteBuilder(appBuilder);
+
+#if NETCOREAPP2_0
+            routeBuilder.DefaultHandler = new MvcRouteHandler(
+                mockInvokerFactory.Object,
+                mockActionSelector.Object,
+                diagnosticSource,
+                mockLoggerFactory.Object,
+                new ActionContextAccessor());
+#else
+            //appBuilder.ApplicationServices.GetRequiredService<MvcRouteHandler>();
+            routeBuilder.DefaultHandler = new MyMvcRouteHandler();
+#endif
+
+            return routeBuilder;
         }
     }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -538,6 +538,7 @@ public class Microsoft.AspNet.OData.ODataOptions {
 	public ODataOptions ()
 
 	CompatibilityOptions CompatibilityOptions  { public get; public set; }
+	bool EnableCaseInsensitiveModelBinding  { public get; public set; }
 	bool EnableContinueOnErrorHeader  { public get; public set; }
 	bool NullDynamicPropertyIsEnabled  { public get; public set; }
 	Microsoft.OData.ODataUrlKeyDelimiter UrlKeyDelimiter  { public get; public set; }
@@ -2205,6 +2206,16 @@ public sealed class Microsoft.AspNet.OData.Extensions.ODataServiceCollectionExte
 	ExtensionAttribute(),
 	]
 	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddODataQueryFilter (Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.AspNetCore.Mvc.Filters.IActionFilter queryFilter)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static IODataBuilder EnableODataCaseInsensitiveModelBinding (IODataBuilder builder)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static IODataBuilder EnableODataCaseInsensitiveModelBinding (IODataBuilder builder, bool enable)
 }
 
 [

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -538,6 +538,7 @@ public class Microsoft.AspNet.OData.ODataOptions {
 	public ODataOptions ()
 
 	CompatibilityOptions CompatibilityOptions  { public get; public set; }
+	bool EnableCaseInsensitiveModelBinding  { public get; public set; }
 	bool EnableContinueOnErrorHeader  { public get; public set; }
 	bool NullDynamicPropertyIsEnabled  { public get; public set; }
 	Microsoft.OData.ODataUrlKeyDelimiter UrlKeyDelimiter  { public get; public set; }
@@ -2370,6 +2371,16 @@ public sealed class Microsoft.AspNet.OData.Extensions.ODataServiceCollectionExte
 	ExtensionAttribute(),
 	]
 	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddODataQueryFilter (Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.AspNetCore.Mvc.Filters.IActionFilter queryFilter)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static IODataBuilder EnableODataCaseInsensitiveModelBinding (IODataBuilder builder)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static IODataBuilder EnableODataCaseInsensitiveModelBinding (IODataBuilder builder, bool enable)
 }
 
 [


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2247 .*

### Description

The exception is thrown when we try extracting the `edmProperty` for the `StructuredType` by passing a property name that doesn’t match what was in the model.
```csharp
IEdmProperty edmProperty = resourceType.FindProperty(property.Name);
```
This issue can be fixed in 2 ways:

- In ODL, update IEdmStructuredTypeReference.FindProperty() to handle case insensitive property names. This will be a breaking change.
- In WebApi, add a way that we can relate the passed property name with the exact property name declared in the model.
i.e we should have a way of matching naMe with Name. We should have a configuration to make this feature optional.

We resolve this by injecting a dependency in the service collection as follows:

**AspNetCore WebApi**
```csharp
public void ConfigureServices(IServiceCollection services)
{
    services.AddOData().EnableODataCaseInsensitiveModelBinding(true);
    ....
    ....
}
```
OR
```csharp
public void ConfigureServices(IServiceCollection services)
{
    services.AddOData().EnableODataCaseInsensitiveModelBinding();
    ....
    ....
}
```
**AspNet WebApi**
```csharp
public static void Register(HttpConfiguration config)
{
    var builder = new ODataConventionModelBuilder();
    ....
    ....
    config.EnableODataCaseInsensitiveModelBinding();
}
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
