### PR TITLE
Add HEAD Support for Attribute Routing

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/RequestMethod.cs
+++ b/src/Microsoft.AspNet.OData.Shared/RequestMethod.cs
@@ -42,5 +42,10 @@ namespace Microsoft.AspNet.OData
         /// "Put"
         /// </summary>
         Put,
+
+        /// <summary>
+        /// "Head"
+        /// </summary>
+        Head,
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/AttributeRoutingConventionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/AttributeRoutingConventionTest.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNet.OData.Routing.Template;
 using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -177,7 +178,12 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             var configuration = RoutingConfigurationFactory.CreateWithRootContainer(RouteName);
             var serviceProvider = GetServiceProvider(configuration, RouteName);
             var request = RequestFactory.Create(configuration, RouteName);
+#if NETCORE
+            request.ODataFeature().Path = new ODataPath();
+            request.Method = method;
+#else
             request.Method = new HttpMethod(method);
+#endif
 
             var descriptors = ControllerDescriptorFactory.Create(configuration, "TestController", 
                 controllerType);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/AttributeRoutingConventionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/Conventions/AttributeRoutingConventionTest.cs
@@ -151,28 +151,34 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
         }
 
         [Theory]
-        [InlineData(typeof(TestODataController), "Customers", "GetCustomers")]
-        [InlineData(typeof(TestODataController), "Customers({key})/Orders", "GetOrdersOfACustomer")]
-        [InlineData(typeof(TestODataController), "Customers({key})", "GetCustomer")]
-        [InlineData(typeof(TestODataController), "VipCustomer", "GetVipCustomer")] // Singleton
-        [InlineData(typeof(TestODataController), "VipCustomer/Orders", "GetOrdersOfVipCustomer")] // Singleton/Navigation
-        [InlineData(typeof(TestODataControllerWithPrefix), "Customers", "GetCustomers")]
-        [InlineData(typeof(TestODataControllerWithPrefix), "Customers({key})/Orders", "GetOrdersOfACustomer")]
-        [InlineData(typeof(TestODataControllerWithPrefix), "Customers({key})", "GetCustomer")]
-        [InlineData(typeof(SingletonTestControllerWithPrefix), "VipCustomer", "GetVipCustomerWithPrefix")] // Singleton
-        [InlineData(typeof(SingletonTestControllerWithPrefix), "VipCustomer/Name", "GetVipCustomerNameWithPrefix")] // Singleton/property
-        [InlineData(typeof(SingletonTestControllerWithPrefix), "VipCustomer/Orders", "GetVipCustomerOrdersWithPrefix")] // Singleton/Navigation
-        [InlineData(typeof(TestODataControllerWithMultiplePrefixes), "Customers({key})", "GetCustomer")]
-        [InlineData(typeof(TestODataControllerWithMultiplePrefixes), "Customers({key})/Orders", "GetOrdersOfACustomer")]
-        [InlineData(typeof(TestODataControllerWithMultiplePrefixes), "VipCustomer", "GetCustomer")]
-        [InlineData(typeof(TestODataControllerWithMultiplePrefixes), "VipCustomer/Orders", "GetOrdersOfACustomer")]
-        public void AttributeMappingsIsInitialized_WithRightActionAndTemplate(Type controllerType,
-            string expectedPathTemplate, string expectedActionName)
+        [InlineData(typeof(TestODataController), "Get", "Customers", "GetCustomers")]
+        [InlineData(typeof(TestODataController), "Get", "Customers({key})/Orders", "GetOrdersOfACustomer")]
+        [InlineData(typeof(TestODataController), "Get", "Customers({key})", "GetCustomer")]
+        [InlineData(typeof(TestODataController), "Head", "Customers({key})", "GetCustomer")]
+        [InlineData(typeof(TestODataController), "Get", "VipCustomer", "GetVipCustomer")] // Singleton
+        [InlineData(typeof(TestODataController), "Get", "VipCustomer/Orders", "GetOrdersOfVipCustomer")] // Singleton/Navigation
+        [InlineData(typeof(TestODataControllerWithPrefix), "Get", "Customers", "GetCustomers")]
+        [InlineData(typeof(TestODataControllerWithPrefix), "Get", "Customers({key})/Orders", "GetOrdersOfACustomer")]
+        [InlineData(typeof(TestODataControllerWithPrefix), "Get", "Customers({key})", "GetCustomer")]
+        [InlineData(typeof(SingletonTestControllerWithPrefix), "Get", "VipCustomer", "GetVipCustomerWithPrefix")] // Singleton
+        [InlineData(typeof(SingletonTestControllerWithPrefix), "Get", "VipCustomer/Name", "GetVipCustomerNameWithPrefix")] // Singleton/property
+        [InlineData(typeof(SingletonTestControllerWithPrefix), "Get", "VipCustomer/Orders", "GetVipCustomerOrdersWithPrefix")] // Singleton/Navigation
+        [InlineData(typeof(TestODataControllerWithMultiplePrefixes), "Get", "Customers({key})", "GetCustomer")]
+        [InlineData(typeof(TestODataControllerWithMultiplePrefixes), "Get", "Customers({key})/Orders", "GetOrdersOfACustomer")]
+        [InlineData(typeof(TestODataControllerWithMultiplePrefixes), "Get", "VipCustomer", "GetCustomer")]
+        [InlineData(typeof(TestODataControllerWithMultiplePrefixes), "Get", "VipCustomer/Orders", "GetOrdersOfACustomer")]
+        public void AttributeMappingsIsInitialized_WithRightActionAndTemplate(
+            Type controllerType,
+            string method,
+            string expectedPathTemplate,
+            string expectedActionName)
         {
             // Arrange
             var configuration = RoutingConfigurationFactory.CreateWithRootContainer(RouteName);
             var serviceProvider = GetServiceProvider(configuration, RouteName);
             var request = RequestFactory.Create(configuration, RouteName);
+            request.Method = new HttpMethod(method);
+
             var descriptors = ControllerDescriptorFactory.Create(configuration, "TestController", 
                 controllerType);
 
@@ -274,6 +280,7 @@ namespace Microsoft.AspNet.OData.Test.Routing.Conventions
             {
             }
 
+            [HttpGet,HttpHead]
             [ODataRoute("Customers({key})")]
             public void GetCustomer()
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

The current version of OData WebApi does not support `[HttpHead]` flagged actions via attribute routing - this is a regression from OData WebApi 6.0.0.

### Description

After upgrading from OData WebApi 6.0.0 to OData WebApi 7.4.1 we noticed that none of our actions that were defined to implement HEAD requests were working. Some investigation suggested this was most likely an oversite when the `IWebApiActionDescriptor` abstraction was introduced, and the fix is straight forward enough.

I've come up with a heinous hack to allow us to continue upgrading to the latest version, but we'd love this fix in the next official release of `Microsoft.AspNet.OData`.

### Checklist (Uncheck if it is not completed)

- [ x] *Test cases added*
- [ x] *Build and test with one-click build and test script passed*
