### PR TITLE
Alwayspersistinstance

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
@@ -118,6 +118,25 @@ namespace Microsoft.AspNet.OData
         }
 
         /// <summary>
+        /// Indicates that <see cref="ISelectExpandWrapper.Instance"/> will always be populated.
+        ///
+        /// By default it is only populated for "$select=*" scenarios, which means custom implementations of OData serializers cannot
+        /// make general assumptions about being able access the original instance returned from a controller. This behavior must be
+        /// explicitly requested as it will cause performance issues with Entity Framework.
+        /// </summary>
+        public bool EnableDeterministicSelectExpandWrapperInstance
+        {
+            get
+            {
+                return _querySettings.EnableDeterministicSelectExpandWrapperInstance;
+            }
+            set
+            {
+                _querySettings.EnableDeterministicSelectExpandWrapperInstance = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the maximum depth of the Any or All elements nested inside the query. This limit helps prevent
         /// Denial of Service attacks.
         /// </summary>
@@ -309,22 +328,6 @@ namespace Microsoft.AspNet.OData
                         _validationSettings.AllowedOrderByProperties.Add(properties[i].Trim());
                     }
                 }
-            }
-        }
-
-        /// <summary>
-        /// Indicates that SelectExpandWrapper&gt;&lt;.Instance will always be populated with the object being wrapped. This
-        /// behavior is not the default because it causes performance issues with Entity Framework.
-        /// </summary>
-        public bool AlwaysSetSelectExpandWrapperInstance
-        {
-            get
-            {
-                return _querySettings.AlwaysSetSelectExpandWrapperInstance;
-            }
-            set
-            {
-                _querySettings.AlwaysSetSelectExpandWrapperInstance = value;
             }
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNet.OData.Shared/EnableQueryAttribute.cs
@@ -313,6 +313,22 @@ namespace Microsoft.AspNet.OData
         }
 
         /// <summary>
+        /// Indicates that SelectExpandWrapper&gt;&lt;.Instance will always be populated with the object being wrapped. This
+        /// behavior is not the default because it causes performance issues with Entity Framework.
+        /// </summary>
+        public bool AlwaysSetSelectExpandWrapperInstance
+        {
+            get
+            {
+                return _querySettings.AlwaysSetSelectExpandWrapperInstance;
+            }
+            set
+            {
+                _querySettings.AlwaysSetSelectExpandWrapperInstance = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the max value of $skip that a client can request.
         /// </summary>
         public int MaxSkip

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -284,25 +284,21 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 Expression.Constant(_modelID);
             wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, wrapperPropertyValueExpression));
 
-            if (_settings.AlwaysSetSelectExpandWrapperInstance)
+            if (IsSelectAll(selectExpandClause))
             {
                 // Initialize property 'Instance' on the wrapper class
                 wrapperProperty = wrapperType.GetProperty("Instance");
                 wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, source));
-            }
-
-            if (IsSelectAll(selectExpandClause))
-            {
-                if (!_settings.AlwaysSetSelectExpandWrapperInstance)
-                {
-                    // Initialize property 'Instance' on the wrapper class
-                    wrapperProperty = wrapperType.GetProperty("Instance");
-                    wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, source));
-                }
 
                 wrapperProperty = wrapperType.GetProperty("UseInstanceForProperties");
                 wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, Expression.Constant(true)));
                 isInstancePropertySet = true;
+            }
+            else if (_settings.EnableDeterministicSelectExpandWrapperInstance)
+            {
+                // Initialize property 'Instance' on the wrapper class
+                wrapperProperty = wrapperType.GetProperty("Instance");
+                wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, source));
             }
             else
             {

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -284,11 +284,21 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 Expression.Constant(_modelID);
             wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, wrapperPropertyValueExpression));
 
-            if (IsSelectAll(selectExpandClause))
+            if (_settings.AlwaysSetSelectExpandWrapperInstance)
             {
                 // Initialize property 'Instance' on the wrapper class
                 wrapperProperty = wrapperType.GetProperty("Instance");
                 wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, source));
+            }
+
+            if (IsSelectAll(selectExpandClause))
+            {
+                if (!_settings.AlwaysSetSelectExpandWrapperInstance)
+                {
+                    // Initialize property 'Instance' on the wrapper class
+                    wrapperProperty = wrapperType.GetProperty("Instance");
+                    wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, source));
+                }
 
                 wrapperProperty = wrapperType.GetProperty("UseInstanceForProperties");
                 wrapperTypeMemberAssignments.Add(Expression.Bind(wrapperProperty, Expression.Constant(true)));

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
@@ -11,7 +11,7 @@ using Microsoft.OData.Edm;
 
 namespace Microsoft.AspNet.OData.Query.Expressions
 {
-    internal abstract class SelectExpandWrapper : IEdmEntityObject, ISelectExpandWrapper
+    internal abstract class SelectExpandWrapper : ISelectExpandWrapper
     {
         private static readonly IPropertyMapper DefaultPropertyMapper = new IdentityPropertyMapper();
         private static readonly Func<IEdmModel, IEdmStructuredType, IPropertyMapper> _mapperProvider =

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
@@ -30,7 +30,14 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         /// </summary>
         public string ModelID { get; set; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// The instance of the object that is being wrapped, if available.
+        /// </summary>
+        // Ideally this would be called "Instance" and SelectExpandWrapper<> would use the "new"
+        // keyword to replace it with a variation that returns the correct type. Unfortunately the
+        // scenarios that consume "Instance" do so using reflection, and such an approach would
+        // introduce ambiguity that would need to be handled in numerous places. Since this is an
+        // internal construct it fine to leave like this.
         public object UntypedInstance { get; set; }
 
         /// <summary>
@@ -42,6 +49,12 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         /// Indicates whether the underlying instance can be used to obtain property values.
         /// </summary>
         public bool UseInstanceForProperties { get; set; }
+
+        /// <inheritdoc />
+        object ISelectExpandWrapper.Instance
+        {
+            get { return UntypedInstance; }
+        }
 
         /// <inheritdoc />
         public IEdmTypeReference GetEdmType()

--- a/src/Microsoft.AspNet.OData.Shared/Query/ISelectExpandWrapper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ISelectExpandWrapper.cs
@@ -13,6 +13,12 @@ namespace Microsoft.AspNet.OData.Query
     public interface ISelectExpandWrapper
     {
         /// <summary>
+        /// The instance of the object that is being wrapped, if available.
+        /// </summary>
+        // The public contract should avoid propagating the "UntypedInstance" terminology.
+        object Instance { get; }
+
+        /// <summary>
         /// Projects the result of a $select and $expand query to a <see cref="IDictionary{TKey,TValue}" />.
         /// </summary>
         /// <returns>An <see cref="IDictionary{TKey,TValue}"/> representing the $select and $expand result.</returns>

--- a/src/Microsoft.AspNet.OData.Shared/Query/ISelectExpandWrapper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ISelectExpandWrapper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNet.OData.Query
     /// <summary>
     /// Represents the result of a $select and $expand query operation.
     /// </summary>
-    public interface ISelectExpandWrapper
+    public interface ISelectExpandWrapper : IEdmEntityObject
     {
         /// <summary>
         /// The instance of the object that is being wrapped, if available.

--- a/src/Microsoft.AspNet.OData.Shared/Query/ODataQuerySettings.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ODataQuerySettings.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.OData.Query
         /// Indicates that SelectExpandWrapper&gt;&lt;.Instance will always be populated with the object being wrapped. This
         /// behavior is not the default because it causes performance issues with Entity Framework.
         /// </summary>
-        public bool AlwaysSetSelectExpandWrapperInstance { get; set; }
+        public bool EnableDeterministicSelectExpandWrapperInstance { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of query results to return based on the type or property.

--- a/src/Microsoft.AspNet.OData.Shared/Query/ODataQuerySettings.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ODataQuerySettings.cs
@@ -25,6 +25,12 @@ namespace Microsoft.AspNet.OData.Query
         }
 
         /// <summary>
+        /// Indicates that SelectExpandWrapper&gt;&lt;.Instance will always be populated with the object being wrapped. This
+        /// behavior is not the default because it causes performance issues with Entity Framework.
+        /// </summary>
+        public bool AlwaysSetSelectExpandWrapperInstance { get; set; }
+
+        /// <summary>
         /// Gets or sets the maximum number of query results to return based on the type or property.
         /// </summary>
         /// <value>

--- a/src/Microsoft.AspNet.OData.Shared/Query/ODataQuerySettings.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ODataQuerySettings.cs
@@ -25,8 +25,11 @@ namespace Microsoft.AspNet.OData.Query
         }
 
         /// <summary>
-        /// Indicates that SelectExpandWrapper&gt;&lt;.Instance will always be populated with the object being wrapped. This
-        /// behavior is not the default because it causes performance issues with Entity Framework.
+        /// Indicates that <see cref="ISelectExpandWrapper.Instance"/> will always be populated.
+        ///
+        /// By default it is only populated for "$select=*" scenarios, which means custom implementations of OData serializers cannot
+        /// make general assumptions about being able access the original instance returned from a controller. This behavior must be
+        /// explicitly requested as it will cause performance issues with Entity Framework.
         /// </summary>
         public bool EnableDeterministicSelectExpandWrapperInstance { get; set; }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -417,9 +417,9 @@ public class Microsoft.AspNet.OData.EnableQueryAttribute : System.Web.Http.Filte
 	AllowedLogicalOperators AllowedLogicalOperators  { public get; public set; }
 	string AllowedOrderByProperties  { public get; public set; }
 	AllowedQueryOptions AllowedQueryOptions  { public get; public set; }
-	bool AlwaysSetSelectExpandWrapperInstance  { public get; public set; }
 	bool EnableConstantParameterization  { public get; public set; }
 	bool EnableCorrelatedSubqueryBuffering  { public get; public set; }
+	bool EnableDeterministicSelectExpandWrapperInstance  { public get; public set; }
 	bool EnsureStableOrdering  { public get; public set; }
 	HandleNullPropagationOption HandleNullPropagation  { public get; public set; }
 	bool HandleReferenceNavigationPropertyExpandFilter  { public get; public set; }
@@ -2333,7 +2333,7 @@ public interface Microsoft.AspNet.OData.Query.IPropertyMapper {
 	string MapProperty (string propertyName)
 }
 
-public interface Microsoft.AspNet.OData.Query.ISelectExpandWrapper {
+public interface Microsoft.AspNet.OData.Query.ISelectExpandWrapper : IEdmEntityObject, IEdmObject, IEdmStructuredObject {
 	object Instance  { public abstract get; }
 
 	System.Collections.Generic.IDictionary`2[[System.String],[System.Object]] ToDictionary ()
@@ -2496,9 +2496,9 @@ public class Microsoft.AspNet.OData.Query.ODataQueryOptions`1 : ODataQueryOption
 public class Microsoft.AspNet.OData.Query.ODataQuerySettings {
 	public ODataQuerySettings ()
 
-	bool AlwaysSetSelectExpandWrapperInstance  { public get; public set; }
 	bool EnableConstantParameterization  { public get; public set; }
 	bool EnableCorrelatedSubqueryBuffering  { public get; public set; }
+	bool EnableDeterministicSelectExpandWrapperInstance  { public get; public set; }
 	bool EnsureStableOrdering  { public get; public set; }
 	HandleNullPropagationOption HandleNullPropagation  { public get; public set; }
 	bool HandleReferenceNavigationPropertyExpandFilter  { public get; public set; }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -417,6 +417,7 @@ public class Microsoft.AspNet.OData.EnableQueryAttribute : System.Web.Http.Filte
 	AllowedLogicalOperators AllowedLogicalOperators  { public get; public set; }
 	string AllowedOrderByProperties  { public get; public set; }
 	AllowedQueryOptions AllowedQueryOptions  { public get; public set; }
+	bool AlwaysSetSelectExpandWrapperInstance  { public get; public set; }
 	bool EnableConstantParameterization  { public get; public set; }
 	bool EnableCorrelatedSubqueryBuffering  { public get; public set; }
 	bool EnsureStableOrdering  { public get; public set; }
@@ -2333,6 +2334,8 @@ public interface Microsoft.AspNet.OData.Query.IPropertyMapper {
 }
 
 public interface Microsoft.AspNet.OData.Query.ISelectExpandWrapper {
+	object Instance  { public abstract get; }
+
 	System.Collections.Generic.IDictionary`2[[System.String],[System.Object]] ToDictionary ()
 	System.Collections.Generic.IDictionary`2[[System.String],[System.Object]] ToDictionary (System.Func`3[[Microsoft.OData.Edm.IEdmModel],[Microsoft.OData.Edm.IEdmStructuredType],[Microsoft.AspNet.OData.Query.IPropertyMapper]] propertyMapperProvider)
 }
@@ -2493,6 +2496,7 @@ public class Microsoft.AspNet.OData.Query.ODataQueryOptions`1 : ODataQueryOption
 public class Microsoft.AspNet.OData.Query.ODataQuerySettings {
 	public ODataQuerySettings ()
 
+	bool AlwaysSetSelectExpandWrapperInstance  { public get; public set; }
 	bool EnableConstantParameterization  { public get; public set; }
 	bool EnableCorrelatedSubqueryBuffering  { public get; public set; }
 	bool EnsureStableOrdering  { public get; public set; }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This PR fixes https://github.com/OData/WebApi/issues/987

### Description

The previous attempt at this fix always populated `Instance` on the `SelectExpandWrapper<>`, however this caused performance issues with Entity Framework when it walked the expression tree in order to determine what SQL query was required. This change instead requires callers to opt in to the behavior, and it is off by default.

### Checklist (Uncheck if it is not completed)

- [X ] *Test cases added*
- [X ] *Build and test with one-click build and test script passed*
