### PR TITLE
Fix issue#2264, enable enum member alias for query options

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
@@ -345,6 +345,17 @@ namespace Microsoft.AspNet.OData.Common
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Cannot Get the Enum Clr member using &apos;{0}&apos;..
+        /// </summary>
+        internal static string CannotGetEnumClrMember
+        {
+            get
+            {
+                return ResourceManager.GetString("CannotGetEnumClrMember", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Cannot determine the Edm type for the CLR type &apos;{0}&apos; because the derived type &apos;{1}&apos; is configured as entity type and another derived type &apos;{2}&apos; is configured as complex type..
         /// </summary>
         internal static string CannotInferEdmType

--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
@@ -940,4 +940,7 @@
   <data name="QueryOptionsNotInExpectedFormat" xml:space="preserve">
     <value>Query options in request body not in expected format: {0}. A series of field-value pairs that meet the defined syntax rules expected.</value>
   </data>
+  <data name="CannotGetEnumClrMember" xml:space="preserve">
+    <value>Cannot Get the Enum Clr member using '{0}'.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -1954,6 +1954,10 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                         {
                             value = clrMember;
                         }
+                        else
+                        {
+                            throw new ODataException(Error.Format(SRResources.CannotGetEnumClrMember, enumMember.Name));
+                        }
                     }
                     else
                     {

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -1936,7 +1936,34 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 Contract.Assert(strValue != null);
 
                 constantType = Nullable.GetUnderlyingType(constantType) ?? constantType;
-                value = Enum.Parse(constantType, strValue);
+
+                IEdmEnumType enumType = edmTypeReference.AsEnum().EnumDefinition();
+                ClrEnumMemberAnnotation memberMapAnnotation = Model.GetClrEnumMemberAnnotation(enumType);
+                if (memberMapAnnotation != null)
+                {
+                    IEdmEnumMember enumMember = enumType.Members.FirstOrDefault(m => m.Name == strValue);
+                    if (enumMember == null)
+                    {
+                        enumMember = enumType.Members.FirstOrDefault(m => m.Value.ToString() == strValue);
+                    }
+
+                    if (enumMember != null)
+                    {
+                        Enum clrMember = memberMapAnnotation.GetClrEnumMember(enumMember);
+                        if (clrMember != null)
+                        {
+                            value = clrMember;
+                        }
+                    }
+                    else
+                    {
+                        value = Enum.Parse(constantType, strValue);
+                    }
+                }
+                else
+                {
+                    value = Enum.Parse(constantType, strValue);
+                }
             }
 
             if (edmTypeReference != null &&

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -1102,6 +1102,9 @@
     <Compile Include="..\Enums\EnumsTest.cs">
       <Link>Enums\EnumsTest.cs</Link>
     </Compile>
+    <Compile Include="..\Enums\EnumsAliasTest.cs">
+      <Link>Enums\EnumsAliasTest.cs</Link>
+    </Compile>
     <Compile Include="..\ETags\DeleteUpdatedEntryWithIfMatchETagsTest.cs">
       <Link>ETags\DeleteUpdatedEntryWithIfMatchETagsTest.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -991,6 +991,9 @@
     <Compile Include="..\Enums\EnumsTest.cs">
       <Link>Enums\EnumsTest.cs</Link>
     </Compile>
+    <Compile Include="..\Enums\EnumsAliasTest.cs">
+      <Link>Enums\EnumsAliasTest.cs</Link>
+    </Compile>
     <Compile Include="..\ETags\DeleteUpdatedEntryWithIfMatchETagsTest.cs">
       <Link>ETags\DeleteUpdatedEntryWithIfMatchETagsTest.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
@@ -1006,6 +1006,9 @@
     <Compile Include="..\Enums\EnumsTest.cs">
       <Link>Enums\EnumsTest.cs</Link>
     </Compile>
+    <Compile Include="..\Enums\EnumsAliasTest.cs">
+      <Link>Enums\EnumsAliasTest.cs</Link>
+    </Compile>
     <Compile Include="..\ETags\DeleteUpdatedEntryWithIfMatchETagsTest.cs">
       <Link>ETags\DeleteUpdatedEntryWithIfMatchETagsTest.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Enums/EnumsAliasTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Enums/EnumsAliasTest.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Microsoft.Test.E2E.AspNet.OData.Common.Extensions;
+using Microsoft.Test.E2E.AspNet.OData.ModelBuilder;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Test.E2E.AspNet.OData.Enums
+{
+    public class EnumsAliasTest : WebHostTestBase
+    {
+        public EnumsAliasTest(WebHostTestFixture fixture)
+            :base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            var controllers = new[] { typeof(WeatherForecastController), typeof(MetadataController) };
+            configuration.AddControllers(controllers);
+
+            configuration.Routes.Clear();
+            configuration.Count().Filter().OrderBy().Expand().MaxTop(null).Select();
+            configuration.MapODataServiceRoute("odata", "odata", EnumsEdmModel.GetEnumAliasModel(configuration));
+            configuration.EnsureInitialized();
+        }
+
+        [Fact]
+        public async Task ModelBuilderTest()
+        {
+            // Arrange
+            string requestUri = string.Format("{0}/odata/$metadata", this.BaseAddress);
+
+            HttpResponseMessage response = await this.Client.GetAsync(requestUri);
+            var stream = await response.Content.ReadAsStreamAsync();
+
+            // Act
+            IODataResponseMessage message = new ODataMessageWrapper(stream, response.Content.Headers);
+            var reader = new ODataMessageReader(message);
+            IEdmModel edmModel = reader.ReadMetadataDocument();
+
+            // Assert
+            IEdmEntityType weatherForecast = edmModel.SchemaElements.OfType<IEdmEntityType>().First();
+            Assert.Equal("WeatherForecast", weatherForecast.Name);
+            Assert.Equal(3, weatherForecast.Properties().Count());
+
+            // Enum Property 1
+            var status = weatherForecast.Properties().SingleOrDefault(p => p.Name == "Status");
+            Assert.True(status.Type.IsEnum());
+
+            // Enum Property 2
+            var skill = weatherForecast.Properties().SingleOrDefault(p => p.Name == "Skill");
+            Assert.True(skill.Type.IsEnum());
+        }
+
+        [Fact]
+        public async Task QueryEntitiesFilterByEnumUsingEnumAlias()
+        {
+            string uri = this.BaseAddress + "/odata/WeatherForecast?$filter=Status eq 'Sold out'";
+
+            using (var response = await this.Client.GetAsync(uri))
+            {
+                Assert.True(response.IsSuccessStatusCode);
+
+                var result = await response.Content.ReadAsObject<JObject>();
+                var value = result.GetValue("value") as JArray;
+                Assert.NotNull(value);
+                Assert.Equal(2, value.Count);
+                JObject item0 = value.ElementAt(0) as JObject;
+                Assert.Equal(2, item0["Id"]);
+
+                JObject item1 = value.ElementAt(1) as JObject;
+                Assert.Equal(4, item1["Id"]);
+            }
+        }
+
+        [Fact]
+        public async Task QueryEntitiesFilterByEnumWithoutEnumAlias()
+        {
+            string uri = this.BaseAddress + "/odata/WeatherForecast?$filter=Skill eq 'Sql'";
+
+            using (var response = await this.Client.GetAsync(uri))
+            {
+                Assert.True(response.IsSuccessStatusCode);
+
+                var result = await response.Content.ReadAsObject<JObject>();
+                var value = result.GetValue("value") as JArray;
+                Assert.NotNull(value);
+                Assert.Equal(3, value.Count);
+                JObject item0 = value.ElementAt(0) as JObject;
+                Assert.Equal(1, item0["Id"]);
+
+                JObject item1 = value.ElementAt(1) as JObject;
+                Assert.Equal(3, item1["Id"]);
+
+                JObject item2 = value.ElementAt(2) as JObject;
+                Assert.Equal(5, item2["Id"]);
+            }
+        }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Enums/EnumsController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Enums/EnumsController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -243,6 +244,26 @@ namespace Microsoft.Test.E2E.AspNet.OData.Enums
             Employee employee = Employees.FirstOrDefault(e => e.ID == id);
             var result = employee.AccessLevel.HasFlag(accessLevel);
             return Ok(result);
+        }
+    }
+
+    public class WeatherForecastController : TestODataController
+    {
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        [EnableQuery]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Id = index,
+                Status = index % 2 == 0 ? Status.SoldOut : Status.InStore,
+                Skill = index % 2 == 0 ? Skill.CSharp : Skill.Sql
+            })
+            .ToArray();
         }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Enums/EnumsDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Enums/EnumsDataModel.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Test.E2E.AspNet.OData.Enums
 {
@@ -47,5 +48,24 @@ namespace Microsoft.Test.E2E.AspNet.OData.Enums
     {
         public Sport LikeMost { get; set; }
         public List<Sport> Like { get; set; }
+    }
+
+    [DataContract]
+    public enum Status
+    {
+        [EnumMember(Value = "Sold out")]
+        SoldOut,
+
+        [EnumMember(Value = "In store")]
+        InStore
+    }
+
+    public class WeatherForecast
+    {
+        public int Id { get; set; }
+
+        public Status Status { get; set; }
+
+        public Skill Skill { get; set; }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Enums/EnumsEdmModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Enums/EnumsEdmModel.cs
@@ -67,6 +67,13 @@ namespace Microsoft.Test.E2E.AspNet.OData.Enums
             return edmModel;
         }
 
+        public static IEdmModel GetEnumAliasModel(WebRouteConfiguration configuration)
+        {
+            ODataConventionModelBuilder builder = configuration.CreateConventionModelBuilder();
+            builder.EntitySet<WeatherForecast>("WeatherForecast");
+            return builder.GetEdmModel();
+        }
+
         private static void AddBoundActionsAndFunctions(EntityTypeConfiguration<Employee> employee)
         {
             var actionConfiguration = employee.Action("AddSkill");


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2264.*

### Description

* Enable "$filter=Status eq 'Sold out'" if Status enum type has enum alias.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
