### PR TITLE
Create the correct expression when casting entity/complex type to der…

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -331,12 +331,12 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
             Expression source = arguments[0];
 
-            if (arguments[0].Type == targetClrType)
+            if (source.Type == targetClrType)
             {
                 // We only support to cast Entity type to the same type now.
                 return source;
             }
-            else if (arguments[0].Type.IsAssignableFrom(targetClrType))
+            else if (source.Type.IsAssignableFrom(targetClrType))
             {
                 // To support to cast Entity/Complex type to the sub type now.
                 return Expression.TypeAs(source, targetClrType);

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -329,16 +329,16 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 targetClrType = EdmLibHelpers.GetClrType(targetEdmType.ToEdmTypeReference(false), Model);
             }
 
+            Expression source = arguments[0];
+
             if (arguments[0].Type == targetClrType)
             {
                 // We only support to cast Entity type to the same type now.
-                return arguments[0];
+                return source;
             }
             else if (arguments[0].Type.IsAssignableFrom(targetClrType))
             {
                 // To support to cast Entity/Complex type to the sub type now.
-                Expression source = BindCastSourceNode(node.Source);
-
                 return Expression.TypeAs(source, targetClrType);
             }
             else

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -329,16 +329,27 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 targetClrType = EdmLibHelpers.GetClrType(targetEdmType.ToEdmTypeReference(false), Model);
             }
 
-            Expression source = arguments[0];
-
-            if (source.Type == targetClrType)
+            if (arguments[0].Type == targetClrType)
             {
                 // We only support to cast Entity type to the same type now.
-                return source;
+                return arguments[0];
             }
-            else if (source.Type.IsAssignableFrom(targetClrType))
+            else if (arguments[0].Type.IsAssignableFrom(targetClrType))
             {
                 // To support to cast Entity/Complex type to the sub type now.
+                Expression source;
+                if(node.Source != null)
+                {
+                    source = BindCastSourceNode(node.Source);
+                }
+                else
+                {
+                    // if the cast is on the root i.e $it (~/Products?$filter=NS.PopularProducts/.....),
+                    // node.Source would be null. Calling BindCastSourceNode will always return '$it'.
+                    // In scenarios where we are casting a navigation property to return an expression that queries against the parent property,
+                    // we need to have a memberAccess expression e.g '$it.Category'. We can get this from arguments[0].
+                    source = arguments[0];
+                }
                 return Expression.TypeAs(source, targetClrType);
             }
             else

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -2316,7 +2316,7 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
 
         [Theory]
         [InlineData("cast('Microsoft.AspNet.OData.Test.Query.Expressions.DerivedProduct')/DerivedProductName eq null", "$it => (($it As DerivedProduct).DerivedProductName == null)","$it => (IIF((($it As DerivedProduct) == null), null, ($it As DerivedProduct).DerivedProductName) == null)")]
-        [InlineData("cast(Category,'Microsoft.AspNet.OData.Test.Query.Expressions.DerivedCategory')/DerivedCategoryName eq null", "$it => (($it As DerivedCategory).DerivedCategoryName == null)", "$it => (IIF((($it As DerivedCategory) == null), null, ($it As DerivedCategory).DerivedCategoryName) == null)")]
+        [InlineData("cast(Category,'Microsoft.AspNet.OData.Test.Query.Expressions.DerivedCategory')/DerivedCategoryName eq null", "$it => (($it.Category As DerivedCategory).DerivedCategoryName == null)", "$it => (IIF((($it.Category As DerivedCategory) == null), null, ($it.Category As DerivedCategory).DerivedCategoryName) == null)")]
         public void CastToQuotedEntityOrComplexType_DerivedProductName(string filter, string expectedExpression, string expectedExpressionWithNullCheck)
         {
             // Arrange, Act & Assert


### PR DESCRIPTION
…ived type

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2255.*

### Description

When calling `Expression.TypeAs(source, targetClrType);`, we need to get the source from the first argument in `node.Parameters`.
My thinking is since `Expression[] arguments = BindArguments(node.Parameters);` is already creating `PropertyAccessExpressions`, we don't need to call `BindCastSourceNode(node.Source)`.

Related logic:
https://github.com/OData/WebApi/blob/ade333a0d063c0b18787623c1fd5651d0a497ed1/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs#L1377
https://github.com/OData/WebApi/blob/ade333a0d063c0b18787623c1fd5651d0a497ed1/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs#L1519

This PR just does minor fixes to this merged PR #1986 

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
