### PR TITLE
group by on date throws exceptions

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -293,6 +293,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                                 };
                             }
                         }
+
                         properties.Add(property);
                     }
                 }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -253,11 +253,11 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             {
                 foreach (var prop in dynamicObject.Values)
                 {
+                    IEdmProperty edmProperty = entityType?.Properties()
+                            .FirstOrDefault(p => p.Name.Equals(prop.Key));
                     if (prop.Value != null
                         && (prop.Value is DynamicTypeWrapper || (prop.Value is IEnumerable<DynamicTypeWrapper>)))
-                    {
-                        IEdmProperty edmProperty = entityType.Properties()
-                            .FirstOrDefault(p => p.Name.Equals(prop.Key));
+                    {                
                         if (edmProperty != null)
                         {
                             dynamicTypeProperties.Add(edmProperty, prop.Value);
@@ -265,17 +265,38 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                     }
                     else
                     {
-                        var property = new ODataProperty
+                        ODataProperty property;
+                        if (prop.Value == null)
                         {
-                            Name = prop.Key,
-                            Value = prop.Value
-                        };
-
+                            property = new ODataProperty
+                            {
+                                Name = prop.Key,
+                                Value = new ODataNullValue()
+                            };
+                        }
+                        else 
+                        {
+                            if (edmProperty != null)
+                            {
+                                property = new ODataProperty
+                                {
+                                    Name = prop.Key,
+                                    Value = ODataPrimitiveSerializer.ConvertPrimitiveValue(prop.Value, edmProperty.Type.AsPrimitive())
+                                };
+                            }
+                            else
+                            {
+                                property = new ODataProperty
+                                {
+                                    Name = prop.Key,
+                                    Value = prop.Value
+                                };
+                            }
+                        }
                         properties.Add(property);
                     }
                 }
             }
-
             return properties;
         }
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DateAndTimeOfDay/DateWithEfTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DateAndTimeOfDay/DateWithEfTest.cs
@@ -60,6 +60,16 @@ namespace Microsoft.Test.E2E.AspNet.OData.DateAndTimeOfDay
         }
 
         [Fact]
+        public async Task CanGroupByDatePropertyForDateTimePropertyOnEf()
+        {
+            string requestUri = string.Format("{0}/odata/EfPeople?$apply=groupby((Birthday), aggregate($count as Cnt))", BaseAddress);
+
+            HttpResponseMessage response = await Client.GetAsync(requestUri);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
         public async Task CanQuerySingleEntityFromTaskReturnTypeInControllerOnEf()
         {
             string requestUri = string.Format("{0}/odata/EfPeople(1)", BaseAddress);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2296 , #912, #1945, #918*

### Description

OData doesn't include DateTime as a primitive type. If a user defines a model as
<pre>
public class Customer
{
    public int Id { get; set; }
    public DateTime Birthday { get; set; }
}
</pre>
then tries to do a groupBy using the Birthday Column, an exception is thrown. 


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
