### PR TITLE
Fix buggy behaviour when addressing derived types

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/EntityRoutingConvention.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/EntityRoutingConvention.cs
@@ -16,8 +16,9 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
         /// <inheritdoc/>
         internal static string SelectActionImpl(ODataPath odataPath, IWebApiControllerContext controllerContext, IWebApiActionMap actionMap)
         {
-            if (odataPath.PathTemplate == "~/entityset/key" ||
-                odataPath.PathTemplate == "~/entityset/key/cast")
+            if (odataPath.PathTemplate == "~/entityset/key"
+                || odataPath.PathTemplate == "~/entityset/key/cast"
+                || odataPath.PathTemplate == "~/entityset/cast/key")
             {
                 string httpMethodName;
 
@@ -51,11 +52,20 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
 
                 if (actionName != null)
                 {
-                    KeySegment keySegment = (KeySegment)odataPath.Segments[1];
+                    KeySegment keySegment;
+                    if (odataPath.PathTemplate == "~/entityset/cast/key")
+                    {
+                        keySegment = (KeySegment)odataPath.Segments[2];
+                    }
+                    else
+                    {
+                        keySegment = (KeySegment)odataPath.Segments[1];
+                    }
                     controllerContext.AddKeyValueToRouteData(keySegment);
                     return actionName;
                 }
             }
+
             return null;
         }
     }

--- a/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/EntityRoutingConvention.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/EntityRoutingConvention.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System.Diagnostics.Contracts;
+using System.Linq;
 using Microsoft.AspNet.OData.Interfaces;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
@@ -52,15 +53,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
 
                 if (actionName != null)
                 {
-                    KeySegment keySegment;
-                    if (odataPath.PathTemplate == "~/entityset/cast/key")
-                    {
-                        keySegment = (KeySegment)odataPath.Segments[2];
-                    }
-                    else
-                    {
-                        keySegment = (KeySegment)odataPath.Segments[1];
-                    }
+                    KeySegment keySegment = (KeySegment)odataPath.Segments.First(d => d is KeySegment);
                     controllerContext.AddKeyValueToRouteData(keySegment);
                     return actionName;
                 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -1045,6 +1045,15 @@
     <Compile Include="..\DependencyInjection\DependencyInjectionEdmModel.cs">
       <Link>DependencyInjection\DependencyInjectionEdmModel.cs</Link>
     </Compile>
+    <Compile Include="..\DerivedTypes\DerivedTypesControllers.cs">
+      <Link>DerivedTypes\DerivedTypesControllers.cs</Link>
+    </Compile>
+    <Compile Include="..\DerivedTypes\DerivedTypesDataModel.cs">
+      <Link>DerivedTypes\DerivedTypesDataModel.cs</Link>
+    </Compile>
+    <Compile Include="..\DerivedTypes\DerivedTypesTests.cs">
+      <Link>DerivedTypes\DerivedTypesTests.cs</Link>
+    </Compile>
     <Compile Include="..\DollarFormat\DollarFormatController.cs">
       <Link>DollarFormat\DollarFormatController.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -934,6 +934,15 @@
     <Compile Include="..\DependencyInjection\DependencyInjectionEdmModel.cs">
       <Link>DependencyInjection\DependencyInjectionEdmModel.cs</Link>
     </Compile>
+    <Compile Include="..\DerivedTypes\DerivedTypesControllers.cs">
+      <Link>DerivedTypes\DerivedTypesControllers.cs</Link>
+    </Compile>
+    <Compile Include="..\DerivedTypes\DerivedTypesDataModel.cs">
+      <Link>DerivedTypes\DerivedTypesDataModel.cs</Link>
+    </Compile>
+    <Compile Include="..\DerivedTypes\DerivedTypesTests.cs">
+      <Link>DerivedTypes\DerivedTypesTests.cs</Link>
+    </Compile>
     <Compile Include="..\DollarFormat\DollarFormatController.cs">
       <Link>DollarFormat\DollarFormatController.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
@@ -949,6 +949,15 @@
     <Compile Include="..\DependencyInjection\DependencyInjectionEdmModel.cs">
       <Link>DependencyInjection\DependencyInjectionEdmModel.cs</Link>
     </Compile>
+    <Compile Include="..\DerivedTypes\DerivedTypesControllers.cs">
+      <Link>DerivedTypes\DerivedTypesControllers.cs</Link>
+    </Compile>
+    <Compile Include="..\DerivedTypes\DerivedTypesDataModel.cs">
+      <Link>DerivedTypes\DerivedTypesDataModel.cs</Link>
+    </Compile>
+    <Compile Include="..\DerivedTypes\DerivedTypesTests.cs">
+      <Link>DerivedTypes\DerivedTypesTests.cs</Link>
+    </Compile>
     <Compile Include="..\DollarFormat\DollarFormatController.cs">
       <Link>DollarFormat\DollarFormatController.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DerivedTypes/DerivedTypesControllers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DerivedTypes/DerivedTypesControllers.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNet.OData;
+using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
+
+namespace Microsoft.Test.E2E.AspNet.OData.DerivedTypes
+{
+    public class CustomersController : TestODataController
+    {
+        static List<Customer> Customers { get; set; }
+
+        static CustomersController()
+        {
+            Customers = new List<Customer>
+            {
+                new Customer { 
+                    Id = 1,
+                    Name = "Customer 1",
+                    Orders = new List<Order>
+                    {
+                        new Order { Id = 1, Amount = 100M }
+                    }
+                },
+                new VipCustomer {
+                    Id = 2,
+                    Name = "Customer 2",
+                    LoyaltyCardNo = "9876543210",
+                    Orders = new List<Order>
+                    {
+                        new Order { Id = 2, Amount = 230M },
+                        new Order { Id = 3, Amount = 150M }
+                    }
+                },
+                new Customer {
+                    Id = 3,
+                    Name = "Customer 3",
+                    Orders = new List<Order>
+                    {
+                        new Order { Id = 4, Amount = 170M }
+                    }
+                }
+            };
+        }
+
+        [EnableQuery]
+        public ITestActionResult Get()
+        {
+            return Ok(Customers);
+        }
+
+        [EnableQuery]
+        public ITestActionResult Get(int key)
+        {
+            var customer = Customers.FirstOrDefault(c => c.Id == key);
+
+            if (customer == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(customer);
+        }
+        
+        // Handles /entityset/cast path template
+        [EnableQuery]
+        public ITestActionResult GetFromVipCustomer()
+        {
+            return Ok(Customers.OfType<VipCustomer>());
+        }
+
+        // Handles /entityset/key/cast and /entityset/cast/key path templates
+        [EnableQuery]
+        public ITestActionResult GetVipCustomer([FromODataUri] int key)
+        {
+            var vipCustomer = Customers.OfType<VipCustomer>().SingleOrDefault(d => d.Id.Equals(key));
+
+            if (vipCustomer == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(vipCustomer);
+        }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DerivedTypes/DerivedTypesDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DerivedTypes/DerivedTypesDataModel.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Test.E2E.AspNet.OData.DerivedTypes
+{
+    public class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public List<Order> Orders { get; set; }
+    }
+
+    public class VipCustomer : Customer
+    {
+        public string LoyaltyCardNo { get; set; }
+    }
+
+    public class Order
+    {
+        public int Id { get; set; }
+        public decimal Amount { get; set; }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DerivedTypes/DerivedTypesTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DerivedTypes/DerivedTypesTests.cs
@@ -60,29 +60,13 @@ namespace Microsoft.Test.E2E.AspNet.OData.DerivedTypes
             Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
         }
 
-        [Fact]
-        public async Task RestrictEntityToDerivedTypeInstance_ForDerivedTypeNameAfterKey()
+        [Theory]
+        [InlineData("Customers(2)/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer")]
+        [InlineData("Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer(2)")]
+        public async Task RestrictEntityToDerivedTypeInstance(string path)
         {
             // Key preceeds name of the derived type
-            string requestUri = this.BaseAddress + "/odata/Customers(2)/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer";
-
-            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-
-            var response = await this.Client.SendAsync(request);
-            Assert.True(response.IsSuccessStatusCode);
-
-            var expectedContent = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata" +
-                "#Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer/$entity\"," +
-                "\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"}}", this.BaseAddress);
-
-            Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
-        }
-
-        [Fact]
-        public async Task RestrictEntityToDerivedTypeInstance_ForDerivedTypeNameBeforeKey()
-        {
-            // Name of the derived type preceeds key
-            string requestUri = this.BaseAddress + "/odata/Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer(2)";
+            string requestUri = this.BaseAddress + "/odata/" + path;
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
@@ -127,11 +111,13 @@ namespace Microsoft.Test.E2E.AspNet.OData.DerivedTypes
             Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
         }
 
-        [Fact]
-        public async Task RestrictEntityToDerivedTypeInstance_ThenExpandNavProperty()
+        [Theory]
+        [InlineData("Customers(2)/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer?$expand=Orders")]
+        [InlineData("Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer(2)?$expand=Orders")]
+        public async Task RestrictEntityToDerivedTypeInstance_ThenExpandNavProperty(string pathAndQuery)
         {
             // Key preceeds name of the derived type
-            string requestUri = this.BaseAddress + "/odata/Customers(2)/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer?$expand=Orders";
+            string requestUri = this.BaseAddress + "/odata/" + pathAndQuery;
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DerivedTypes/DerivedTypesTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DerivedTypes/DerivedTypesTests.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Routing;
+using Microsoft.AspNet.OData.Routing.Conventions;
+using Microsoft.OData.Edm;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Xunit;
+
+namespace Microsoft.Test.E2E.AspNet.OData.DerivedTypes
+{
+    public class DerivedTypeTests : WebHostTestBase
+    {
+        public DerivedTypeTests(WebHostTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            var controllers = new[] { typeof(CustomersController), typeof(MetadataController) };
+            configuration.AddControllers(controllers);
+
+            configuration.Routes.Clear();
+            configuration.Count().Filter().OrderBy().Expand().MaxTop(null).Select();
+            configuration.MapODataServiceRoute("odata", "odata", GetEdmModel(configuration), new DefaultODataPathHandler(), ODataRoutingConventions.CreateDefault());
+        }
+
+        private static IEdmModel GetEdmModel(WebRouteConfiguration configuration)
+        {
+            ODataConventionModelBuilder builder = configuration.CreateConventionModelBuilder();
+
+            builder.EntitySet<Customer>("Customers");
+            builder.EntityType<Order>();
+            builder.EntityType<VipCustomer>().DerivesFrom<Customer>();
+
+            return builder.GetEdmModel();
+        }
+
+        [Fact]
+        public async Task RestrictEntitySetToDerivedTypeInstances()
+        {
+            string requestUri = this.BaseAddress + "/odata/Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer";
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            var response = await this.Client.SendAsync(request);
+            Assert.True(response.IsSuccessStatusCode);
+
+            var expectedContent = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata" +
+                "#Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer\"," +
+                "\"value\":[{{\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"}}]}}", this.BaseAddress);
+
+            Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task RestrictEntityToDerivedTypeInstance_ForDerivedTypeNameAfterKey()
+        {
+            // Key preceeds name of the derived type
+            string requestUri = this.BaseAddress + "/odata/Customers(2)/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer";
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            var response = await this.Client.SendAsync(request);
+            Assert.True(response.IsSuccessStatusCode);
+
+            var expectedContent = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata" +
+                "#Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer/$entity\"," +
+                "\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"}}", this.BaseAddress);
+
+            Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task RestrictEntityToDerivedTypeInstance_ForDerivedTypeNameBeforeKey()
+        {
+            // Name of the derived type preceeds key
+            string requestUri = this.BaseAddress + "/odata/Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer(2)";
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            var response = await this.Client.SendAsync(request);
+            Assert.True(response.IsSuccessStatusCode);
+
+            var expectedContent = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata" +
+                "#Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer/$entity\"," +
+                "\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"}}", this.BaseAddress);
+
+            Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task ReturnNotFound_ForKeyNotAssociatedWithDerivedType()
+        {
+            // Customer with Id 1 is not a VipCustomer
+            string requestUri = this.BaseAddress + "/odata/Customers(1)/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer";
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            var response = await this.Client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task RestrictEntitySetToDerivedTypeInstances_ThenExpandNavProperty()
+        {
+            string requestUri = this.BaseAddress + "/odata/Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer?$expand=Orders";
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            var response = await this.Client.SendAsync(request);
+            Assert.True(response.IsSuccessStatusCode);
+
+            var expectedContent = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata" +
+                "#Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer(Orders())\"," +
+                "\"value\":[{{\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"," +
+                "\"Orders\":[{{\"Id\":2,\"Amount\":230}},{{\"Id\":3,\"Amount\":150}}]}}]}}", this.BaseAddress);
+
+            Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task RestrictEntityToDerivedTypeInstance_ThenExpandNavProperty()
+        {
+            // Key preceeds name of the derived type
+            string requestUri = this.BaseAddress + "/odata/Customers(2)/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer?$expand=Orders";
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            var response = await this.Client.SendAsync(request);
+            Assert.True(response.IsSuccessStatusCode);
+
+            var expectedContent = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata" +
+                "#Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer(Orders())/$entity\"," +
+                "\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"," +
+                "\"Orders\":[{{\"Id\":2,\"Amount\":230}},{{\"Id\":3,\"Amount\":150}}]}}", this.BaseAddress);
+
+            Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
+        }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DollarQuery/DollarQueryTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DollarQuery/DollarQueryTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -119,8 +118,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.DollarQuery
             var response = await this.Client.SendAsync(request);
             Assert.True(response.IsSuccessStatusCode);
 
-            var contentAsString = response.Content.ReadAsStringAsync().Result;
-            Assert.Contains("\"value\":[{\"Id\":1,\"Name\":\"Customer Name 1\"}]", contentAsString);
+            Assert.Contains("\"value\":[{\"Id\":1,\"Name\":\"Customer Name 1\"}]", await response.Content.ReadAsStringAsync());
         }
 
         [Fact]
@@ -138,8 +136,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.DollarQuery
             var response = await this.Client.SendAsync(request);
             Assert.True(response.IsSuccessStatusCode);
 
-            var contentAsString = response.Content.ReadAsStringAsync().Result;
-            Assert.Contains("\"value\":[{\"Id\":9,\"Name\":\"Customer Name 9\"},{\"Id\":1,\"Name\":\"Customer Name 1\"}]", contentAsString);
+            Assert.Contains("\"value\":[{\"Id\":9,\"Name\":\"Customer Name 9\"},{\"Id\":1,\"Name\":\"Customer Name 1\"}]",
+                await response.Content.ReadAsStringAsync());
         }
 
         [Fact]
@@ -333,8 +331,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.DollarQuery
             var response = await this.Client.SendAsync(request);
             Assert.True(response.IsSuccessStatusCode);
 
-            var contentAsString = response.Content.ReadAsStringAsync().Result;
-            Assert.Contains("\"value\":[{\"Id\":1,\"Name\":\"Customer Name 1\"}]", contentAsString);
+            Assert.Contains("\"value\":[{\"Id\":1,\"Name\":\"Customer Name 1\"}]",
+                await response.Content.ReadAsStringAsync());
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2277.*

### Description

Based on the [OData specification](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_AddressingDerivedTypes), the following two requests should be applicable when restricting an entity to a derived type instance

http://host/service/Customers/Model.VipCustomer(1) - key appearing after the cast
http://host/service/Customers(1)/Model.VipCustomer - key appearing before the cast (right after entity set)

In addition, if the customer with key 1 is not a VipCustomer, the result should be a 404 Not Found

This PR addresses that. Also added missing tests for these scenarios.

**Note:**
In the [**EntitySetRoutingConvention**](https://github.com/OData/WebApi/blob/ade333a0d063c0b18787623c1fd5651d0a497ed1/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/EntitySetRoutingConvention.cs#L66), the _~/entityset/cast_ path template is handled by either **Get[EntitySet]From[EntityType]** (e.g. `GetCustomersFromVipCustomer()`) or **GetFrom[EntityType]** (e.g. `GetFromVipCustomer()`). However, in regard to the [**EntityRoutingConventation**](https://github.com/OData/WebApi/blob/ade333a0d063c0b18787623c1fd5651d0a497ed1/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/EntityRoutingConvention.cs#L20), the _~/entityset/key/cast_ path template is handled by **Get[EntityType]** (e.g. `GetVipCustomer(int key)`) and `Get(int key)`. This is actually what our documentation says on [routing conventions](https://docs.microsoft.com/en-us/odata/webapi/built-in-routing-conventions). For this reason, where the relevant action method is not implemented, a 404 Not Found is returned and may create the impression that there's a bug/feature gap.

Q. Would there be any added benefit in having the _~/entityset/key/cast_ path template be handled _**additionally**_ by `GetCustomersFromVipCustomer(int key)` and `GetFromVipCustomer(int key)` to mirror the equivalent methods for derived type entity set routing?

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
