### PR TITLE
Enable case insensitive request binding

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/CompatibilityOptions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/CompatibilityOptions.cs
@@ -18,6 +18,11 @@ namespace Microsoft.AspNet.OData
         /// <summary>
         ///  Generate nextlink even if the top value specified in request is less than page size when the request extension method is directly called.
         /// </summary>
-        AllowNextLinkWithNonPositiveTopValue = 0x1
+        AllowNextLinkWithNonPositiveTopValue = 0x1,
+
+        /// <summary>
+        /// Disable case-insensitive request property binding.
+        /// </summary>
+        DisableCaseInsensitiveRequestPropertyBinding = 0x2
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataDeserializerContext.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataDeserializerContext.cs
@@ -47,6 +47,11 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         /// </summary>
         internal IWebApiUrlHelper InternalUrlHelper { get; private set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to disable case-insensitive request property binding.
+        /// </summary>
+        internal bool DisableCaseInsensitiveRequestPropertyBinding { get; set; }
+
         internal bool IsDeltaOfT
         {
             get

--- a/src/Microsoft.AspNet.OData/Adapters/WebApiRequestMessage.cs
+++ b/src/Microsoft.AspNet.OData/Adapters/WebApiRequestMessage.cs
@@ -224,5 +224,14 @@ namespace Microsoft.AspNet.OData.Adapters
         {
             get { return this.innerRequest.GetWriterSettings(); }
         }
+
+        /// <summary>
+        /// Gets the HttpConfiguration associated with the request.
+        /// </summary>
+        /// <returns></returns>
+        public HttpConfiguration Configuration
+        {
+            get { return this.innerRequest.GetConfiguration(); }
+        }
     }
 }

--- a/src/Microsoft.AspNet.OData/Formatter/Deserialization/ODataDeserializerContext.cs
+++ b/src/Microsoft.AspNet.OData/Formatter/Deserialization/ODataDeserializerContext.cs
@@ -4,6 +4,7 @@
 using System.Net.Http;
 using System.Web.Http.Controllers;
 using Microsoft.AspNet.OData.Adapters;
+using Microsoft.AspNet.OData.Extensions;
 
 namespace Microsoft.AspNet.OData.Formatter.Deserialization
 {
@@ -25,8 +26,13 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             set
             {
                 _request = value;
-                InternalRequest = _request != null ? new WebApiRequestMessage(_request) : null;
+                WebApiRequestMessage webApiRequestMessage = _request != null ? new WebApiRequestMessage(_request) : null;
+                InternalRequest = webApiRequestMessage;
                 InternalUrlHelper = _request != null ? new WebApiUrlHelper(_request.GetUrlHelper()) : null;
+
+                // We add this setting via CompatibilityOptions
+                CompatibilityOptions options = webApiRequestMessage != null ? webApiRequestMessage.Configuration.GetCompatibilityOptions() : CompatibilityOptions.None;
+                DisableCaseInsensitiveRequestPropertyBinding = options.HasFlag(CompatibilityOptions.DisableCaseInsensitiveRequestPropertyBinding) ? true : false;
             }
         }
 

--- a/src/Microsoft.AspNetCore.OData/Adapters/WebApiRequestMessage.cs
+++ b/src/Microsoft.AspNetCore.OData/Adapters/WebApiRequestMessage.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNet.OData.Adapters
         /// <summary>
         /// The inner request wrapped by this instance.
         /// </summary>
-        internal HttpRequest innerRequest;
+        private HttpRequest innerRequest;
 
         /// <summary>
         /// Initializes a new instance of the WebApiRequestMessage class.

--- a/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerContext.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/Deserialization/ODataDeserializerContext.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNet.OData.Adapters;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNet.OData.Formatter.Deserialization
 {
@@ -25,8 +26,13 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             set
             {
                 _request = value;
-                InternalRequest = _request != null ? new WebApiRequestMessage(_request) : null;
+                WebApiRequestMessage webApiRequestMessage = _request != null ? new WebApiRequestMessage(_request) : null;
+                InternalRequest = webApiRequestMessage;
                 InternalUrlHelper = _request != null ? new WebApiUrlHelper(_request.GetUrlHelper()) : null;
+
+                // We add this setting via CompatibilityOptions
+                CompatibilityOptions options = webApiRequestMessage != null ? webApiRequestMessage.RequestContainer.GetService<ODataOptions>().CompatibilityOptions : CompatibilityOptions.None;
+                DisableCaseInsensitiveRequestPropertyBinding = options.HasFlag(CompatibilityOptions.DisableCaseInsensitiveRequestPropertyBinding) ? true : false;
             }
         }
     }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -3,6 +3,7 @@ FlagsAttribute(),
 ]
 public enum Microsoft.AspNet.OData.CompatibilityOptions : int {
 	AllowNextLinkWithNonPositiveTopValue = 1
+	DisableCaseInsensitiveRequestPropertyBinding = 2
 	None = 0
 }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/RequestFactory.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/RequestFactory.cs
@@ -4,11 +4,9 @@
 using System;
 using System.Linq;
 using System.Net.Http;
-using Microsoft.AspNet.OData;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/RoutingConfigurationFactory.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/RoutingConfigurationFactory.cs
@@ -14,8 +14,8 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 #if NETCOREAPP2_0
-    using Microsoft.AspNetCore.Builder.Internal;
-    using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Builder.Internal;
+using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -156,6 +156,66 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
             applicationPartManager.ApplicationParts.Add(part);
 
             return builder;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the routing configuration class.
+        /// </summary>
+        /// <returns>A new instance of the routing configuration class.</returns>
+        public static IRouteBuilder CreateWithDisabledCaseInsensitiveRequestPropertyBinding()
+        {
+            IServiceCollection serviceCollection = new ServiceCollection();
+            serviceCollection.AddMvc();
+            serviceCollection.AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
+            serviceCollection.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+            serviceCollection.AddOData();
+
+            // For routing tests, add an IActionDescriptorCollectionProvider.
+            serviceCollection.AddSingleton<IActionDescriptorCollectionProvider, TestActionDescriptorCollectionProvider>();
+
+            // Add an action select to return a default descriptor.
+            var mockAction = new Mock<ActionDescriptor>();
+            ActionDescriptor actionDescriptor = mockAction.Object;
+
+            var mockActionSelector = new Mock<IActionSelector>();
+            mockActionSelector
+                .Setup(a => a.SelectCandidates(It.IsAny<RouteContext>()))
+                .Returns(new ActionDescriptor[] { actionDescriptor });
+
+            mockActionSelector
+                .Setup(a => a.SelectBestCandidate(It.IsAny<RouteContext>(), It.IsAny<IReadOnlyList<ActionDescriptor>>()))
+                .Returns(actionDescriptor);
+
+            // Add a mock action invoker & factory.
+            var mockInvoker = new Mock<IActionInvoker>();
+            mockInvoker.Setup(i => i.InvokeAsync())
+                .Returns(Task.FromResult(true));
+
+            var mockInvokerFactory = new Mock<IActionInvokerFactory>();
+            mockInvokerFactory.Setup(f => f.CreateInvoker(It.IsAny<ActionContext>()))
+                .Returns(mockInvoker.Object);
+
+            // Create a logger, diagnostic source and app builder.
+            var mockLoggerFactory = new Mock<ILoggerFactory>();
+            var diagnosticSource = new DiagnosticListener("Microsoft.AspNetCore");
+            IApplicationBuilder appBuilder = new ApplicationBuilder(serviceCollection.BuildServiceProvider());
+
+            // Create a route build with a default path handler.
+            IRouteBuilder routeBuilder = new RouteBuilder(appBuilder);
+
+#if NETCOREAPP2_0
+            routeBuilder.DefaultHandler = new MvcRouteHandler(
+                mockInvokerFactory.Object,
+                mockActionSelector.Object,
+                diagnosticSource,
+                mockLoggerFactory.Object,
+                new ActionContextAccessor());
+#else
+            //appBuilder.ApplicationServices.GetRequiredService<MvcRouteHandler>();
+            routeBuilder.DefaultHandler = new MyMvcRouteHandler();
+#endif
+            routeBuilder.SetCompatibilityOptions(CompatibilityOptions.DisableCaseInsensitiveRequestPropertyBinding);
+            return routeBuilder;
         }
     }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -3,6 +3,7 @@ FlagsAttribute(),
 ]
 public enum Microsoft.AspNet.OData.CompatibilityOptions : int {
 	AllowNextLinkWithNonPositiveTopValue = 1
+	DisableCaseInsensitiveRequestPropertyBinding = 2
 	None = 0
 }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -3,6 +3,7 @@ FlagsAttribute(),
 ]
 public enum Microsoft.AspNet.OData.CompatibilityOptions : int {
 	AllowNextLinkWithNonPositiveTopValue = 1
+	DisableCaseInsensitiveRequestPropertyBinding = 2
 	None = 0
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2247 .*

### Description

Original PR merged accidentally and reverted #2249 
The exception is thrown when we try extracting the `edmProperty` for the `StructuredType` by passing a property name that doesn’t match what was in the model.
```csharp
IEdmProperty edmProperty = resourceType.FindProperty(property.Name);
```
Since properties in the Url are case-insensitive by default, we will make properties in the request case-insensitive by default. We can disable this through a compatibility option.

**AspNetCore WebApi**
We resolve this by injecting a dependency as follows:
```csharp
public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
{
    ...
    app.UseMvc(routeBuilder =>
    { 
         routeBuilder.Select().Filter().Expand().MaxTop(100).OrderBy().Count().SetCompatibilityOptions(CompatibilityOptions.DisableCaseInsensitiveRequestPropertyBinding);
    });
}
```
**AspNet WebApi**
```csharp
public static void Register(HttpConfiguration config)
{
    var builder = new ODataConventionModelBuilder();
    ....
    ....
    config.SetCompatibilityOptions(CompatibilityOptions.DisableCaseInsensitiveRequestPropertyBinding);
}
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
