### PR TITLE
add support for parameters defined with type

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Extensions/Endpoint/ODataEndpointLinkGenerator.cs
+++ b/src/Microsoft.AspNetCore.OData/Extensions/Endpoint/ODataEndpointLinkGenerator.cs
@@ -107,12 +107,18 @@ namespace Microsoft.AspNet.OData.Extensions
                 startIndex = end + 1;
 
                 string subStr = prefix.Substring(start, end - start + 1);
+
                 templates.Add(subStr);
             }
 
             foreach (var item in templates)
             {
                 string variable = item.Substring(1, item.Length - 2); // remove { and }
+                var colonIndex = variable.IndexOf(":");
+                if (colonIndex != -1)
+                {
+                    variable = variable.Substring(0, colonIndex);
+                }
 
                 if (values != null && values.TryGetValue(variable, out object valueFromValues))
                 {

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointLinkGeneratorTests.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointLinkGeneratorTests.cs
@@ -161,6 +161,26 @@ namespace Microsoft.AspNet.OData.Test.Extensions
             // Assert
             Assert.Equal(expect, actual);
         }
+
+        [Theory]
+        [InlineData("api/v1/tenants/{tid:guid}", "api/v1/tenants/003890b9972e4092aef80e882f1e0999")]
+        public void BindPrefixTemplateWithGuidParameterWorksAsExpected(string prefix, string expect)
+        {
+            // Arrange
+            RouteValueDictionary values = new RouteValueDictionary
+            (
+                new
+                {
+                    tid = "003890b9972e4092aef80e882f1e0999"
+                }
+            );
+
+            // Act
+            string actual = ODataEndpointLinkGenerator.BindPrefixTemplate(prefix, values, null);
+
+            // Assert
+            Assert.Equal(expect, actual);
+        }
     }
 }
 #endif


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

#2312 

### Description

Add support for parameters defined with type when Endpoint Routing is used for aspnetcore 3.1.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

