### PR TITLE
Fix failing tests occasioned by use of await expression in test asserts

### DIFF
--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DerivedTypes/DerivedTypesTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DerivedTypes/DerivedTypesTests.cs
@@ -53,11 +53,9 @@ namespace Microsoft.Test.E2E.AspNet.OData.DerivedTypes
             var response = await this.Client.SendAsync(request);
             Assert.True(response.IsSuccessStatusCode);
 
-            var expectedContent = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata" +
-                "#Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer\"," +
-                "\"value\":[{{\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"}}]}}", this.BaseAddress);
+            var expectedContent = "\"value\":[{\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"}]";
 
-            Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
+            Assert.Contains(expectedContent, await response.Content.ReadAsStringAsync());
         }
 
         [Theory]
@@ -73,11 +71,9 @@ namespace Microsoft.Test.E2E.AspNet.OData.DerivedTypes
             var response = await this.Client.SendAsync(request);
             Assert.True(response.IsSuccessStatusCode);
 
-            var expectedContent = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata" +
-                "#Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer/$entity\"," +
-                "\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"}}", this.BaseAddress);
+            var expectedContent = "\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"";
 
-            Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
+            Assert.Contains(expectedContent, await response.Content.ReadAsStringAsync());
         }
 
         [Fact]
@@ -103,12 +99,10 @@ namespace Microsoft.Test.E2E.AspNet.OData.DerivedTypes
             var response = await this.Client.SendAsync(request);
             Assert.True(response.IsSuccessStatusCode);
 
-            var expectedContent = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata" +
-                "#Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer(Orders())\"," +
-                "\"value\":[{{\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"," +
-                "\"Orders\":[{{\"Id\":2,\"Amount\":230}},{{\"Id\":3,\"Amount\":150}}]}}]}}", this.BaseAddress);
+            var expectedContent = "\"value\":[{\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"," +
+                "\"Orders\":[{\"Id\":2,\"Amount\":230},{\"Id\":3,\"Amount\":150}]}]";
 
-            Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
+            Assert.Contains(expectedContent, await response.Content.ReadAsStringAsync());
         }
 
         [Theory]
@@ -124,12 +118,10 @@ namespace Microsoft.Test.E2E.AspNet.OData.DerivedTypes
             var response = await this.Client.SendAsync(request);
             Assert.True(response.IsSuccessStatusCode);
 
-            var expectedContent = string.Format("{{\"@odata.context\":\"{0}/odata/$metadata" +
-                "#Customers/Microsoft.Test.E2E.AspNet.OData.DerivedTypes.VipCustomer(Orders())/$entity\"," +
-                "\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"," +
-                "\"Orders\":[{{\"Id\":2,\"Amount\":230}},{{\"Id\":3,\"Amount\":150}}]}}", this.BaseAddress);
+            var expectedContent = "\"Id\":2,\"Name\":\"Customer 2\",\"LoyaltyCardNo\":\"9876543210\"," +
+                "\"Orders\":[{\"Id\":2,\"Amount\":230},{\"Id\":3,\"Amount\":150}]";
 
-            Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
+            Assert.Contains(expectedContent, await response.Content.ReadAsStringAsync());
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

Fix failing tests on master occasioned by use of await expression in test asserts

### More details:
When an Xunit assert statement contains an `await` expression as shown below, it'd seem that on ADO, the `@odata.context` property in the response will have the DNS HostName (equivalent to machine name but in upper case) in place of the actual machine name and this causes the assertion to fail.
```c#
Assert.Equal(expectedContent, await response.Content.ReadAsStringAsync());
```
Results into the error:
```
2020-10-06T06:13:49.8104815Z [xUnit.net 00:19:49.5446312]       Expected: Â·Â·Â·ta.context":"http://WIN-D2O1RI1MT21:11129/odata/$metadata#CusÂ·Â·Â·
2020-10-06T06:13:49.8106363Z [xUnit.net 00:19:49.5446408]       Actual:   Â·Â·Â·ta.context":"http://win-d2o1ri1mt21:11129/odata/$metadata#CusÂ·Â·Â·
```
This can be fixed by eagerly awaiting the results of the asynchronous operation as follows:
```c#
var actualContent = response.Content.ReadAsStringAsync().Result;
Assert.Equal(expectedContent, actualContent);
```
Instead of clawing back the gains from use of asynchrony, we instead change the assert statement to verify what is of interest - the substantive body of the response, e.g.,
```c#
Assert.Contains("\"value\":[{\"Id\":1,\"Name\":\"Customer Name 1\"}]",
                await response.Content.ReadAsStringAsync());
```