### PR TITLE
Fix routing regression causing 404 on actions with [FromQuery]

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
@@ -141,8 +141,8 @@ namespace Microsoft.AspNet.OData.Routing
                         id: c.Id,
                         parameterCount: c.Parameters.Count,
                         filteredParameters: c.Parameters.Where(p => p.ParameterType != typeof(ODataPath) &&
-                            !IsParameterFromQuery(c as ControllerActionDescriptor, p.Name) &&
-                            !ODataQueryParameterBindingAttribute.ODataQueryParameterBinding.IsODataQueryOptions(p.ParameterType)),
+                            !ODataQueryParameterBindingAttribute.ODataQueryParameterBinding.IsODataQueryOptions(p.ParameterType) &&
+                            !IsParameterFromQuery(c as ControllerActionDescriptor, p.Name)),
                         descriptor: c));
 
                 // retrieve the optional parameters

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
@@ -267,7 +267,6 @@ namespace Microsoft.AspNet.OData.Routing
                     }
                 }
 
-
                 // if we can't find the parameter in the request, check whether
                 // there's a special model binder registered to handle it
                 if (ParameterHasRegisteredModelBinder(p))

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Routing/ODataActionSelectorTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Routing/ODataActionSelectorTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNet.OData.Query;
 using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
+using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Routing
@@ -43,6 +44,18 @@ namespace Microsoft.AspNet.OData.Test.Routing
                         ("GET", null),
                         (typeof(KeyAndQueryController), "Get",
                         new [] { typeof(int), typeof(ODataQueryOptions)})
+                    },
+                    {
+                        new Dictionary<string, object>(),
+                        ("GET", null),
+                        (typeof(FromQueryController), "Get",
+                        new [] { typeof(string), typeof(ODataQueryOptions)})
+                    },
+                    {
+                        new Dictionary<string, object>() { { "key", 1 } },
+                        ("GET", null),
+                        (typeof(FromQueryController), "Get",
+                        new [] { typeof(int), typeof(string) })
                     },
                     {
                         new Dictionary<string, object>() { { "key", 1 }, { "relatedKey", 2 } },
@@ -96,6 +109,65 @@ namespace Microsoft.AspNet.OData.Test.Routing
                         ("PATCH", "{}"),
                         (typeof(ExtraParametersWithOwnModelBindersController), "Patch",
                         new [] { typeof(int), typeof(System.Threading.CancellationToken), typeof(Delta<object>) })
+                    },         
+                    {
+                        new Dictionary<string, object>() { { "key", 1 } },
+                        ("GET", null),
+                        (typeof(FromQueryController), "Get",
+                        new [] { typeof(int), typeof(string) })
+                    },
+                    {
+                    new Dictionary<string, object>() { { "key", 1 }, { "relatedKey", 2 } },
+                        ("GET", null),
+                        (typeof(KeyAndRelatedKeyController), "Get",
+                        new[] { typeof(int), typeof(int) })
+                    },
+                    {
+                    new Dictionary<string, object>() { { "key", 1 }, { "relatedKey", 2 } },
+                        ("GET", null),
+                        (typeof(KeyAndRelatedKeyAndPathController), "Get",
+                        new[] { typeof(int), typeof(int), typeof(ODataPath) })
+                    },
+                    {
+                    new Dictionary<string, object>()
+                        {
+                            { "key", 1 }, { "relatedKey", 2 }, { "navigationProperty", 3 }
+                        },
+                        ("GET", null),
+                        (typeof(KeyAndRelatedKeyAndPathController), "Get",
+                        new[] { typeof(int), typeof(int), typeof(int) })
+                    },
+                    {
+                    new Dictionary<string, object>() { { "key", 1 } },
+                        ("GET", null),
+                        (typeof(KeyAndRelatedKeyAndPathController), "Get",
+                        new[] { typeof(int), typeof(ODataPath) })
+                    },
+                    // actions that expect request body
+                    {
+                    new Dictionary<string, object>(),
+                        ("POST", "{}"),
+                        (typeof(BodyOnlyController), "Post",
+                        new[] { typeof(int) })
+                    },
+                    {
+                    new Dictionary<string, object> { { "key", 1 } },
+                        ("PATCH", "{}"),
+                        (typeof(KeyBodyController), "Patch",
+                        new[] { typeof(int), typeof(Delta<object>) })
+                    },
+                    // actions that declare extra parameters with registered model binders
+                    {
+                    new Dictionary<string, object> { { "key", 1 } },
+                        ("GET", null),
+                        (typeof(ExtraParametersWithOwnModelBindersController), "Get",
+                        new[] { typeof(int), typeof(System.Threading.CancellationToken) })
+                    },
+                    {
+                    new Dictionary<string, object> { { "key", 1 } },
+                        ("PATCH", "{}"),
+                        (typeof(ExtraParametersWithOwnModelBindersController), "Patch",
+                        new[] { typeof(int), typeof(System.Threading.CancellationToken), typeof(Delta<object>) })
                     }
                 };
             }
@@ -195,6 +267,12 @@ namespace Microsoft.AspNet.OData.Test.Routing
         public void Get(int key, ODataQueryOptions queryOptions) { }
 
         public void Get(int key) { }
+    }
+
+    public class FromQueryController : TestODataController
+    {
+        public void Get([FromQuery] string option, ODataQueryOptions queryOptions) { }
+        public void Get(int key, [FromQuery] string option) { }
     }
 
     public class KeyAndRelatedKeyController : TestODataController

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Routing/ODataActionSelectorTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Routing/ODataActionSelectorTest.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNet.OData.Test.Routing
                         ("PATCH", "{}"),
                         (typeof(ExtraParametersWithOwnModelBindersController), "Patch",
                         new [] { typeof(int), typeof(System.Threading.CancellationToken), typeof(Delta<object>) })
-                    },         
+                    },
                     {
                         new Dictionary<string, object>() { { "key", 1 } },
                         ("GET", null),


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2301.*

### Description

*Briefly describe the changes of this pull request.*

The routing was failing in this case because the action selector could not match the parameter decorated with `[FromQuery]` to keys in the url. Since `[FromQuery]` parameters are bound from query options, the action selector should ignore them (it already ignores parameters of type `ODataQueryOptions`). I made the corresponding update to the action selector.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
