### PR TITLE
Issue2316: Select a complex with null value fails

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -792,10 +792,10 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 return;
             }
 
-            // EF5 and EF6 doesn't support to compare the complex with null.
-            // With the following null check, EF5 and EF6 will throw except similar to:
-            // "Cannot compare elements of type 'xxxx'.Only primitive types, enumeration types and entity types are supported.
-            // EF Core has imporvement so the following null won't throw error.
+            // EF5 and EF6 don't support comparing complex objects to null, and will throw an exception similar to following if it is
+            // attempted:
+            //    "Cannot compare elements of type 'xxxx'. Only primitive types, enumeration types and entity types are supported."
+            // EFCore has changed its implementation so the null check executes as expected.
             Expression nullCheck = null;
             if (_dataSourceProviderKind != DataSourceProviderKind.EFClassic)
             {

--- a/src/Microsoft.AspNet.OData.Shared/Query/HandleNullPropagationOptionHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/HandleNullPropagationOptionHelper.cs
@@ -78,8 +78,11 @@ namespace Microsoft.AspNet.OData.Query
                 case ObjectContextQueryProviderNamespaceEFCore2:
                     return DataSourceProviderKind.EFCore;
 
-                default:
+                case Linq2ObjectsQueryProviderNamespace:
                     return DataSourceProviderKind.InMemory;
+
+                default:
+                    return DataSourceProviderKind.Unknown;
             }
         }
     }
@@ -87,9 +90,9 @@ namespace Microsoft.AspNet.OData.Query
     internal enum DataSourceProviderKind
     {
         /// <summary>
-        /// None Data source provider
+        /// Unknown data source provider
         /// </summary>
-        None,
+        Unknown,
 
         /// <summary>
         /// In memory data source provider
@@ -104,6 +107,6 @@ namespace Microsoft.AspNet.OData.Query
         /// <summary>
         /// EF Core Data source provider
         /// </summary>
-        EFCore
+        EFCore,
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Query/HandleNullPropagationOptionHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/HandleNullPropagationOptionHelper.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNet.OData.Query
                     return DataSourceProviderKind.EFCore;
 
                 default:
-                    return DataSourceProviderKind.None;
+                    return DataSourceProviderKind.InMemory;
             }
         }
     }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/SelectExpandTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/SelectExpandTest.cs
@@ -259,6 +259,30 @@ namespace Microsoft.AspNet.OData.Test
         }
 
         [Fact]
+        public async Task SelectExpand_WithNullComplexProperty()
+        {
+            // Arrange
+            var uri = "/odata/SelectExpandTestCustomers?$select=ID,Address";
+
+            // Act
+            var response = await GetResponse(uri, AcceptJson);
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync();
+            SelectExpandTestCustomer[] customers = JObject.Parse(content).GetValue("value").ToObject<SelectExpandTestCustomer[]>();
+            Assert.NotNull(customers);
+            Assert.Equal(3, customers.Length);
+
+            for (int i = 0; i < 3; i++)
+            {
+                SelectExpandTestCustomer customer = customers[i];
+                Assert.Equal(42 + i, customer.ID);
+                Assert.Null(customer.Address);
+            }
+        }
+
+        [Fact]
         public async Task SelectExpand_QueryableOnSingleEntity_Works()
         {
             // Arrange
@@ -569,6 +593,8 @@ namespace Microsoft.AspNet.OData.Test
             }
         }
 
+        public SelectExpandTestCustomerAddress Address { get; set; }
+
         public int ID { get; set; }
 
         public string Name { get; set; }
@@ -576,6 +602,11 @@ namespace Microsoft.AspNet.OData.Test
         public SelectExpandTestOrder[] Orders { get; set; }
 
         public SelectExpandTestCustomer PreviousCustomer { get; set; }
+    }
+
+    public class SelectExpandTestCustomerAddress
+    {
+        public string City { get; set; }
     }
 
     public class SelectExpandTestSpecialCustomer : SelectExpandTestCustomer


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This is a fix for https://github.com/OData/WebApi/issues/2316, please see that issue for a full discussion

### Description

If I have a simple object model like this:

```
    public class Simple
    {
        [DataMember]
        public Complex Complex { get; set; }

        [Key]
        public string Id { get; set; }

        [DataMember]
        public string Name { get; set; }
    }

    public class Complex
    {
        public string Value { get; set; }
    }
```
*Where Simple is used for the entity set.*

And I make a query like this:
`.../Simple?$select=Complex`

The request will fail if any of the `Simple` instances have a null value for `Complex`.

This change fixes the issue by sure the null check is only removed for the scenario that was problematic in the first place. It also does a couple of other things:
1. Rename `None` to `Unknown`
1. Map `System.Linq` as `InMemory`

### Checklist (Uncheck if it is not completed)

- [x ] *Test cases added*
- [x ] *Build and test with one-click build and test script passed*
