### PR TITLE
Fix regression affecting usage of "in" expression with primitive collection property on RHS

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -512,8 +512,15 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             Expression singleValue = Bind(inNode.Left);
             Expression collection = Bind(inNode.Right);
 
-            Type collectionItemType = collection.Type.GetElementType() ?? (typeof(IEnumerable).IsAssignableFrom(collection.Type) ? collection.Type.GetGenericArguments()[0] : null);
-            Contract.Assert(collectionItemType != null); // Not expected
+            Type collectionItemType = collection.Type.GetElementType();
+            if (collectionItemType == null)
+            {
+                Type[] genericArgs = collection.Type.GetGenericArguments();
+                // The model builder does not support non-generic collections like ArrayList
+                // or generic collections with generic arguments > 1 like IDictionary<,>
+                Contract.Assert(genericArgs.Length == 1);
+                collectionItemType = genericArgs[0];
+            }
 
             if (IsIQueryable(collection.Type))
             {

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -512,14 +512,17 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             Expression singleValue = Bind(inNode.Left);
             Expression collection = Bind(inNode.Right);
 
+            Type collectionItemType = collection.Type.GetElementType() ?? (typeof(IEnumerable).IsAssignableFrom(collection.Type) ? collection.Type.GetGenericArguments()[0] : null);
+            Contract.Assert(collectionItemType != null); // Not expected
+
             if (IsIQueryable(collection.Type))
             {
-                Expression containsExpression = singleValue.Type != collection.Type.GetGenericArguments()[0] ? Expression.Call(null, ExpressionHelperMethods.QueryableCastGeneric.MakeGenericMethod(singleValue.Type), collection) : collection;
+                Expression containsExpression = singleValue.Type != collectionItemType ? Expression.Call(null, ExpressionHelperMethods.QueryableCastGeneric.MakeGenericMethod(singleValue.Type), collection) : collection;
                 return Expression.Call(null, ExpressionHelperMethods.QueryableContainsGeneric.MakeGenericMethod(singleValue.Type), containsExpression, singleValue);
             }
             else
             {
-                Expression containsExpression = singleValue.Type != collection.Type.GetGenericArguments()[0] ? Expression.Call(null, ExpressionHelperMethods.EnumerableCastGeneric.MakeGenericMethod(singleValue.Type), collection) : collection;
+                Expression containsExpression = singleValue.Type != collectionItemType ? Expression.Call(null, ExpressionHelperMethods.EnumerableCastGeneric.MakeGenericMethod(singleValue.Type), collection) : collection;
                 return Expression.Call(null, ExpressionHelperMethods.EnumerableContainsGeneric.MakeGenericMethod(singleValue.Type), containsExpression, singleValue);
             }
         }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -2956,6 +2956,25 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 "$it => (Convert(IIF((($it.ProductProperties != null) AndAlso $it.ProductProperties.ContainsKey(Token)), $it.ProductPropertiesToken, null)) == \"1\")");
         }
 
+        [Fact]
+        public void InOnPrimitiveCollectionPropertyOnRHS()
+        {
+            var filters = VerifyQueryDeserialization(
+               "42 in AlternateIDs",
+               "$it => $it.AlternateIDs.Contains(42)",
+               NotTesting);
+
+            RunFilters(
+                filters,
+                new Product { AlternateIDs = new[] { 1, 2, 42 } },
+                new { WithNullPropagation = true, WithoutNullPropagation = true });
+
+            RunFilters(
+                filters,
+                new Product { AlternateIDs = new[] { 1, 2 } },
+                new { WithNullPropagation = false, WithoutNullPropagation = false });
+        }
+
 #region Negative Tests
 
         [Fact]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -2956,8 +2956,10 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 "$it => (Convert(IIF((($it.ProductProperties != null) AndAlso $it.ProductProperties.ContainsKey(Token)), $it.ProductPropertiesToken, null)) == \"1\")");
         }
 
-        [Fact]
-        public void InOnPrimitiveCollectionPropertyOnRHS()
+        [Theory]
+        [InlineData(new[] { 1, 2, 42 }, true)]
+        [InlineData(new[] { 1, 2 }, false)]
+        public void InOnPrimitiveCollectionPropertyOnRHS(int[] alternateIds, bool withNullPropagation)
         {
             var filters = VerifyQueryDeserialization(
                "42 in AlternateIDs",
@@ -2966,13 +2968,8 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
 
             RunFilters(
                 filters,
-                new Product { AlternateIDs = new[] { 1, 2, 42 } },
-                new { WithNullPropagation = true, WithoutNullPropagation = true });
-
-            RunFilters(
-                filters,
-                new Product { AlternateIDs = new[] { 1, 2 } },
-                new { WithNullPropagation = false, WithoutNullPropagation = false });
+                new Product { AlternateIDs = alternateIds },
+                new { WithNullPropagation = withNullPropagation, WithoutNullPropagation = withNullPropagation });
         }
 
 #region Negative Tests


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2318 .*

### Description

Fix regression affecting usage of "in" expression with primitive collection property on RHS. Introduced in [this](https://github.com/OData/WebApi/pull/2195/files#diff-0f1b878d20db0edc22bbe7cb23057c8ea3e3dffad198ea5044920fff31515b42R522) PR.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
