### PR TITLE
Fix invalid next page link in nested collections

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Routing/ODataRoute.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataRoute.cs
@@ -69,7 +69,6 @@ namespace Microsoft.AspNet.OData.Routing
                 {
                     // Try to generate an optimized direct link
                     // Otherwise, fall back to the base implementation
-                    VirtualPathData path;
                     if (CanGenerateDirectLink)
                     {
                         return GenerateLinkDirectly(odataPath);
@@ -96,7 +95,7 @@ namespace Microsoft.AspNet.OData.Routing
                         // Q. Are there scenarios when we'd be happy with having the path separator escaped for us?
                         string token = System.Guid.NewGuid().ToString().Replace("-", "");
                         context.Values[ODataRouteConstants.ODataPath] = odataPath.Replace("/", token);
-                        path = base.GetVirtualPath(context);
+                        VirtualPathData path = base.GetVirtualPath(context);
                         path.VirtualPath = path.VirtualPath.Replace(token, "/");
                         return path;
                     }

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataRoute.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataRoute.cs
@@ -73,11 +73,8 @@ namespace Microsoft.AspNet.OData.Routing
                     {
                         return GenerateLinkDirectly(odataPath);
                     }
-                    else if (!odataPath.Contains("/"))
-                    {
-                        return base.GetVirtualPath(context);
-                    }
-                    else
+
+                    if (odataPath.Contains("/"))
                     {
                         // During link generation using `RouteCollection`'s `GetVirtualPath` method, 
                         // the catch-all parameter escapes the appropriate characters when the route 
@@ -94,10 +91,17 @@ namespace Microsoft.AspNet.OData.Routing
                         // after the call to `GetVirtualPath`.
                         // Q. Are there scenarios when we'd be happy with having the path separator escaped for us?
                         string token = System.Guid.NewGuid().ToString().Replace("-", "");
+
                         context.Values[ODataRouteConstants.ODataPath] = odataPath.Replace("/", token);
                         VirtualPathData path = base.GetVirtualPath(context);
                         path.VirtualPath = path.VirtualPath.Replace(token, "/");
+                        context.Values[ODataRouteConstants.ODataPath] = odataPath;
+
                         return path;
+                    }
+                    else
+                    {
+                        return base.GetVirtualPath(context);
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataRoute.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataRoute.cs
@@ -99,10 +99,8 @@ namespace Microsoft.AspNet.OData.Routing
 
                         return path;
                     }
-                    else
-                    {
-                        return base.GetVirtualPath(context);
-                    }
+
+                    return base.GetVirtualPath(context);
                 }
             }
 

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataRoute.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataRoute.cs
@@ -69,9 +69,37 @@ namespace Microsoft.AspNet.OData.Routing
                 {
                     // Try to generate an optimized direct link
                     // Otherwise, fall back to the base implementation
-                    return CanGenerateDirectLink
-                        ? GenerateLinkDirectly(odataPath)
-                        : base.GetVirtualPath(context);
+                    VirtualPathData path;
+                    if (CanGenerateDirectLink)
+                    {
+                        return GenerateLinkDirectly(odataPath);
+                    }
+                    else if (!odataPath.Contains("/"))
+                    {
+                        return base.GetVirtualPath(context);
+                    }
+                    else
+                    {
+                        // During link generation using `RouteCollection`'s `GetVirtualPath` method, 
+                        // the catch-all parameter escapes the appropriate characters when the route 
+                        // is used to generate a URL, including path separator (/) characters. 
+                        // For example, the route prefix/{*odataPath} with 
+                        // route values { odataPath = "Customers(1)/Orders" } 
+                        // generates prefix/Customers(1)%2FOrders. The forward slash is escaped. 
+                        // https://docs.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-2.1#url-generation-with-linkgenerator
+                        // This causes a problem in some scenarios, e.g. when generating 
+                        // next page link for an expanded collection navigation property
+
+                        // HACK! We go round the problem by substituting the forward slash 
+                        // with a unique token and then substituting the forward slash back 
+                        // after the call to `GetVirtualPath`.
+                        // Q. Are there scenarios when we'd be happy with having the path separator escaped for us?
+                        string token = System.Guid.NewGuid().ToString().Replace("-", "");
+                        context.Values[ODataRouteConstants.ODataPath] = odataPath.Replace("/", token);
+                        path = base.GetVirtualPath(context);
+                        path.VirtualPath = path.VirtualPath.Replace(token, "/");
+                        return path;
+                    }
                 }
             }
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -1684,6 +1684,15 @@
     <Compile Include="..\Routing\UnqualifiedNameCallRoutingTests.cs">
       <Link>Routing\UnqualifiedNameCallRoutingTests.cs</Link>
     </Compile>
+    <Compile Include="..\ServerSidePaging\ServerSidePagingControllers.cs">
+      <Link>ServerSidePaging\ServerSidePagingControllers.cs</Link>
+    </Compile>
+    <Compile Include="..\ServerSidePaging\ServerSidePagingDataModel.cs">
+      <Link>ServerSidePaging\ServerSidePagingDataModel.cs</Link>
+    </Compile>
+    <Compile Include="..\ServerSidePaging\ServerSidePagingTests.cs">
+      <Link>ServerSidePaging\ServerSidePagingTests.cs</Link>
+    </Compile>
     <Compile Include="..\SingleResult\SingleResultController.cs">
       <Link>SingleResult\SingleResultController.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -1537,6 +1537,15 @@
     <Compile Include="..\Routing\UnqualifiedNameCallRoutingTests.cs">
       <Link>Routing\UnqualifiedNameCallRoutingTests.cs</Link>
     </Compile>
+    <Compile Include="..\ServerSidePaging\ServerSidePagingControllers.cs">
+      <Link>ServerSidePaging\ServerSidePagingControllers.cs</Link>
+    </Compile>
+    <Compile Include="..\ServerSidePaging\ServerSidePagingDataModel.cs">
+      <Link>ServerSidePaging\ServerSidePagingDataModel.cs</Link>
+    </Compile>
+    <Compile Include="..\ServerSidePaging\ServerSidePagingTests.cs">
+      <Link>ServerSidePaging\ServerSidePagingTests.cs</Link>
+    </Compile>
     <Compile Include="..\SingleResult\SingleResultController.cs">
       <Link>SingleResult\SingleResultController.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
@@ -1552,6 +1552,15 @@
     <Compile Include="..\Routing\UnqualifiedNameCallRoutingTests.cs">
       <Link>Routing\UnqualifiedNameCallRoutingTests.cs</Link>
     </Compile>
+    <Compile Include="..\ServerSidePaging\ServerSidePagingControllers.cs">
+      <Link>ServerSidePaging\ServerSidePagingControllers.cs</Link>
+    </Compile>
+    <Compile Include="..\ServerSidePaging\ServerSidePagingDataModel.cs">
+      <Link>ServerSidePaging\ServerSidePagingDataModel.cs</Link>
+    </Compile>
+    <Compile Include="..\ServerSidePaging\ServerSidePagingTests.cs">
+      <Link>ServerSidePaging\ServerSidePagingTests.cs</Link>
+    </Compile>
     <Compile Include="..\SingleResult\SingleResultController.cs">
       <Link>SingleResult\SingleResultController.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingControllers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingControllers.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNet.OData;
+using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
+
+namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
+{
+    public class ServerSidePagingCustomersController : TestODataController
+    {
+        private readonly IList<ServerSidePagingCustomer> _serverSidePagingCustomers;
+
+        public ServerSidePagingCustomersController()
+        {
+            _serverSidePagingCustomers = new List<ServerSidePagingCustomer>(
+                Enumerable.Range(1, 7).Select(i => new ServerSidePagingCustomer
+                {
+                    Id = i,
+                    Name = "Customer Name " + i
+                }));
+
+            for (int i = 0; i < _serverSidePagingCustomers.Count; i++)
+            {
+                // Customer 1 => 6 Orders, Customer 2 => 5 Orders, Customer 3 => 4 Orders, ...
+                // NextPageLink will be expected on the Customers collection as well as
+                // the Orders child collection on Customer 1
+                _serverSidePagingCustomers[i].ServerSidePagingOrders = new List<ServerSidePagingOrder>(
+                    Enumerable.Range(1, 6 - i).Select(j => new ServerSidePagingOrder
+                    {
+                        Id = j,
+                        Amount = (i + j) * 10,
+                        ServerSidePagingCustomer = _serverSidePagingCustomers[i]
+                    }));
+            }
+        }
+
+        [EnableQuery(PageSize = 5)]
+        public ITestActionResult Get()
+        {
+            return Ok(_serverSidePagingCustomers);
+        }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingControllers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingControllers.cs
@@ -14,25 +14,25 @@ namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
 
         public ServerSidePagingCustomersController()
         {
-            _serverSidePagingCustomers = new List<ServerSidePagingCustomer>(
-                Enumerable.Range(1, 7).Select(i => new ServerSidePagingCustomer
+            _serverSidePagingCustomers = Enumerable.Range(1, 7)
+                .Select(i => new ServerSidePagingCustomer
                 {
                     Id = i,
                     Name = "Customer Name " + i
-                }));
+                }).ToList();
 
             for (int i = 0; i < _serverSidePagingCustomers.Count; i++)
             {
                 // Customer 1 => 6 Orders, Customer 2 => 5 Orders, Customer 3 => 4 Orders, ...
                 // NextPageLink will be expected on the Customers collection as well as
                 // the Orders child collection on Customer 1
-                _serverSidePagingCustomers[i].ServerSidePagingOrders = new List<ServerSidePagingOrder>(
-                    Enumerable.Range(1, 6 - i).Select(j => new ServerSidePagingOrder
+                _serverSidePagingCustomers[i].ServerSidePagingOrders = Enumerable.Range(1, 6 - i)
+                    .Select(j => new ServerSidePagingOrder
                     {
                         Id = j,
                         Amount = (i + j) * 10,
                         ServerSidePagingCustomer = _serverSidePagingCustomers[i]
-                    }));
+                    }).ToList();
             }
         }
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingDataModel.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
+{
+    public class ServerSidePagingCustomer
+	{
+		[Key]
+		public int Id { get; set; }
+		public string Name { get; set; }
+		public IList<ServerSidePagingOrder> ServerSidePagingOrders { get; set; }
+	}
+
+	public class ServerSidePagingOrder
+	{
+		[Key]
+		public int Id { get; set; }
+		public decimal Amount { get; set; }
+		public ServerSidePagingCustomer ServerSidePagingCustomer { get; set; }
+	}
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Routing;
+using Microsoft.AspNet.OData.Routing.Conventions;
+using Microsoft.OData.Edm;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Xunit;
+
+namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
+{
+    public class ServerSidePagingTests : WebHostTestBase
+    {
+        public ServerSidePagingTests(WebHostTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            configuration.Select().Filter().OrderBy().Expand().Count().MaxTop(null);
+            // NOTE: Brackets in prefix to force a call into `RouteCollection`'s `GetVirtualPath`
+            configuration.MapODataServiceRoute(
+                routeName: "bracketsInPrefix",
+                routePrefix: "{a}",
+                model: GetEdmModel(configuration),
+                pathHandler: new DefaultODataPathHandler(),
+                routingConventions: ODataRoutingConventions.CreateDefault());
+        }
+
+        protected static IEdmModel GetEdmModel(WebRouteConfiguration configuration)
+        {
+            ODataModelBuilder builder = configuration.CreateConventionModelBuilder();
+            builder.EntitySet<ServerSidePagingOrder>("ServerSidePagingOrders").EntityType.HasRequired(d => d.ServerSidePagingCustomer);
+            builder.EntitySet<ServerSidePagingCustomer>("ServerSidePagingCustomers").EntityType.HasMany(d => d.ServerSidePagingOrders);
+            return builder.GetEdmModel();
+        }
+
+        [Fact]
+        public async Task ValidNextLinksGenerated()
+        {
+            var requestUri = this.BaseAddress + "/prefix/ServerSidePagingCustomers?$expand=ServerSidePagingOrders";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Customer 1 => 6 Orders, Customer 2 => 5 Orders, Customer 3 => 4 Orders, ...
+            // NextPageLink will be expected on the Customers collection as well as
+            // the Orders child collection on Customer 1
+            Assert.Contains("@odata.nextLink", content);
+            Assert.Contains("/prefix/ServerSidePagingCustomers?$expand=ServerSidePagingOrders&$skip=5",
+                content);
+            // Orders child collection
+            Assert.Contains("ServerSidePagingOrders@odata.nextLink", content);
+            Assert.Contains("/prefix/ServerSidePagingCustomers(1)/ServerSidePagingOrders?$skip=5",
+                content);
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2321 .*

### Description

During link generation using `RouteCollection`'s `GetVirtualPath` method, the catch-all parameter escapes the appropriate characters when the route is used to generate a URL, including path separator (/) characters. 
For example, the route `prefix/{*odataPath}` with route values `{ odataPath = "Customers(1)/Orders" }` generates `prefix/Customers(1)%2FOrders` - the forward slash is escaped. 
https://docs.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-2.1#url-generation-with-linkgenerator
This causes a problem in some scenarios, e.g. when generating next page link for an expanded collection navigation property

This PR mitigates the problem by substituting the forward slash with a unique token and then substituting the forward slash back after the call to `GetVirtualPath`.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
