### PR TITLE
Fix behaviour for Preflight requests on the ODataBatchMiddleware.

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchMiddleware.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchMiddleware.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.OData.Batch
         public async Task Invoke(HttpContext context)
         {
             HttpRequest request = context.Request;
-            bool isPreFlight = request.Method.Equals("Options", StringComparison.OrdinalIgnoreCase);
+            bool isPreFlight = HttpMethods.IsOptions(request.Method);
            
             // Attempt to match the path to a batch route.
             ODataBatchPathMapping batchMapping = context.RequestServices.GetRequiredService<ODataBatchPathMapping>();

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchMiddleware.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchMiddleware.cs
@@ -34,19 +34,13 @@ namespace Microsoft.AspNet.OData.Batch
         /// <returns>A task that can be awaited.</returns>
         public async Task Invoke(HttpContext context)
         {
-            var request = context.Request;
-            var isPreFlight = request.Method.Equals("Options", StringComparison.OrdinalIgnoreCase);
-            if (isPreFlight)
-            {
-                // if the request is a preflight request let the next handler be called as trying to handle the request will result in preflight requests failing.
-                await this.next(context);
-                return;
-            }
-
-            // Attempt to match the path to a bach route.
+            HttpRequest request = context.Request;
+            bool isPreFlight = request.Method.Equals("Options", StringComparison.OrdinalIgnoreCase);
+           
+            // Attempt to match the path to a batch route.
             ODataBatchPathMapping batchMapping = context.RequestServices.GetRequiredService<ODataBatchPathMapping>();
 
-            if (batchMapping.TryGetRouteName(context, out var routeName))
+            if (!isPreFlight && batchMapping.TryGetRouteName(context, out var routeName))
             {
                 // Get the per-route container and retrieve the batch handler.
                 IPerRouteContainer perRouteContainer = context.RequestServices.GetRequiredService<IPerRouteContainer>();

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchMiddleware.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchMiddleware.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.OData.Batch
             // Attempt to match the path to a batch route.
             ODataBatchPathMapping batchMapping = context.RequestServices.GetRequiredService<ODataBatchPathMapping>();
 
-            if (!isPreFlight && batchMapping.TryGetRouteName(context, out var routeName))
+            if (!isPreFlight && batchMapping.TryGetRouteName(context, out string routeName))
             {
                 // Get the per-route container and retrieve the batch handler.
                 IPerRouteContainer perRouteContainer = context.RequestServices.GetRequiredService<IPerRouteContainer>();

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchMiddlewareTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchMiddlewareTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.AspNet.OData.Test.Batch
 {
     public class ODataBatchMiddlewareTests
     {
-#if NETCOREAPP3_1
         [Fact]
         public async Task BatchMiddlewareShouldNotHandlePreflightRequests()
         {
@@ -28,8 +27,6 @@ namespace Microsoft.AspNet.OData.Test.Batch
             Assert.True(request.HttpContext.Items.ContainsKey("TestKey"));
         }
 
-
-#endif
         [Fact]
         public async Task BatchMiddlewareShouldWorkNormally()
         {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchMiddlewareTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchMiddlewareTests.cs
@@ -1,0 +1,72 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Batch;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Test.Abstraction;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData;
+using Xunit;
+using ServiceLifetime = Microsoft.OData.ServiceLifetime;
+
+namespace Microsoft.AspNet.OData.Test.Batch
+{
+    public class ODataBatchMiddlewareTests
+    {
+#if NETCOREAPP3_1
+        [Fact]
+        public async Task BatchMiddlewareShouldNotHandlePreflightRequests()
+        {
+            string uri = "http://localhost/$batch";
+            var request = RequestFactory.Create(HttpMethod.Options, uri);
+            RequestDelegate next = CorsDelegate;
+            var sut = new ODataBatchMiddleware(next);
+
+            await sut.Invoke(request.HttpContext);
+
+            Assert.True(request.HttpContext.Items.ContainsKey("TestKey"));
+        }
+
+
+#endif
+        [Fact]
+        public async Task BatchMiddlewareShouldWorkNormally()
+        {
+            string uri = "http://localhost/$batch";
+            IRouteBuilder routeBuilder = RoutingConfigurationFactory.CreateWithRootContainer("odata");
+            routeBuilder.MapODataServiceRoute("odata", "odata", b =>
+            {
+                b.AddService<ODataBatchHandler>(ServiceLifetime.Singleton,
+                    implementationFactory => new TestODataBatchHandler());
+            });
+            var request = RequestFactory.Create(HttpMethod.Post, uri, routeBuilder, "odata");
+            ODataBatchPathMapping batchMapping = request.HttpContext.RequestServices.GetRequiredService<ODataBatchPathMapping>();
+            batchMapping.AddRoute("odata", "/$batch");
+
+            RequestDelegate next = CorsDelegate;
+            var sut = new ODataBatchMiddleware(next);
+
+            await sut.Invoke(request.HttpContext);
+
+            Assert.False(request.HttpContext.Items.ContainsKey("TestKey"));
+        }
+
+        private Task CorsDelegate(HttpContext context)
+        {
+            // This mocks the execution of the cors middleware which should be registered for cors to work normally.
+            // the ODatabatch middleware should not process the request but instead pass it on to the next middleware for cors to work as expected.
+            // https://github.com/dotnet/aspnetcore/blob/master/src/Middleware/CORS/src/Infrastructure/CorsMiddleware.cs
+            context.Items.Add("TestKey", "TestValue");
+            return Task.CompletedTask;
+        }
+    }
+
+    public class TestODataBatchHandler : DefaultODataBatchHandler
+    {
+        public override Task ProcessBatchAsync(HttpContext context, RequestDelegate nextHandler)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchMiddlewareTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchMiddlewareTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.OData.Test.Batch
         private HttpRequest CreateRequest(HttpMethod method)
         {
             
-            HttpRequest request = RequestFactory.Create(HttpMethod.Post, URI, this._routeBuilder, "odata");
+            HttpRequest request = RequestFactory.Create(method, URI, this._routeBuilder, "odata");
             ODataBatchPathMapping batchMapping =
                 request.HttpContext.RequestServices.GetRequiredService<ODataBatchPathMapping>();
             batchMapping.AddRoute("odata", "/$batch");

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchMiddlewareTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchMiddlewareTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿#if NETCORE
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNet.OData.Batch;
 using Microsoft.AspNet.OData.Extensions;
@@ -80,3 +81,4 @@ namespace Microsoft.AspNet.OData.Test.Batch
         }
     }
 }
+#endif

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Batch\MockHttpServer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchContentTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchHttpRequestMessageExtensionsTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchReaderExtensionsTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchRequestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchRequestItemTest.cs" />

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
@@ -15,6 +15,8 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.7.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.7.1" />

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
@@ -15,8 +15,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.7.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.7.1" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2327.*

### Description
This introduces a change that allows the batch handler to yield to other middleware's requests that are preflight. This allows the cors middleware to do its job if registered.
For this to work correctly the Cors handler needs to be registered before calling
```csharp
app.UseCors(); //needs to be before batching.
app.UseODataBatching();
```

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
