### PR TITLE
Fix bug in attribute convention route values

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/AttributeRoutingConvention.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/AttributeRoutingConvention.cs
@@ -59,6 +59,11 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
 
                     return result;
                 }
+
+                // It's possible that template.TryMatch inserted values in the values dict even if
+                // it did not match the current path. So let's clear the dict before trying
+                // the next template
+                values.Clear();
             }
 
             return null;
@@ -79,6 +84,7 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
                         item.Value is ODataParameterValue)
                     {
                         routingConventionsStore.Add(item);
+                        RoutingConventionHelpers.IncrementKeyCount(routingConventionsStore);
                     }
                     else
                     {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingModel.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingModel.cs
@@ -32,6 +32,7 @@ namespace Microsoft.AspNet.OData.Test.Routing
             builder.EntitySet<Incident>("Incidents");
             builder.EntitySet<NotFoundCustomer>("NotFoundCustomers");
             builder.EntitySet<NotFoundWithIdCustomer>("NotFoundWithIdCustomers");
+            builder.EntitySet<AttributeCustomer>("AttributeCustomers");
             builder.ComplexType<Dog>();
             builder.ComplexType<Cat>();
             builder.EntityType<SpecialProduct>();
@@ -386,6 +387,12 @@ namespace Microsoft.AspNet.OData.Test.Routing
         public class NotFoundWithIdCustomer
         {
             public int ID { get; set; }
+        }
+
+        public class AttributeCustomer
+        {
+            public int ID { get; set; }
+            public string Name { get; set; }
         }
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingTest.cs
@@ -59,7 +59,8 @@ namespace Microsoft.AspNet.OData.Test.Routing
                 typeof(DestinationsController),
                 typeof(IncidentsController),
                 typeof(NotFoundWithIdCustomersController),
-                typeof(NotFoundCustomersController)
+                typeof(NotFoundCustomersController),
+                typeof(AttributeCustomersController)
             };
 
             // Separate clients and servers so routes are not ambiguous.
@@ -300,7 +301,10 @@ namespace Microsoft.AspNet.OData.Test.Routing
                     // test optional parameter routing (white space is intentional.)
                     { "GET", "Products/Default.GetCount(minSalary=1.1)",                               "GetCount(1.1, 0, 1200.99)" },
                     { "GET", "Products/Default.GetCount(minSalary=1.2, maxSalary=2.9)",                "GetCount(1.2, 2.9, 1200.99)" },
-                    { "GET", "Products/Default.GetCount(minSalary=1.3, maxSalary=3.4, aveSalary=4.5)", "GetCount(1.3, 3.4, 4.5)" }
+                    { "GET", "Products/Default.GetCount(minSalary=1.3, maxSalary=3.4, aveSalary=4.5)", "GetCount(1.3, 3.4, 4.5)" },
+                    // test [ODataRoute] works correctly for overloaded actions
+                    { "GET", "AttributeCustomers", "Get()" },
+                    { "GET", "AttributeCustomers(10)", "Get(10)" }
                 };
             }
         }
@@ -945,6 +949,21 @@ namespace Microsoft.AspNet.OData.Test.Routing
         public string Delete()
         {
             return "Delete()";
+        }
+    }
+
+    public class AttributeCustomersController: TestODataController
+    {
+        [ODataRoute("AttributeCustomers")]
+        public string Get()
+        {
+            return "Get()";
+        }
+
+        [ODataRoute("AttributeCustomers({key})")]
+        public string Get(int key)
+        {
+            return $"Get({key})";
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Fixes #2363 

### Description

*Briefly describe the changes of this pull request.*

**Some background**
Routing conventions that add values from the url to the routing convention store also keep track of the number of values added (by using the `IncrementKeyCount` helper method). The action selector uses this information to match the controller action with the correct number of parameters (amongst many overloads).

**Current issue**
The `AttributeRoutingConvention` adds values to routing convention store directly without using existing helper methods and did not increment the key count. This misleads the action selector to behave as if there were not keys in the url and consequently picks the `Get()` action without parameters over the `Get(int key)` action. The `AttributeRoutingConvention` also had an additional bug that caused it to add extra key-value pairs to the routing store, because each `ODataRoute` template it tried to match could insert values to the store, even if that template would not end up matching the path.

This PR fixes those issues by incrementing the key count for each value added to the convention store and clearing the values left over by route templates that did not match the current odata path.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
