### PR TITLE
Fix MergeIndividualAndBatchPreferences method

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -331,6 +331,11 @@ namespace Microsoft.AspNet.OData.Batch
                 .Where(pref => !individualPreferenceNames.Contains(pref.Split('=').FirstOrDefault()));
             string filteredBatchPreferences = string.Join(",", filteredBatchList);
 
+            if (string.IsNullOrEmpty(filteredBatchPreferences))
+            {
+                return individualPreferences;
+            }
+
             return string.Join(",", individualPreferences, filteredBatchPreferences);
         }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
@@ -562,6 +562,16 @@ Accept-Charset: UTF-8
                 "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer="
             },
             {
+                // should not concatenate preferences that should not be inherited
+                new []
+                {
+                    "wait=100,handling=lenient"
+                },
+                "GET,ContentType=,ContentLength=,Prefer=",
+                "DELETE,ContentType=,ContentLength=,Prefer=wait=100,handling=lenient",
+                "POST,ContentType=text/plain; charset=utf-8,ContentLength=3,Prefer="
+            },
+            {
                 // inheritable preferences should be copied over
                 // and combined with the individual request's own preferences if any
                 new []


### PR DESCRIPTION
for same Prefer headers case (bug with an unnecessary comma at the end of line)

<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #2376.

### Description

Fix join strings in method MergeIndividualAndBatchPreferences.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
