### PR TITLE
Moving EnableQuery request level query data storage to HttpContext

### DIFF
--- a/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
@@ -54,7 +54,11 @@ namespace Microsoft.AspNet.OData
 
             base.OnActionExecuting(context);
 
-            RequestQueryData requestQueryData = new RequestQueryData();
+            RequestQueryData requestQueryData = new RequestQueryData()
+            {
+                QueryValidationRunBeforeActionExecution = false,
+            };
+
             context.HttpContext.Items.Add(nameof(RequestQueryData), requestQueryData);
 
             HttpRequest request = context.HttpContext.Request;

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/ConcurrentQuery/ConcurrentQueryController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/ConcurrentQuery/ConcurrentQueryController.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Query;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Microsoft.Test.E2E.AspNet.OData.ConcurrentQuery
+{
+    public class CustomersController : Controller
+    {
+        [EnableQuery(AllowedQueryOptions = AllowedQueryOptions.Count | AllowedQueryOptions.Filter)]
+        public IQueryable<Customer> GetCustomers()
+        {
+            return Enumerable.Range(1, 100)
+                .Select(i => new Customer
+                {
+                    Id = i,
+                }).AsQueryable();
+        }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/ConcurrentQuery/ConcurrentQueryEdmModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/ConcurrentQuery/ConcurrentQueryEdmModel.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.OData.Edm;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+
+namespace Microsoft.Test.E2E.AspNet.OData.ConcurrentQuery
+{
+    public class ConcurrentQueryEdmModel
+    {
+        public static IEdmModel GetEdmModel(WebRouteConfiguration configuration)
+        {
+            var builder = configuration.CreateConventionModelBuilder();
+            builder.EntitySet<Customer>("Customers");
+            return builder.GetEdmModel();
+        }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/ConcurrentQuery/ConcurrentQueryODataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/ConcurrentQuery/ConcurrentQueryODataModel.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Test.E2E.AspNet.OData.ConcurrentQuery
+{
+    public class Customer
+    {
+        public int Id { get; set; }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/ConcurrentQuery/ConcurrentQueryTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/ConcurrentQuery/ConcurrentQueryTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Test.E2E.AspNet.OData.ConcurrentQuery
+{
+    /// <summary>
+    /// Ensures that concurrent execution of EnableQuery is thread-safe.
+    /// </summary>
+    public class ConcurrentQueryTests : WebHostTestBase
+    {
+        public ConcurrentQueryTests(WebHostTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            configuration.AddControllers(typeof(CustomersController));
+            configuration.JsonReferenceLoopHandling = ReferenceLoopHandling.Ignore;
+            configuration.Count().Filter().OrderBy().Expand().MaxTop(null);
+            configuration.MapODataServiceRoute("concurrentquery", "concurrentquery",
+                ConcurrentQueryEdmModel.GetEdmModel(configuration));
+
+            configuration.EnableDependencyInjection();
+        }
+
+        /// <summary>
+        /// For OData paths enable query should work with expansion.
+        /// </summary>
+        /// <returns>Task tracking operation.</returns>
+        [Fact]
+        public async Task ConcurrentQueryExecutionIsThreadSafe()
+        {
+            // Arrange
+            HttpClient client = new HttpClient();
+
+            // Bumping thread count to allow higher parallelization.
+            ThreadPool.SetMinThreads(100, 100);
+
+            // Act
+            var results = await Task.WhenAll(
+                Enumerable.Range(1, 100)
+                .Select(async i =>
+                {
+                    string queryUrl = string.Format("{0}/concurrentquery/Customers?$filter=Id gt {1}", BaseAddress, i);
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+                    request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+
+                    HttpResponseMessage response = await client.SendAsync(request);
+
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    List<Customer> customers = JToken.Parse(await response.Content.ReadAsStringAsync())["value"].ToObject<List<Customer>>();
+
+                    return (i: i, length: customers.Count);
+                }));
+
+            // Assert
+            foreach (var result in results)
+            {
+                Assert.Equal(100 - result.i, result.length);
+            }
+        }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/QueryValidationBeforeAction/QueryValidationBeforeActionController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/QueryValidationBeforeAction/QueryValidationBeforeActionController.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Query;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Microsoft.Test.E2E.AspNet.OData.QueryValidationBeforeAction
+{
+    public class CustomersController : Controller
+    {
+        [EnableQuery(AllowedQueryOptions = AllowedQueryOptions.Top, MaxTop = 10)]
+        public IEnumerable<Customer> GetCustomers()
+        {
+            throw new Exception("Controller should never be invoked as query validation should fail");
+        }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/QueryValidationBeforeAction/QueryValidationBeforeActionEdmModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/QueryValidationBeforeAction/QueryValidationBeforeActionEdmModel.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.OData.Edm;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+
+namespace Microsoft.Test.E2E.AspNet.OData.QueryValidationBeforeAction
+{
+    public class QueryValidationBeforeActionEdmModel
+    {
+        public static IEdmModel GetEdmModel(WebRouteConfiguration configuration)
+        {
+            var builder = configuration.CreateConventionModelBuilder();
+            builder.EntitySet<Customer>("Customers");
+            return builder.GetEdmModel();
+        }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/QueryValidationBeforeAction/QueryValidationBeforeActionODataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/QueryValidationBeforeAction/QueryValidationBeforeActionODataModel.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Test.E2E.AspNet.OData.QueryValidationBeforeAction
+{
+    public class Customer
+    {
+        public string Id { get; set; }
+
+        public IEnumerable<Book> Books { get; set; }
+    }
+
+    public class Book
+    {
+        public string Id { get; set; }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/QueryValidationBeforeAction/QueryValidationBeforeActionTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/QueryValidationBeforeAction/QueryValidationBeforeActionTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Test.E2E.AspNet.OData.QueryValidationBeforeAction
+{
+    /// <summary>
+    /// Checks that query validations are run before action execution.
+    /// </summary>
+    public class QueryValidationBeforeActionTests : WebHostTestBase
+    {
+        public QueryValidationBeforeActionTests(WebHostTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            configuration.AddControllers(typeof(CustomersController));
+            configuration.JsonReferenceLoopHandling = ReferenceLoopHandling.Ignore;
+            configuration.Count().Filter().OrderBy().Expand().MaxTop(null);
+            configuration.MapODataServiceRoute("queryvalidationbeforeaction", "queryvalidationbeforeaction",
+                QueryValidationBeforeActionEdmModel.GetEdmModel(configuration));
+
+            configuration.EnableDependencyInjection();
+        }
+
+        /// <summary>
+        /// For bad queries query execution should happen (and fail) before action being called.
+        /// </summary>
+        /// <returns>Task tracking operation.</returns>
+        [Fact]
+        public async Task QueryExecutionBeforeActionBadQuery()
+        {
+            // Arrange (Allowed top is 10, we are sending 100)
+            string queryUrl = string.Format("{0}/queryvalidationbeforeaction/Customers?$top=100", BaseAddress);
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+            HttpClient client = new HttpClient();
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2395*

### Description

Moving query data to HttpContext instead of instance variable since Attribute instances are not thread-safe.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
