### PR TITLE
inconsistencies in query options when_returnscollection is used on co…

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/FunctionConfiguration.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/FunctionConfiguration.cs
@@ -189,6 +189,14 @@ namespace Microsoft.AspNet.OData.Builder
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "In keeping with rest of API")]
         public FunctionConfiguration ReturnsCollection<TReturnElementType>()
         {
+            Type clrElementType = typeof(TReturnElementType);
+            IEdmTypeConfiguration edmElementType = ModelBuilder.GetTypeConfigurationOrNull(clrElementType);
+
+            if (edmElementType is EntityTypeConfiguration)
+            {
+                throw Error.InvalidOperation(SRResources.ReturnEntityCollectionWithoutEntitySet, edmElementType.FullName);
+            }
+
             ReturnsCollectionImplementation<TReturnElementType>();
             return this;
         }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/ODataFeedSerializeWithoutNavigationSourceTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/ODataFeedSerializeWithoutNavigationSourceTests.cs
@@ -39,9 +39,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter
             ODataModelBuilder builder = config.CreateConventionModelBuilder();
             builder.EntitySet<DerivedTypeA>("SetA");
             builder.EntitySet<DerivedTypeB>("SetB");
+            builder.EntitySet<BaseType>("SetC");
 
             builder.EntityType<BaseType>(); // this line is necessary.
-            builder.Function("ReturnAll").ReturnsCollection<BaseType>();
+
+            builder.Function("ReturnAll").ReturnsCollectionFromEntitySet<BaseType>("SetC");
 
             return builder.GetEdmModel();
         }
@@ -61,7 +63,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter
             Assert.NotNull(response.Content);
 
             JObject content = await response.Content.ReadAsObject<JObject>();
-            Assert.Contains("/odata/$metadata#Collection(Microsoft.Test.E2E.AspNet.OData.Formatter.BaseType)", content["@odata.context"].ToString());
+            Assert.Contains("/odata/$metadata#SetC", content["@odata.context"].ToString());
 
             Assert.Equal(2, content["value"].Count());
 


### PR DESCRIPTION
…llections of entity types

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

### Description
Currently, it is possible to use the <code>ReturnsCollection</code> action configuration method with a collection of entity types. From the docs, 
the <code>ReturnsCollection</code> action configuration method is meant to be used with collections of either primitives or complex types. https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnet.odata.builder.actionconfiguration.returnscollection?view=odata-aspnetcore-7.0

Using the <code>ReturnsCollection </code> action configuration method with collections of entity types leads to exceptions or inconsistencies when some query options are applied on the returned collection. 

This PR fixes that. 