### PR TITLE
Generate correct odata.nextlink when expanding multi-level contained entities

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSetSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSetSerializer.cs
@@ -486,10 +486,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             if (writeContext.NavigationSource.NavigationSourceKind() == EdmNavigationSourceKind.ContainedEntitySet)
             {
                 // Contained navigation.
-                Uri idlink = linkBuilder.BuildIdLink(writeContext.ExpandedResource);
-
-                var link = idlink.ToString() + "/" + writeContext.NavigationProperty.Name;
-                navigationLink = new Uri(link);
+                navigationLink = writeContext.ExpandedResource.GenerateContainedNavigationPropertyLink(writeContext.NavigationProperty, false);
             }
             else
             {

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSetSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSetSerializer.cs
@@ -486,7 +486,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             if (writeContext.NavigationSource.NavigationSourceKind() == EdmNavigationSourceKind.ContainedEntitySet)
             {
                 // Contained navigation.
-                navigationLink = writeContext.ExpandedResource.GenerateContainedNavigationPropertyLink(writeContext.NavigationProperty, false);
+                navigationLink = writeContext.ExpandedResource.GenerateContainedNavigationPropertyLink(writeContext.NavigationProperty);
             }
             else
             {

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Containment/ContainmentDataModels.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Containment/ContainmentDataModels.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.Containment
         public string FriendlyName { get; set; }
         [Contained]
         public Statement Statement { get; set; }
+        [Contained]
+        public List<Signatory> Signatories { get; set; }
     }
 
     public class Statement
@@ -44,5 +46,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.Containment
         public int StatementID { get; set; }
         public string TransactionDescription { get; set; }
         public double Amount { get; set; }
+    }
+
+    public class Signatory
+    {
+        public int SignatoryID { get; set; }
+        public string SignatoryName { get; set; }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Containment/ContainmentDataSource.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Containment/ContainmentDataSource.cs
@@ -168,6 +168,19 @@ namespace Microsoft.Test.E2E.AspNet.OData.Containment
                                     StatementID=1,
                                     TransactionDescription="Physical Goods.",
                                 },
+                            Signatories = new List<Signatory>()
+                            {
+                                new Signatory()
+                                {
+                                    SignatoryID=1001,
+                                    SignatoryName="Signatory 1"
+                                },
+                                new Signatory()
+                                {
+                                    SignatoryID=1002,
+                                    SignatoryName="Signatory 2"
+                                }
+                            }
                         },
                         new PaymentInstrument()
                         {
@@ -179,6 +192,19 @@ namespace Microsoft.Test.E2E.AspNet.OData.Containment
                                     StatementID=101,
                                     TransactionDescription="Physical Goods.",
                                 },
+                            Signatories = new List<Signatory>()
+                            {
+                                new Signatory()
+                                {
+                                    SignatoryID=1003,
+                                    SignatoryName="Signatory 3"
+                                },
+                                new Signatory()
+                                {
+                                    SignatoryID=1004,
+                                    SignatoryName="Signatory 4"
+                                }
+                            }
                         },
                     },
                 },
@@ -203,6 +229,19 @@ namespace Microsoft.Test.E2E.AspNet.OData.Containment
                                     StatementID=1,
                                     TransactionDescription="Physical Goods.",
                                 },
+                            Signatories = new List<Signatory>()
+                            {
+                                new Signatory()
+                                {
+                                    SignatoryID=1005,
+                                    SignatoryName="Signatory 5"
+                                },
+                                new Signatory()
+                                {
+                                    SignatoryID=1006,
+                                    SignatoryName="Signatory 6"
+                                }
+                            }
                         },
                         new PaymentInstrument()
                         {
@@ -214,6 +253,19 @@ namespace Microsoft.Test.E2E.AspNet.OData.Containment
                                     StatementID=201,
                                     TransactionDescription="Physical Goods.",
                                 },
+                            Signatories = new List<Signatory>()
+                            {
+                                new Signatory()
+                                {
+                                    SignatoryID=1007,
+                                    SignatoryName="Signatory 7"
+                                },
+                                new Signatory()
+                                {
+                                    SignatoryID=1008,
+                                    SignatoryName="Signatory 8"
+                                }
+                            }
                         }
                     }
                 },

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Containment/ContainmentEdmModels.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Containment/ContainmentEdmModels.cs
@@ -32,11 +32,16 @@ namespace Microsoft.Test.E2E.AspNet.OData.Containment
             paymentInstrumentType.HasKey(pi => pi.PaymentInstrumentID);
             paymentInstrumentType.Property(pi => pi.FriendlyName);
             var statement = paymentInstrumentType.ContainsOptional(pi => pi.Statement);
+            var signatories = paymentInstrumentType.HasMany(p => p.Signatories).Contained();
 
             var statementType = builder.EntityType<Statement>();
             statementType.HasKey(s => s.StatementID);
             statementType.Property(s => s.TransactionDescription);
             statementType.Property(s => s.Amount);
+
+            var signatoryType = builder.EntityType<Signatory>();
+            signatoryType.HasKey(s => s.SignatoryID);
+            signatoryType.Property(s => s.SignatoryName);
 
             var accounts = builder.EntitySet<Account>("Accounts"); 
             accounts.HasIdLink(c => c.GenerateSelfLink(false), true);

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Containment/ContainmentTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Containment/ContainmentTests.cs
@@ -579,6 +579,23 @@ namespace Microsoft.Test.E2E.AspNet.OData.Containment
 
         [Theory]
         [MemberData(nameof(MediaTypes))]
+        // To test if we can get the odata.nextLink in a contained navigation property of collection type when using $expand.
+        public async Task QueryMultiExpandPaginatedPayinPIsFromAccount(string mode, string mime)
+        {
+            await ResetDatasource();
+            string requestUri = string.Format("{0}/{1}/PaginatedAccounts?$expand=PayinPIs($expand=Signatories)&$format={2}", BaseAddress, mode, mime);
+
+            HttpResponseMessage response = await this.Client.GetAsync(requestUri);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var payload = await response.Content.ReadAsStringAsync();
+            payload = payload.Replace("%28", "(").Replace("%29", ")").ToLower();
+            Assert.Contains(string.Format("\"Signatories@odata.nextLink\":\"{0}/{1}/PaginatedAccounts(100)/PayinPIs(101)/Signatories?$skip=1", BaseAddress, mode).ToLower(), payload);
+            Assert.Contains(string.Format("\"PayinPIs@odata.nextLink\":\"{0}/{1}/PaginatedAccounts(100)/PayinPIs?$expand=Signatories&$skip=1", BaseAddress, mode).ToLower(), payload);
+        }
+
+        [Theory]
+        [MemberData(nameof(MediaTypes))]
         // To test it is able to query ONE entity of a collectiona containment navigation property
         // GET ~/Accounts(1)/PayinPIs(1)
         public async Task QueryOnePayinPI(string mode, string mime)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2262* 
*Additional work after PR #2287*
### Description

*Briefly describe the changes of this pull request.*
We have been generating an incorrect `navigationLink` when generating `nextLink` in multi-level expand in contained entities. This PR fixes that.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
