### PR TITLE
Using Metadata document write async

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataMetadataSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataMetadataSerializer.cs
@@ -49,8 +49,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             // NOTE: ODataMessageWriter doesn't have a way to set the IEdmModel. So, there is an underlying assumption here that
             // the model received by this method and the model passed(from configuration) while building ODataMessageWriter is the same (clr object).
 
-            // Note: MessageWriter doesn't have a WriteMetadataDocumentAsync method. We should fix that by providing a default implementation in the base class.
-            return Task.Run(() => messageWriter.WriteMetadataDocument());
+            return messageWriter.WriteMetadataDocumentAsync();
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

### Description

* ODL 7.8.2 introduces the new async version to write metadata. 
* This PR changes the async wrapper call to use the real async version.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
