### PR TITLE
Excessive memory in ODataConventionModelBuilder BuildDerivedTypesMapping

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/TypeHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/TypeHelper.cs
@@ -416,11 +416,9 @@ namespace Microsoft.AspNet.OData
         // This code is copied from DefaultHttpControllerTypeResolver.GetControllerTypes.
         internal static IEnumerable<Type> GetLoadedTypes(IWebApiAssembliesResolver assembliesResolver)
         {
-            List<Type> result = new List<Type>();
-
             if (assembliesResolver == null)
             {
-                return result;
+                yield return null;
             }
 
             // Go through all assemblies referenced by the application and search for types matching a predicate
@@ -449,11 +447,15 @@ namespace Microsoft.AspNet.OData
 
                 if (exportedTypes != null)
                 {
-                    result.AddRange(exportedTypes.Where(t => t != null && TypeHelper.IsVisible(t)));
+                    foreach (var t in exportedTypes)
+                    {
+                        if ((t != null) && (TypeHelper.IsVisible(t)))
+                        {
+                            yield return t;
+                        }
+                    }
                 }
             }
-
-            return result;
         }
 
         internal static Type GetTaskInnerTypeOrSelf(Type type)

--- a/src/Microsoft.AspNet.OData.Shared/TypeHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/TypeHelper.cs
@@ -447,7 +447,7 @@ namespace Microsoft.AspNet.OData
 
                 if (exportedTypes != null)
                 {
-                    foreach (var t in exportedTypes)
+                    foreach (Type t in exportedTypes)
                     {
                         if ((t != null) && (TypeHelper.IsVisible(t)))
                         {

--- a/src/Microsoft.AspNet.OData.Shared/TypeHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/TypeHelper.cs
@@ -416,42 +416,40 @@ namespace Microsoft.AspNet.OData
         // This code is copied from DefaultHttpControllerTypeResolver.GetControllerTypes.
         internal static IEnumerable<Type> GetLoadedTypes(IWebApiAssembliesResolver assembliesResolver)
         {
-            if (assembliesResolver == null)
+            if (assembliesResolver != null)
             {
-                yield return null;
-            }
-
-            // Go through all assemblies referenced by the application and search for types matching a predicate
-            IEnumerable<Assembly> assemblies = assembliesResolver.Assemblies;
-            foreach (Assembly assembly in assemblies)
-            {
-                Type[] exportedTypes = null;
-                if (assembly == null || assembly.IsDynamic)
+                // Go through all assemblies referenced by the application and search for types matching a predicate
+                IEnumerable<Assembly> assemblies = assembliesResolver.Assemblies;
+                foreach (Assembly assembly in assemblies)
                 {
-                    // can't call GetTypes on a null (or dynamic?) assembly
-                    continue;
-                }
-
-                try
-                {
-                    exportedTypes = assembly.GetTypes();
-                }
-                catch (ReflectionTypeLoadException ex)
-                {
-                    exportedTypes = ex.Types;
-                }
-                catch
-                {
-                    continue;
-                }
-
-                if (exportedTypes != null)
-                {
-                    foreach (Type t in exportedTypes)
+                    Type[] exportedTypes = null;
+                    if (assembly == null || assembly.IsDynamic)
                     {
-                        if ((t != null) && (TypeHelper.IsVisible(t)))
+                        // can't call GetTypes on a null (or dynamic?) assembly
+                        continue;
+                    }
+
+                    try
+                    {
+                        exportedTypes = assembly.GetTypes();
+                    }
+                    catch (ReflectionTypeLoadException ex)
+                    {
+                        exportedTypes = ex.Types;
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+
+                    if (exportedTypes != null)
+                    {
+                        foreach (Type t in exportedTypes)
                         {
-                            yield return t;
+                            if ((t != null) && (TypeHelper.IsVisible(t)))
+                            {
+                                yield return t;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2435.*

### Description

Here is the code generating it:

```C#
        private static Dictionary<Type, List<Type>> BuildDerivedTypesMapping(IAssembliesResolver assemblyResolver)
        {
            IEnumerable<Type> enumerable =
                from t in TypeHelper.GetLoadedTypes(assemblyResolver)
                where t.IsVisible && t.IsClass && t != typeof(object)
                select t;
            Dictionary<Type, List<Type>> dictionary = enumerable.ToDictionary((Type k) => k, (Type k) => new List<Type>());

            foreach (Type current in enumerable)
            {
                List<Type> list;
                if (current.BaseType != null && dictionary.TryGetValue(current.BaseType, out list))
                {
                    list.Add(current);
                }
            }
            return dictionary;
        }
```
The dictionary is allocated to contain all visible reference types which is not system.Object, each with an empty List<Type> allocated. The list is used to keep derived types. 

This change is to make the dictionary as small as possible.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
