### PR TITLE
Extend runtime Type methods of OperationConfiguration

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/OperationConfiguration.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/OperationConfiguration.cs
@@ -289,12 +289,31 @@ namespace Microsoft.AspNet.OData.Builder
         /// <summary>
         /// Adds a new non-binding collection parameter
         /// </summary>
+        public ParameterConfiguration CollectionParameter(Type clrElementType, string name)
+        {
+            IEdmTypeConfiguration elementTypeConfiguration = GetOperationTypeConfiguration(clrElementType);
+            CollectionTypeConfiguration parameterType = new CollectionTypeConfiguration(elementTypeConfiguration, typeof(IEnumerable<>).MakeGenericType(clrElementType));
+            return AddParameter(name, parameterType);
+        }
+
+        /// <summary>
+        /// Adds a new non-binding collection parameter
+        /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "In keeping with rest of API")]
         public ParameterConfiguration CollectionParameter<TElementType>(string name)
         {
-            Type elementType = typeof(TElementType);
-            IEdmTypeConfiguration elementTypeConfiguration = GetOperationTypeConfiguration(typeof(TElementType));
-            CollectionTypeConfiguration parameterType = new CollectionTypeConfiguration(elementTypeConfiguration, typeof(IEnumerable<>).MakeGenericType(elementType));
+            return this.CollectionParameter(typeof(TElementType), name);
+        }
+
+        /// <summary>
+        /// Adds a new non-binding entity type parameter.
+        /// </summary>
+        public ParameterConfiguration EntityParameter(Type clrEntityType, string name)
+        {
+            IEdmTypeConfiguration parameterType =
+                ModelBuilder.StructuralTypes.FirstOrDefault(t => t.ClrType == clrEntityType) ??
+                ModelBuilder.AddEntityType(clrEntityType);
+
             return AddParameter(name, parameterType);
         }
 
@@ -305,10 +324,20 @@ namespace Microsoft.AspNet.OData.Builder
             Justification = "In keeping with rest of API")]
         public ParameterConfiguration EntityParameter<TEntityType>(string name) where TEntityType : class
         {
-            Type entityType = typeof(TEntityType);
-            IEdmTypeConfiguration parameterType =
-                ModelBuilder.StructuralTypes.FirstOrDefault(t => t.ClrType == entityType) ??
-                ModelBuilder.AddEntityType(entityType);
+            return this.EntityParameter(typeof(TEntityType), name);
+        }
+
+        /// <summary>
+        /// Adds a new non-binding collection of entity type parameter.
+        /// </summary>
+        public ParameterConfiguration CollectionEntityParameter(Type clrElementEntityType, string name)
+        {
+            IEdmTypeConfiguration elementTypeConfiguration =
+                ModelBuilder.StructuralTypes.FirstOrDefault(t => t.ClrType == clrElementEntityType) ??
+                ModelBuilder.AddEntityType(clrElementEntityType);
+
+            CollectionTypeConfiguration parameterType = new CollectionTypeConfiguration(elementTypeConfiguration,
+                typeof(IEnumerable<>).MakeGenericType(clrElementEntityType));
 
             return AddParameter(name, parameterType);
         }
@@ -320,15 +349,7 @@ namespace Microsoft.AspNet.OData.Builder
             Justification = "In keeping with rest of API")]
         public ParameterConfiguration CollectionEntityParameter<TElementEntityType>(string name) where TElementEntityType : class
         {
-            Type elementType = typeof(TElementEntityType);
-            IEdmTypeConfiguration elementTypeConfiguration =
-                ModelBuilder.StructuralTypes.FirstOrDefault(t => t.ClrType == elementType) ??
-                ModelBuilder.AddEntityType(elementType);
-
-            CollectionTypeConfiguration parameterType = new CollectionTypeConfiguration(elementTypeConfiguration,
-                typeof(IEnumerable<>).MakeGenericType(elementType));
-
-            return AddParameter(name, parameterType);
+            return this.CollectionEntityParameter(typeof(TElementEntityType), name);
         }
 
         /// <summary>

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/ActionConfigurationTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/ActionConfigurationTest.cs
@@ -782,7 +782,7 @@ namespace Microsoft.AspNet.OData.Test.Builder
             var actionBuilder = movie.Action("ActionName");
             actionBuilder.Parameter(paramType, "p1");
 
-            MethodInfo method = typeof(OperationConfiguration).GetMethod("CollectionParameter", BindingFlags.Instance | BindingFlags.Public);
+            MethodInfo method = typeof(OperationConfiguration).GetMethod("CollectionParameter", new Type[] { typeof(string) });
             method.MakeGenericMethod(paramType).Invoke(actionBuilder, new[] { "p2" });
 
             // Act

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/FunctionConfigurationTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/FunctionConfigurationTest.cs
@@ -843,7 +843,7 @@ namespace Microsoft.AspNet.OData.Test.Builder
             var functionBuilder = movie.Function("FunctionName").Returns<int>();
             functionBuilder.Parameter(paramType, "p1");
 
-            MethodInfo method = typeof(OperationConfiguration).GetMethod("CollectionParameter", BindingFlags.Instance | BindingFlags.Public);
+            MethodInfo method = typeof(OperationConfiguration).GetMethod("CollectionParameter", new Type[] { typeof(string) });
             method.MakeGenericMethod(paramType).Invoke(functionBuilder, new[] { "p2" });
 
             // Act

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -1033,8 +1033,11 @@ public abstract class Microsoft.AspNet.OData.Builder.OperationConfiguration {
 
 	public ParameterConfiguration AddParameter (string name, IEdmTypeConfiguration parameterType)
 	public ParameterConfiguration CollectionEntityParameter (string name)
+	public ParameterConfiguration CollectionEntityParameter (System.Type clrElementEntityType, string name)
 	public ParameterConfiguration CollectionParameter (string name)
+	public ParameterConfiguration CollectionParameter (System.Type clrElementType, string name)
 	public ParameterConfiguration EntityParameter (string name)
+	public ParameterConfiguration EntityParameter (System.Type clrEntityType, string name)
 	public ParameterConfiguration Parameter (string name)
 	public ParameterConfiguration Parameter (System.Type clrParameterType, string name)
 }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -1094,8 +1094,11 @@ public abstract class Microsoft.AspNet.OData.Builder.OperationConfiguration {
 
 	public ParameterConfiguration AddParameter (string name, IEdmTypeConfiguration parameterType)
 	public ParameterConfiguration CollectionEntityParameter (string name)
+	public ParameterConfiguration CollectionEntityParameter (System.Type clrElementEntityType, string name)
 	public ParameterConfiguration CollectionParameter (string name)
+	public ParameterConfiguration CollectionParameter (System.Type clrElementType, string name)
 	public ParameterConfiguration EntityParameter (string name)
+	public ParameterConfiguration EntityParameter (System.Type clrEntityType, string name)
 	public ParameterConfiguration Parameter (string name)
 	public ParameterConfiguration Parameter (System.Type clrParameterType, string name)
 }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -1098,8 +1098,11 @@ public abstract class Microsoft.AspNet.OData.Builder.OperationConfiguration {
 
 	public ParameterConfiguration AddParameter (string name, IEdmTypeConfiguration parameterType)
 	public ParameterConfiguration CollectionEntityParameter (string name)
+	public ParameterConfiguration CollectionEntityParameter (System.Type clrElementEntityType, string name)
 	public ParameterConfiguration CollectionParameter (string name)
+	public ParameterConfiguration CollectionParameter (System.Type clrElementType, string name)
 	public ParameterConfiguration EntityParameter (string name)
+	public ParameterConfiguration EntityParameter (System.Type clrEntityType, string name)
 	public ParameterConfiguration Parameter (string name)
 	public ParameterConfiguration Parameter (System.Type clrParameterType, string name)
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue https://github.com/OData/WebApi/issues/2439.

### Description

Extend runtime Type methods of OperationConfiguration. Currently only Parameter(Type,string) exists, this pull requests adds CollectionParameter(Type,string), CollectionEntityParameter(Type,string), EntityParameter(Type,string).

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*

