### PR TITLE
ODataResourceDeserializer Preserves Request on ODataDeserializerContext for Nested Resource

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -492,6 +492,8 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             {
                 Path = readContext.Path,
                 Model = readContext.Model,
+                Request = readContext.Request,
+                RequestContext = readContext.RequestContext,
             };
 
             Type clrType = null;
@@ -600,6 +602,8 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             {
                 Path = readContext.Path,
                 Model = readContext.Model,
+                Request = readContext.Request,
+                RequestContext = readContext.RequestContext,
             };
 
             if (readContext.IsUntyped)

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -493,7 +493,6 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                 Path = readContext.Path,
                 Model = readContext.Model,
                 Request = readContext.Request,
-                RequestContext = readContext.RequestContext,
             };
 
             Type clrType = null;
@@ -603,7 +602,6 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                 Path = readContext.Path,
                 Model = readContext.Model,
                 Request = readContext.Request,
-                RequestContext = readContext.RequestContext,
             };
 
             if (readContext.IsUntyped)

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/ODataResourceDeserializerTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/ODataResourceDeserializerTests.cs
@@ -1267,8 +1267,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
                 builder.AddService(ServiceLifetime.Singleton, prov => ((Mock<ODataResourceSetDeserializer>)prov.GetService(typeof(Mock<ODataResourceSetDeserializer>))).Object);
             });
 
-            HttpRequestMessage originalReq = new HttpRequestMessage(HttpMethod.Post, "http://localhost/OData/OData.svc/Products");
-            originalReq.SetRequestContext(new System.Web.Http.Controllers.HttpRequestContext() { Configuration = new System.Web.Http.HttpConfiguration(), Url = new System.Web.Http.Routing.UrlHelper(originalReq) });
+            HttpRequestMessage originalReq = RequestFactory.Create();
 
             var readContext = new ODataDeserializerContext
             {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/ODataResourceDeserializerTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/ODataResourceDeserializerTests.cs
@@ -1267,12 +1267,17 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
                 builder.AddService(ServiceLifetime.Singleton, prov => ((Mock<ODataResourceSetDeserializer>)prov.GetService(typeof(Mock<ODataResourceSetDeserializer>))).Object);
             });
 
-            HttpRequestMessage originalReq = RequestFactory.Create();
+
+            var originalContext = new ODataDeserializerContext
+            {
+                Model = _edmModel,
+                Request = RequestFactory.Create()
+            };
 
             var readContext = new ODataDeserializerContext
             {
-                Model = _edmModel,
-                Request = originalReq
+                Model = originalContext.Model,
+                Request = originalContext.Request
             };
 
             ODataNestedResourceInfoWrapper nestedResourceInfoWrapper = new ODataNestedResourceInfoWrapper(new ODataNestedResourceInfo() { Name = "Address" });
@@ -1291,10 +1296,10 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
             resourceSetDeserializer.CallBase = resourceDeserializer.CallBase = true;
 
             resourceDeserializer.Setup(d => d.ReadResource(It.IsAny<ODataResourceWrapper>(), It.IsAny<IEdmStructuredTypeReference>(),
-               It.Is<ODataDeserializerContext>(context => context.Request == originalReq))).Verifiable();
+               It.Is<ODataDeserializerContext>(context => context.Request == originalContext.Request))).Verifiable();
 
             resourceSetDeserializer.Setup(d => d.ReadResourceSet(It.IsAny<ODataResourceSetWrapper>(), It.IsAny<IEdmStructuredTypeReference>(),
-               It.Is<ODataDeserializerContext>(context => context.Request == originalReq))).Verifiable();
+               It.Is<ODataDeserializerContext>(context => context.Request == originalContext.Request))).Verifiable();
 
             // Act
             new ODataResourceDeserializer(resourceDeserializer.Object.DeserializerProvider).ApplyNestedProperties(new Supplier(), resourceWrapper, _supplierEdmType, readContext);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1828.*

### Description

*Trying to acces the readContext.Request property yields a null value when deserializing nested resources

The readContext.Request property is now being copied to the nestedReadContext*

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

*No Additional work necessary.*
