### PR TITLE
Feature/add support for odatabind

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataEntityReferenceLinkBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataEntityReferenceLinkBase.cs
@@ -17,17 +17,13 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         public ODataEntityReferenceLinkBase(ODataEntityReferenceLink item)
             : base(item)
         {
+            EntityReferenceLink = item;
         }
 
         /// <summary>
         /// Gets the wrapped <see cref="ODataEntityReferenceLink"/>.
         /// </summary>
-        public ODataEntityReferenceLink EntityReferenceLink
-        {
-            get
-            {
-                return Item as ODataEntityReferenceLink;
-            }
-        }
+        public ODataEntityReferenceLink EntityReferenceLink { get; }
+
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataNestedResourceInfoWrapper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataNestedResourceInfoWrapper.cs
@@ -40,5 +40,6 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         /// Gets the nested items that are part of this nested resource info.
         /// </summary>
         public IList<ODataItemBase> NestedItems { get; private set; }
+
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -404,7 +404,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         }
 
         private ODataResourceWrapper CreateResourceWrapper(IEdmTypeReference edmPropertyType, ODataEntityReferenceLinkBase refLink, ODataDeserializerContext readContext)
-        {
+        { 
             Contract.Assert(readContext != null);
 
             ODataResource resource = new ODataResource
@@ -432,7 +432,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         /// <param name="readContext">The read context.</param>
         /// <returns>The resource wrapper.</returns>
         private ODataResourceWrapper UpdateResourceWrapper(ODataResourceWrapper resourceWrapper, ODataDeserializerContext readContext)
-        {
+        { 
             Contract.Assert(readContext != null);
 
             if (resourceWrapper?.Resource?.Id == null)
@@ -473,7 +473,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         /// <param name="id">The key Id.</param>
         /// <param name="readContext">The reader context.</param>
         /// <returns>The key properties.</returns>
-        private static IList<ODataProperty> CreateKeyProperties(Uri id, ODataDeserializerContext readContext)
+        private IList<ODataProperty> CreateKeyProperties(Uri id, ODataDeserializerContext readContext)
         {
             Contract.Assert(id != null);
             Contract.Assert(readContext != null);

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -426,7 +426,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         }
 
         /// <summary>
-        /// Update the resource wrapper if it's have the "Id" value.
+        /// Update the resource wrapper if it has the "Id" value.
         /// </summary>
         /// <param name="resourceWrapper">The resource wrapper.</param>
         /// <param name="readContext">The read context.</param>
@@ -483,36 +483,29 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                 return properties;
             }
 
-            try
-            {
-                IODataPathHandler pathHandler = readContext.InternalRequest.PathHandler;
-                IWebApiRequestMessage internalRequest = readContext.InternalRequest;
-                IWebApiUrlHelper urlHelper = readContext.InternalUrlHelper;    
-                string serviceRoot = urlHelper.CreateODataLink(
-                    internalRequest.Context.RouteName,
-                    internalRequest.PathHandler,
-                    new List<ODataPathSegment>());
+            IODataPathHandler pathHandler = readContext.InternalRequest.PathHandler;
+            IWebApiRequestMessage internalRequest = readContext.InternalRequest;
+            IWebApiUrlHelper urlHelper = readContext.InternalUrlHelper;
+            string serviceRoot = urlHelper.CreateODataLink(
+                internalRequest.Context.RouteName,
+                internalRequest.PathHandler,
+                new List<ODataPathSegment>());
 
-                ODataPath odataPath = pathHandler.Parse(serviceRoot, id.OriginalString, internalRequest.RequestContainer);
-                IList<KeySegment> keySegments = odataPath.Segments.OfType<KeySegment>().ToList();
-                foreach (KeySegment keySegment in keySegments)
-                {            
-                    foreach (KeyValuePair<string, object> key in keySegment.Keys)
+            ODataPath odataPath = pathHandler.Parse(serviceRoot, id.OriginalString, internalRequest.RequestContainer);
+            IList<KeySegment> keySegments = odataPath.Segments.OfType<KeySegment>().ToList();
+            foreach (KeySegment keySegment in keySegments)
+            {
+                foreach (KeyValuePair<string, object> key in keySegment.Keys)
+                {
+                    properties.Add(new ODataProperty
                     {
-                        properties.Add(new ODataProperty
-                        {
-                            Name = key.Key,
-                            Value = key.Value
-                        });
-                    }
+                        Name = key.Key,
+                        Value = key.Value
+                    });
                 }
+            }
 
-                return properties;
-            }
-            catch (Exception)
-            {
-                throw;
-            }
+            return properties;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -384,8 +384,8 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         }
 
 
-        private ODataResourceSetWrapper CreateResourceSetWrapper(IEdmCollectionTypeReference edmPropertyType,
-    IList<ODataEntityReferenceLinkBase> refLinks, ODataDeserializerContext readContext)
+        private ODataResourceSetWrapper CreateResourceSetWrapper(IEdmCollectionTypeReference edmPropertyType, 
+            IList<ODataEntityReferenceLinkBase> refLinks, ODataDeserializerContext readContext)
         {
             ODataResourceSet resourceSet = new ODataResourceSet
             {
@@ -473,7 +473,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         /// <param name="id">The key Id.</param>
         /// <param name="readContext">The reader context.</param>
         /// <returns>The key properties.</returns>
-        private IList<ODataProperty> CreateKeyProperties(Uri id, ODataDeserializerContext readContext)
+        private static IList<ODataProperty> CreateKeyProperties(Uri id, ODataDeserializerContext readContext)
         {
             Contract.Assert(id != null);
             Contract.Assert(readContext != null);
@@ -486,26 +486,32 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             IODataPathHandler pathHandler = readContext.InternalRequest.PathHandler;
             IWebApiRequestMessage internalRequest = readContext.InternalRequest;
             IWebApiUrlHelper urlHelper = readContext.InternalUrlHelper;
-            string serviceRoot = urlHelper.CreateODataLink(
-                internalRequest.Context.RouteName,
-                internalRequest.PathHandler,
-                new List<ODataPathSegment>());
-
-            ODataPath odataPath = pathHandler.Parse(serviceRoot, id.OriginalString, internalRequest.RequestContainer);
-            KeySegment keySegment = odataPath.Segments.OfType<KeySegment>().LastOrDefault();
-            if (keySegment != null)
+            try
             {
-                foreach (KeyValuePair<string, object> key in keySegment.Keys)
+                string serviceRoot = urlHelper.CreateODataLink(
+                    internalRequest.Context.RouteName,
+                    internalRequest.PathHandler,
+                    new List<ODataPathSegment>());
+                ODataPath odataPath = pathHandler.Parse(serviceRoot, id.OriginalString, internalRequest.RequestContainer);
+                KeySegment keySegment = odataPath.Segments.OfType<KeySegment>().LastOrDefault();
+                if (keySegment != null)
                 {
-                    properties.Add(new ODataProperty
+                    foreach (KeyValuePair<string, object> key in keySegment.Keys)
                     {
-                        Name = key.Key,
-                        Value = key.Value
-                    });
+                        properties.Add(new ODataProperty
+                        {
+                            Name = key.Key,
+                            Value = key.Value
+                        });
+                    }
                 }
-            }
 
-            return properties;
+                return properties;
+            }
+            catch (Exception)
+            {
+                return properties;
+            }          
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -492,8 +492,8 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                 new List<ODataPathSegment>());
 
             ODataPath odataPath = pathHandler.Parse(serviceRoot, id.OriginalString, internalRequest.RequestContainer);
-            IList<KeySegment> keySegments = odataPath.Segments.OfType<KeySegment>().ToList();
-            foreach (KeySegment keySegment in keySegments)
+            KeySegment keySegment = odataPath.Segments.OfType<KeySegment>().LastOrDefault();
+            if (keySegment != null)
             {
                 foreach (KeyValuePair<string, object> key in keySegment.Keys)
                 {

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -11,9 +11,12 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNet.OData.Common;
-using Microsoft.AspNet.OData.Formatter.Serialization;
+using Microsoft.AspNet.OData.Interfaces;
+using Microsoft.AspNet.OData.Routing;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+using ODataPath = Microsoft.AspNet.OData.Routing.ODataPath;
 
 namespace Microsoft.AspNet.OData.Formatter.Deserialization
 {
@@ -96,6 +99,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
 
             // Recursion guard to avoid stack overflows
             RuntimeHelpers.EnsureSufficientExecutionStack();
+            resourceWrapper = UpdateResourceWrapper(resourceWrapper, readContext);
 
             return ReadResource(resourceWrapper, edmType.AsStructured(), readContext);
         }
@@ -297,7 +301,39 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                 }
             }
 
-            foreach (ODataItemBase childItem in resourceInfoWrapper.NestedItems)
+            IList<ODataItemBase> nestedItems;
+            ODataEntityReferenceLinkBase[] referenceLinks = resourceInfoWrapper.NestedItems.OfType<ODataEntityReferenceLinkBase>().ToArray();
+            if (referenceLinks.Length > 0)
+            {
+                // Be noted:
+                // 1) OData v4.0, it's "Orders@odata.bind", and we get "ODataEntityReferenceLinkWrapper"(s) for that.
+                // 2) OData v4.01, it's {"odata.id" ...}, and we get "ODataResource"(s) for that.
+                // So, in OData v4, if it's a single, NestedItems contains one ODataEntityReferenceLinkWrapper,
+                // if it's a collection, NestedItems contains multiple ODataEntityReferenceLinkWrapper(s)
+                // We can use the following code to adjust the `ODataEntityReferenceLinkWrapper` to `ODataResourceWrapper`.
+                // In OData v4.01, we will not be here.
+                // Only supports declared property
+                Contract.Assert(edmProperty != null);
+
+                nestedItems = new List<ODataItemBase>();
+                if (edmProperty.Type.IsCollection())
+                {
+                    IEdmCollectionTypeReference edmCollectionTypeReference = edmProperty.Type.AsCollection();
+                    ODataResourceSetWrapper resourceSetWrapper = CreateResourceSetWrapper(edmCollectionTypeReference, referenceLinks, readContext);
+                    nestedItems.Add(resourceSetWrapper);
+                }
+                else
+                {
+                    ODataResourceWrapper resourceWrapper = CreateResourceWrapper(edmProperty.Type, referenceLinks[0], readContext);
+                    nestedItems.Add(resourceWrapper);
+                }
+            }
+            else
+            {
+                nestedItems = resourceInfoWrapper.NestedItems;
+            }
+
+            foreach (ODataItemBase childItem in nestedItems)
             {
                 // it maybe null.
                 if (childItem == null)
@@ -312,13 +348,6 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                     {
                         ApplyResourceInNestedProperty(edmProperty, resource, null, readContext);
                     }
-                }
-
-                ODataEntityReferenceLinkBase entityReferenceLink = childItem as ODataEntityReferenceLinkBase;
-                if (entityReferenceLink != null)
-                {
-                    // ignore entity reference links.
-                    continue;
                 }
 
                 ODataResourceSetWrapper resourceSetWrapper = childItem as ODataResourceSetWrapper;
@@ -351,6 +380,138 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                         ApplyResourceInNestedProperty(edmProperty, resource, resourceWrapper, readContext);
                     }
                 }
+            }
+        }
+
+
+        private ODataResourceSetWrapper CreateResourceSetWrapper(IEdmCollectionTypeReference edmPropertyType,
+    IList<ODataEntityReferenceLinkBase> refLinks, ODataDeserializerContext readContext)
+        {
+            ODataResourceSet resourceSet = new ODataResourceSet
+            {
+                TypeName = edmPropertyType.FullName(),
+            };
+
+            IEdmTypeReference elementType = edmPropertyType.ElementType();
+            ODataResourceSetWrapper resourceSetWrapper = new ODataResourceSetWrapper(resourceSet);
+            foreach (ODataEntityReferenceLinkBase refLinkWrapper in refLinks)
+            {
+                ODataResourceWrapper resourceWrapper = CreateResourceWrapper(elementType, refLinkWrapper, readContext);
+                resourceSetWrapper.Resources.Add(resourceWrapper);
+            }
+
+            return resourceSetWrapper;
+        }
+
+        private ODataResourceWrapper CreateResourceWrapper(IEdmTypeReference edmPropertyType, ODataEntityReferenceLinkBase refLink, ODataDeserializerContext readContext)
+        {
+            Contract.Assert(readContext != null);
+
+            ODataResource resource = new ODataResource
+            {
+                TypeName = edmPropertyType.FullName(),
+            };
+
+            resource.Properties = CreateKeyProperties(refLink.EntityReferenceLink.Url, readContext);
+         
+            if (refLink.EntityReferenceLink.InstanceAnnotations != null)
+            {
+                foreach (ODataInstanceAnnotation instanceAnnotation in refLink.EntityReferenceLink.InstanceAnnotations)
+                {
+                    resource.InstanceAnnotations.Add(instanceAnnotation);
+                };
+            }
+
+            return new ODataResourceWrapper(resource);
+        }
+
+        /// <summary>
+        /// Update the resource wrapper if it's have the "Id" value.
+        /// </summary>
+        /// <param name="resourceWrapper">The resource wrapper.</param>
+        /// <param name="readContext">The read context.</param>
+        /// <returns>The resource wrapper.</returns>
+        private ODataResourceWrapper UpdateResourceWrapper(ODataResourceWrapper resourceWrapper, ODataDeserializerContext readContext)
+        {
+            Contract.Assert(readContext != null);
+
+            if (resourceWrapper?.Resource?.Id == null)
+            {
+                return resourceWrapper;
+            }
+
+            IEnumerable<ODataProperty> keys = CreateKeyProperties(resourceWrapper.Resource.Id, readContext);
+            if (keys == null)
+            {
+                return resourceWrapper;
+            }
+
+            if (resourceWrapper.Resource.Properties == null)
+            {
+                resourceWrapper.Resource.Properties = keys;
+            }
+            else
+            {
+                IDictionary<string, ODataProperty> newPropertiesDic = resourceWrapper.Resource.Properties.ToDictionary(p => p.Name, p => p);
+                foreach (ODataProperty key in keys)
+                {
+                    if (!newPropertiesDic.ContainsKey(key.Name))
+                    {
+                        newPropertiesDic[key.Name] = key;
+                    }
+                }
+
+                resourceWrapper.Resource.Properties = newPropertiesDic.Values;
+            }
+
+            return resourceWrapper;
+        }
+
+        /// <summary>
+        /// Do uri parsing to get the key values.
+        /// </summary>
+        /// <param name="id">The key Id.</param>
+        /// <param name="readContext">The reader context.</param>
+        /// <returns>The key properties.</returns>
+        private static IList<ODataProperty> CreateKeyProperties(Uri id, ODataDeserializerContext readContext)
+        {
+            Contract.Assert(id != null);
+            Contract.Assert(readContext != null);
+            IList<ODataProperty> properties = new List<ODataProperty>();
+            if (readContext.Request == null)
+            {
+                return properties;
+            }
+
+            try
+            {
+                IODataPathHandler pathHandler = readContext.InternalRequest.PathHandler;
+                IWebApiRequestMessage internalRequest = readContext.InternalRequest;
+                IWebApiUrlHelper urlHelper = readContext.InternalUrlHelper;    
+                string serviceRoot = urlHelper.CreateODataLink(
+                    internalRequest.Context.RouteName,
+                    internalRequest.PathHandler,
+                    new List<ODataPathSegment>());
+
+                ODataPath odataPath = pathHandler.Parse(serviceRoot, id.OriginalString, internalRequest.RequestContainer);
+                IList<KeySegment> keySegments = odataPath.Segments.OfType<KeySegment>().ToList();
+                foreach (KeySegment keySegment in keySegments)
+                {            
+                    foreach (KeyValuePair<string, object> key in keySegment.Keys)
+                    {
+                        properties.Add(new ODataProperty
+                        {
+                            Name = key.Key,
+                            Value = key.Value
+                        });
+                    }
+                }
+
+                return properties;
+            }
+            catch (Exception)
+            {
+                throw;
             }
         }
 
@@ -492,7 +653,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             {
                 Path = readContext.Path,
                 Model = readContext.Model,
-                Request = readContext.Request,
+                Request = readContext.Request
             };
 
             Type clrType = null;
@@ -518,7 +679,6 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                 : clrType;
             return deserializer.ReadInline(resourceWrapper, edmType, nestedReadContext);
         }
-
         private void ApplyResourceSetInNestedProperty(IEdmProperty nestedProperty, object resource,
             ODataResourceSetWrapper resourceSetWrapper, ODataDeserializerContext readContext)
         {
@@ -601,7 +761,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             {
                 Path = readContext.Path,
                 Model = readContext.Model,
-                Request = readContext.Request,
+                Request = readContext.Request
             };
 
             if (readContext.IsUntyped)

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Formatter/ODataEntityReferenceLinkE2ETests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Formatter/ODataEntityReferenceLinkE2ETests.cs
@@ -1,0 +1,276 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Data.Entity;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Routing;
+using Microsoft.OData.Edm;
+using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Test.E2E.AspNet.OData.Formatter
+{
+    public class ODataEntityReferenceLinkE2ETests : WebHostTestBase
+    {
+        public ODataEntityReferenceLinkE2ETests(WebHostTestFixture fixture)
+            : base(fixture)
+        {
+        }
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            var controllers = new[] { typeof(BooksController)};
+            configuration.AddControllers(controllers);
+            configuration.Count().Filter().OrderBy().Expand().MaxTop(null).Select();
+            configuration.MapODataServiceRoute("odata", "odata", BuildEdmModel(configuration));
+        }
+        private static IEdmModel BuildEdmModel(WebRouteConfiguration configuration)
+        {
+            var builder = configuration.CreateConventionModelBuilder();
+            builder.EntitySet<Book>("Books");
+            builder.EntitySet<Author>("Authors");
+            builder.Action("ResetDataSource");
+            builder.Action("RelateToExistingEntityAndUpdate").ReturnsFromEntitySet<Book>("Books").EntityParameter<Book>("book");
+
+            return builder.GetEdmModel();
+        }
+
+        [Fact]
+        public async Task CanCreate_ANewEntityAndRelateToAnExistingEntity_UsingODataBind()
+        {
+            await ResetDataSource();
+            // Arrange
+            const string Payload = "{" +
+            "\"Id\":\"1\"," +
+            "\"Name\":\"BookA\"," +
+            "\"Author@odata.bind\":\"Authors(1)\"}";
+
+            string Uri = BaseAddress + "/odata/Books";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, Uri);
+
+            request.Content = new StringContent(Payload);
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+
+            // Act
+            HttpResponseMessage response = await Client.SendAsync(request);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            //Get the above saved entity from the database
+            //and expand the navigation property to see if
+            //it was correctly created with the existing entity
+            //attached to it. 
+            string query = string.Format("{0}/odata/Books?$expand=Author", BaseAddress);
+            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, query);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            
+            // Act
+            HttpResponseMessage res = await Client.SendAsync(requestMessage);
+
+            // Assert
+            Assert.True(res.IsSuccessStatusCode);
+            var responseObject = JObject.Parse(await res.Content.ReadAsStringAsync());
+            var result = responseObject["value"] as JArray;
+            var expandProp = result[0]["Author"] as JObject;
+            Assert.Equal(1, expandProp["Id"]);
+
+        }
+
+        [Fact]
+        public async Task CanUpdate_TheRelatedEntitiesProperties()
+        {
+            await ResetDataSource();
+            // Arrange
+            const string Payload = "{" +
+               "\"book\":{" +
+                   "\"Id\":\"1\"," +
+                   "\"Name\":\"BookA\"," +
+                   "\"Author\":{" +
+                       "\"@odata.id\":\"Authors(1)\"," +
+                       "\"Name\":\"UpdatedAuthor\"}}}";
+
+            string Uri = BaseAddress + "/odata/RelateToExistingEntityAndUpdate";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, Uri);
+
+            request.Content = new StringContent(Payload);
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+
+            // Act
+            HttpResponseMessage response = await Client.SendAsync(request);
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            //Get the above saved entity from the database
+            //and expand its navigation property to see if it was created with
+            //the existing entity correctly.
+            //Also note that we were able to update the name property 
+            //of the existing entity
+            string query = string.Format("{0}/odata/Books?$expand=Author", BaseAddress);
+            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, query);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+            // Act
+            HttpResponseMessage res = await Client.SendAsync(requestMessage);
+
+            // Assert
+            Assert.True(res.IsSuccessStatusCode);
+            var responseObject = JObject.Parse(await res.Content.ReadAsStringAsync());
+            var result = responseObject["value"] as JArray;
+            var expandProp = result[0]["Author"] as JObject;
+            Assert.Equal(1, expandProp["Id"]);
+            Assert.Equal("UpdatedAuthor", expandProp["Name"]);
+        }
+
+        private async Task ResetDataSource()
+        {
+            string requestUri = BaseAddress + "/odata/ResetDataSource";
+            HttpClient client = new HttpClient();
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+            response.EnsureSuccessStatusCode();
+        }
+    }
+
+    public class BooksController : TestODataController
+#if NETCORE
+        , IDisposable
+#endif
+    { 
+        private ODataEntityReferenceLinkContext db = new ODataEntityReferenceLinkContext();
+
+        [EnableQuery]
+        public ITestActionResult Get()
+        {        
+            return Ok(db.Books);
+        }
+        public ITestActionResult Post([FromBody] Book book)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest();
+            }
+
+            db.Authors.Attach(book.Author);
+            db.Books.Add(book);
+            db.SaveChanges();
+
+            return Created(book);
+        }
+
+        [HttpPost]
+        [ODataRoute("RelateToExistingEntityAndUpdate")]
+        public ITestActionResult RelateToExistingEntityAndUpdate(ODataActionParameters odataActionParameters)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest();
+            }
+
+            Book book = (Book)odataActionParameters["book"];
+            string authorName = book.Author.Name;
+            Author author = new Author()
+            {
+                Id = book.Author.Id
+            };
+            db.Authors.Attach(author);
+            book.Author = author;
+            book.Author.Name = authorName;
+            db.Books.Add(book);
+
+            db.SaveChanges();
+            return Created(book);
+        }
+
+        [HttpGet]
+        [ODataRoute("ResetDataSource")]
+        public ITestActionResult ResetDataSource()
+        {
+            db.Database.Delete();  // Start from scratch so that tests aren't broken by schema changes.
+            CreateDatabase();
+            return Ok();
+        }
+
+        private static void CreateDatabase()
+        {
+            using (ODataEntityReferenceLinkContext db = new ODataEntityReferenceLinkContext())
+            {
+                if (!db.Authors.Any())
+                {
+                    IList<Author> authors = new List<Author>()
+                    {
+                        new Author()
+                        {
+                            Id = 1,
+                            Name = "AuthorA"
+                        },
+                        new Author()
+                        {
+                            Id = 2,
+                            Name = "AuthorB"
+                        },
+                        new Author()
+                        {
+                            Id = 3,
+                            Name = "AuthorC"
+                        }
+                    };
+
+                    foreach (var author in authors)
+                    {
+                        db.Authors.Add(author);
+                    }
+                    db.SaveChanges();
+                }
+            }
+        }
+
+#if NETCORE
+        public void Dispose()
+        {
+             //_db.Dispose();
+        }
+#endif
+
+    }
+
+    public class Book
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public Author Author { get; set; }
+        public IList<Author> AuthorList { get; set; }
+    }
+
+    public class Author
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class ODataEntityReferenceLinkContext : DbContext
+    {
+        public static string ConnectionString = @"Data Source=(LocalDb)\MSSQLLocalDB;Integrated Security=True;Initial Catalog=ODataEntityReferenceLinkContext";
+        public ODataEntityReferenceLinkContext()
+            : base(ConnectionString)
+        {
+        }
+        public DbSet<Book> Books { get; set; }
+        public DbSet<Author> Authors { get; set; }
+    }
+}

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataEntityReferenceLinkTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataEntityReferenceLinkTests.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Formatter;
+using Microsoft.AspNet.OData.Formatter.Deserialization;
+using Microsoft.AspNet.OData.Test.Abstraction;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+using Xunit;
+using ODataPath = Microsoft.AspNet.OData.Routing.ODataPath;
+
+namespace Microsoft.AspNet.OData.Test.Formatter
+{
+    public class ODataEntityReferenceLinkTests
+    {
+        private readonly ODataDeserializerProvider _deserializerProvider;
+        public ODataEntityReferenceLinkTests()
+        {
+            _deserializerProvider = ODataDeserializerProviderFactory.Create();
+        }
+
+        /// <summary>
+        /// In OData v4.0 an ODataEntityReferenceLink will be converted 
+        /// to a resource then deserialized as a resource.
+        /// </summary>
+        [Fact]
+        public void ReadResource_CanRead_AnEntityRefenceLink()
+        {
+            // Arrange
+            ODataConventionModelBuilder builder = ODataConventionModelBuilderFactory.Create();
+            var books = builder.EntitySet<Book>("Books");
+            builder.EntityType<Author>();
+            builder.EntitySet<Author>("Authors");
+            var author =
+               books.EntityType.HasOptional<Author>((e) => e.Author);
+            books.HasNavigationPropertyLink(author, (a, b) => new Uri("aa:b"), false);
+            books.HasOptionalBinding((e) => e.Author, "authorr");
+
+
+            IEdmModel model = builder.GetEdmModel();
+            IEdmEntityTypeReference bookTypeReference = model.GetEdmTypeReference(typeof(Book)).AsEntity();
+            var deserializer = new ODataResourceDeserializer(_deserializerProvider);
+            ODataResource odataResource = new ODataResource
+            {
+                Properties = new[]
+                {
+                    new ODataProperty { Name = "Id", Value = 1},
+                    new ODataProperty { Name = "Name", Value = "BookA"},
+                },
+                TypeName = "Microsoft.AspNet.OData.Test.Formatter.Book"
+            };
+
+            IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("Books");
+            ODataPath path = new ODataPath(new EntitySetSegment(entitySet));
+            var request = RequestFactory.CreateFromModel(model, path: path);
+
+            ODataDeserializerContext readContext = new ODataDeserializerContext()
+            {
+                Model = model,
+                Request = request,
+                Path = path
+            };
+
+            ODataResourceWrapper topLevelResourceWrapper = new ODataResourceWrapper(odataResource);
+            ODataNestedResourceInfo resourceInfo = new ODataNestedResourceInfo
+            {
+                IsCollection = false,
+                Name = "Author"
+            };
+
+            ODataEntityReferenceLink refLink = new ODataEntityReferenceLink { Url = new Uri("http://localhost/Authors(2)") };
+            ODataEntityReferenceLinkBase refLinkWrapper = new ODataEntityReferenceLinkBase(refLink);
+
+            ODataNestedResourceInfoWrapper resourceInfoWrapper = new ODataNestedResourceInfoWrapper(resourceInfo);
+            resourceInfoWrapper.NestedItems.Add(refLinkWrapper);
+            topLevelResourceWrapper.NestedResourceInfos.Add(resourceInfoWrapper);
+
+            // Act
+            Book book = deserializer.ReadResource(topLevelResourceWrapper, bookTypeReference, readContext)
+                as Book;
+
+            // Assert
+            Assert.NotNull(book);
+            Assert.Equal(2, book.Author.Id);
+            Assert.NotNull(book.Author);
+       
+        }
+
+        [Fact]
+        public void ReadResource_CanRead_ACollectionOfEntityRefenceLinks()
+        {
+            // Arrange
+            ODataConventionModelBuilder builder = ODataConventionModelBuilderFactory.Create();
+            var books = builder.EntitySet<Book>("Books");
+            builder.EntityType<Author>();
+            builder.EntitySet<Author>("Authors");
+            var author =
+               books.EntityType.HasOptional<Author>((e) => e.Author);
+            books.HasNavigationPropertyLink(author, (a, b) => new Uri("aa:b"), false);
+            books.HasOptionalBinding((e) => e.Author, "authorr");
+
+
+            IEdmModel model = builder.GetEdmModel();
+            IEdmEntityTypeReference bookTypeReference = model.GetEdmTypeReference(typeof(Book)).AsEntity();
+            var deserializer = new ODataResourceDeserializer(_deserializerProvider);
+            ODataResource odataResource = new ODataResource
+            {
+                Properties = new[]
+                {
+                    new ODataProperty { Name = "Id", Value = 1},
+                    new ODataProperty { Name = "Name", Value = "BookA"},
+                },
+                TypeName = "Microsoft.AspNet.OData.Test.Formatter.Book"
+            };
+
+            IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("Books");
+            ODataPath path = new ODataPath(new EntitySetSegment(entitySet));
+            var request = RequestFactory.CreateFromModel(model, path: path);
+
+            ODataDeserializerContext readContext = new ODataDeserializerContext()
+            {
+                Model = model,
+                Request = request,
+                Path = path
+            };
+
+            ODataResourceWrapper topLevelResourceWrapper = new ODataResourceWrapper(odataResource);
+            ODataNestedResourceInfo resourceInfo = new ODataNestedResourceInfo
+            {
+                IsCollection = true,
+                Name = "AuthorList"
+            };
+
+            IList<ODataEntityReferenceLinkBase> refLinks = new List<ODataEntityReferenceLinkBase>()
+            {
+                new ODataEntityReferenceLinkBase(new ODataEntityReferenceLink{ Url = new Uri("http://localhost/Authors(2)") }),
+                new ODataEntityReferenceLinkBase(new ODataEntityReferenceLink{ Url = new Uri("http://localhost/Authors(3)")})
+            };
+
+
+            ODataNestedResourceInfoWrapper resourceInfoWrapper = new ODataNestedResourceInfoWrapper(resourceInfo);
+
+            foreach (ODataEntityReferenceLinkBase refLinkWrapper in refLinks)
+            {
+                resourceInfoWrapper.NestedItems.Add(refLinkWrapper);
+            }
+            topLevelResourceWrapper.NestedResourceInfos.Add(resourceInfoWrapper);
+
+            // Act
+            Book book = deserializer.ReadResource(topLevelResourceWrapper, bookTypeReference, readContext)
+                as Book;
+
+            // Assert
+            Assert.NotNull(book);
+            Assert.NotNull(book.AuthorList);
+            Assert.Equal(2, book.AuthorList.Count());
+        }
+
+        public class Book
+        {
+            [Key]
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public Author Author { get; set; }
+            public IList<Author> AuthorList { get; set; }
+        }
+
+        public class Author
+        {
+            [Key]
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}    

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
@@ -167,6 +167,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Formatter\Deserialization\CollectionDeserializationHelpersTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter\Deserialization\ODataActionPayloadDeserializerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter\Deserialization\ODataDeserializationTestsCommon.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Formatter\ODataEntityReferenceLinkTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter\ODataModelBinderConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter\Serialization\ODataEntityReferenceLinksSerializerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter\Serialization\ODataEnumTypeSerializerTests.cs" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

### Description
If you have such a model: 
```
public class Item
{
    [Key]
    public int ID { get; set; }

    [Required]
    public string Name { get; set; }

    [Required]
    public virtual Group Group { get; set; }
}

public class Group
{
    [Key]
    public int ID { get; set; }

    [Required]
    public string Name { get; set; }
}
```

And you want to create a new Item and reference an existing Group in your database or in whichever data source that you have, then as per the OData spec http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_LinktoRelatedEntitiesWhenCreatinganE , you should be able to do so using any of the following below formats depending on the OData Version that you are using: 

For v4.0 clients 
```
{
  "@odata.type":"#Item",
  "ID": 1,
  "Name": "ItemA",
  "Group@odata.bind":"http://host/service/Groups(4)"
}
```
For v4.01 clients
```
{
  "@odata.type":"#Item",
  "ID": 1,
  "Name": "ItemA",
  "Group":{"@odata.id":"http://host/service/Groups(4)"}
}
```
*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
