### PR TITLE
Add the OData version to reader settings when specified in the request

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataInputFormatterHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataInputFormatterHelper.cs
@@ -51,6 +51,7 @@ namespace Microsoft.AspNet.OData.Formatter
             Type type,
             object defaultValue,
             IEdmModel model,
+            ODataVersion version,
             Uri baseAddress,
             IWebApiRequestMessage internalRequest,
             Func<IODataRequestMessage> getODataRequestMessage,
@@ -74,6 +75,7 @@ namespace Microsoft.AspNet.OData.Formatter
                 ODataMessageReaderSettings oDataReaderSettings = internalRequest.ReaderSettings;
                 oDataReaderSettings.BaseUri = baseAddress;
                 oDataReaderSettings.Validations = oDataReaderSettings.Validations & ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+                oDataReaderSettings.Version = version;
 
                 IODataRequestMessage oDataRequestMessage = getODataRequestMessage();
 

--- a/src/Microsoft.AspNet.OData/Formatter/ODataMediaTypeFormatter.cs
+++ b/src/Microsoft.AspNet.OData/Formatter/ODataMediaTypeFormatter.cs
@@ -251,6 +251,7 @@ namespace Microsoft.AspNet.OData.Formatter
                     type,
                     defaultValue,
                     Request.GetModel(),
+                    ResultHelpers.GetODataResponseVersion(Request),
                     GetBaseAddressInternal(Request),
                     new WebApiRequestMessage(Request),
                     () => ODataMessageWrapperHelper.Create(readStream, contentHeaders, Request.GetODataContentIdMapping(), Request.GetRequestContainer()),

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNet.OData.Batch;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Formatter.Deserialization;
+using Microsoft.AspNet.OData.Results;
 using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Headers;
@@ -147,6 +148,7 @@ namespace Microsoft.AspNet.OData.Formatter
                     type,
                     defaultValue,
                     request.GetModel(),
+                    ResultHelpers.GetODataVersion(request),
                     GetBaseAddressInternal(request),
                     new WebApiRequestMessage(request),
                     () => ODataMessageWrapperHelper.Create(new StreamWrapper(request.Body), request.Headers, request.GetODataContentIdMapping(), request.GetRequestContainer()),

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
@@ -200,7 +200,7 @@ namespace Microsoft.AspNet.OData.Formatter
             }
 
             // Add version header.
-            response.Headers[ODataVersionConstraint.ODataServiceVersionHeader] = ODataUtils.ODataVersionToString(ResultHelpers.GetODataResponseVersion(request));
+            response.Headers[ODataVersionConstraint.ODataServiceVersionHeader] = ODataUtils.ODataVersionToString(ResultHelpers.GetODataVersion(request));
         }
 
         /// <inheritdoc/>
@@ -246,7 +246,7 @@ namespace Microsoft.AspNet.OData.Formatter
                 type,
                 context.Object,
                 request.GetModel(),
-                ResultHelpers.GetODataResponseVersion(request),
+                ResultHelpers.GetODataVersion(request),
                 baseAddress,
                 contentType,
                 new WebApiUrlHelper(request.GetUrlHelper()),

--- a/src/Microsoft.AspNetCore.OData/Results/CreatedODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/CreatedODataResult.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.OData.Results
             // before calling AddEntityId() to ensure the response code is set correctly.
             await result.ExecuteResultAsync(context);
             ResultHelpers.AddEntityId(response, () => GenerateEntityId(request));
-            ResultHelpers.AddServiceVersion(response, () => ODataUtils.ODataVersionToString(ResultHelpers.GetODataResponseVersion(request)));
+            ResultHelpers.AddServiceVersion(response, () => ODataUtils.ODataVersionToString(ResultHelpers.GetODataVersion(request)));
         }
 
         // internal just for unit test.

--- a/src/Microsoft.AspNetCore.OData/Results/ResultHelpers.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/ResultHelpers.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNet.OData.Results
             }
         }
 
-        internal static ODataVersion GetODataResponseVersion(HttpRequest request)
+        internal static ODataVersion GetODataVersion(HttpRequest request)
         {
             Contract.Assert(request != null, "GetODataResponseVersion called with a null request");
             return request.ODataMaxServiceVersion() ??

--- a/src/Microsoft.AspNetCore.OData/Results/UpdatedODataResult.cs
+++ b/src/Microsoft.AspNetCore.OData/Results/UpdatedODataResult.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNet.OData.Results
             HttpRequest request = context.HttpContext.Request;
             IActionResult result = GetInnerActionResult(request);
             await result.ExecuteResultAsync(context);
-            ResultHelpers.AddServiceVersion(response, () => ODataUtils.ODataVersionToString(ResultHelpers.GetODataResponseVersion(request)));
+            ResultHelpers.AddServiceVersion(response, () => ODataUtils.ODataVersionToString(ResultHelpers.GetODataVersion(request)));
         }
 
         internal IActionResult GetInnerActionResult(HttpRequest request)


### PR DESCRIPTION
Fixes #2449

<!-- markdownlint-disable MD002 MD041 -->

The OData reader in the framework does not respect the OData-Max-Version/OData-Version header in the request when reading the request body. This should be propagated to the ODataMessageReaderSettings so the OData framework can deserialize using OData version 4.01. By default, it uses version 4.0 which will break any scenarios that use 4.01 annotations.

### Assemblies affected

All OData versions since the issue is in master.

### Reproduce steps

Pass \@type as part of the request as specified in the OData docs. This can be used when you have an abstract type and the type information is passed as part of the request.

### Expected result

OData version 4.01 annotations should be respected.

### Actual result

OData version 4.01 annotations are not respected and will fail internally in the framework.

### Additional detail

This is already done for the writer settings, it just needs to be propagated in the same way to the reader settings.

Writer settings (already implemented)
https://github.com/OData/WebApi/blob/1d6ddf999cb27a8c74fb06ec5a73fee64edaa46b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataOutputFormatterHelper.cs#L155

Reader settings (not implemented)
https://github.com/OData/WebApi/blob/1d6ddf999cb27a8c74fb06ec5a73fee64edaa46b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataInputFormatterHelper.cs#L76