### PR TITLE
Get auto expand navigation properties from Context.ElementClrType ins…

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
@@ -875,10 +875,18 @@ namespace Microsoft.AspNet.OData.Query
         private string GetAutoExpandRawValue()
         {
             var expandRawValue = RawValues.Expand;
-            IEdmEntityType baseEntityType = Context.TargetStructuredType as IEdmEntityType;
+            IEdmEntityType baseEntityType;
+            if (Context.ElementClrType != null)
+            {
+                IEdmType edmType = Context.Model.GetTypeMappingCache().GetEdmType(Context.ElementClrType, Context.Model)?.Definition;
+                baseEntityType = edmType as IEdmEntityType;
+            }
+            else
+                baseEntityType = Context.TargetStructuredType as IEdmEntityType;
+
             var autoExpandRawValue = String.Empty;
             var autoExpandNavigationProperties = EdmLibHelpers.GetAutoExpandNavigationProperties(
-                Context.TargetProperty, Context.TargetStructuredType, Context.Model,
+                Context.TargetProperty, baseEntityType, Context.Model,
                 !String.IsNullOrEmpty(RawValues.Select));
 
             foreach (var property in autoExpandNavigationProperties)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue  #2465.

### Description

 Get auto expand navigation properties from Context.ElementClrType instead of Context.TargetStructuredType

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

Someone with more in-depth knowledge should check if this proposal is the correct way to do it.