### PR TITLE
Delta does not allow UpdatableProperties to be changed

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
@@ -4,13 +4,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using Microsoft.AspNet.OData.Builder.Conventions.Attributes;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Formatter;
 
@@ -24,11 +22,11 @@ namespace Microsoft.AspNet.OData
     public class Delta<TStructuralType> : TypedDelta, IDelta where TStructuralType : class
     {
         // cache property accessors for this type and all its derived types.
-        private static ConcurrentDictionary<Type, Dictionary<string, PropertyAccessor<TStructuralType>>> _propertyCache
+        private static readonly ConcurrentDictionary<Type, Dictionary<string, PropertyAccessor<TStructuralType>>> _propertyCache
             = new ConcurrentDictionary<Type, Dictionary<string, PropertyAccessor<TStructuralType>>>();
 
         private Dictionary<string, PropertyAccessor<TStructuralType>> _allProperties;
-        private HashSet<string> _updatableProperties;
+        private List<string> _updatableProperties;
 
         private HashSet<string> _changedProperties;
 
@@ -38,7 +36,7 @@ namespace Microsoft.AspNet.OData
         private TStructuralType _instance;
         private Type _structuredType;
 
-        private PropertyInfo _dynamicDictionaryPropertyinfo;
+        private readonly PropertyInfo _dynamicDictionaryPropertyinfo;
         private HashSet<string> _changedDynamicProperties;
         private IDictionary<string, object> _dynamicDictionaryCache;
 
@@ -94,35 +92,19 @@ namespace Microsoft.AspNet.OData
 
         /// <inheritdoc/>
         public override Type StructuredType
-        {
-            get
-            {
-                return _structuredType;
-            }
-        }
+            => _structuredType;
 
         /// <inheritdoc/>
         public override Type ExpectedClrType
-        {
-            get { return typeof(TStructuralType); }
-        }
+            => typeof(TStructuralType);
 
         /// <summary>
         /// The list of property names that can be updated.
         /// </summary>
         /// <remarks>When the list is modified, any modified properties that were removed from the list are no longer
         /// considered to be changed.</remarks>
-        public IEnumerable<string> UpdatableProperties
-        {
-            get => _updatableProperties;
-            set
-            {
-                _updatableProperties = InitializeUpdatableProperties(value);
-
-                // Remove any un-updatable properties from the changed list
-                _changedProperties.IntersectWith(_updatableProperties);
-            }
-        }
+        public IList<string> UpdatableProperties
+            => _updatableProperties;
 
         /// <inheritdoc/>
         public override void Clear()
@@ -133,7 +115,7 @@ namespace Microsoft.AspNet.OData
         /// <inheritdoc/>
         public override bool TrySetPropertyValue(string name, object value)
         {
-            if (string.IsNullOrWhiteSpace(name))
+            if (String.IsNullOrWhiteSpace(name))
             {
                 throw Error.ArgumentNull("name");
             }
@@ -188,7 +170,7 @@ namespace Microsoft.AspNet.OData
                 }
             }
 
-            if (this._deltaNestedResources.ContainsKey(name))
+            if (_deltaNestedResources.ContainsKey(name))
             {
                 // If this is a nested resource, get the value from the dictionary of nested resources.
                 object deltaNestedResource = _deltaNestedResources[name];
@@ -276,7 +258,7 @@ namespace Microsoft.AspNet.OData
         /// </summary>
         public override IEnumerable<string> GetChangedPropertyNames()
         {
-            return _changedProperties.Concat(_deltaNestedResources.Keys);
+            return _changedProperties.Intersect(_updatableProperties).Concat(_deltaNestedResources.Keys);
         }
 
         /// <summary>
@@ -286,7 +268,8 @@ namespace Microsoft.AspNet.OData
         /// </summary>
         public override IEnumerable<string> GetUnchangedPropertyNames()
         {
-            return _updatableProperties.Except(GetChangedPropertyNames());
+            // UpdatableProperties could include arbitrary strings, filter by _allProperties
+            return _updatableProperties.Intersect(_allProperties.Keys).Except(GetChangedPropertyNames());
         }
 
         /// <summary>
@@ -312,7 +295,7 @@ namespace Microsoft.AspNet.OData
 
             // For regular non-structural properties at current level.
             PropertyAccessor<TStructuralType>[] propertiesToCopy =
-                this._changedProperties.Select(s => _allProperties[s]).ToArray();
+                _changedProperties.Intersect(_updatableProperties).Select(s => _allProperties[s]).ToArray();
             foreach (PropertyAccessor<TStructuralType> propertyToCopy in propertiesToCopy)
             {
                 propertyToCopy.Copy(_instance, original);
@@ -520,28 +503,19 @@ namespace Microsoft.AspNet.OData
                     .Select<PropertyInfo, PropertyAccessor<TStructuralType>>(p => new FastPropertyAccessor<TStructuralType>(p))
                     .ToDictionary(p => p.Property.Name));
 
-            _updatableProperties = InitializeUpdatableProperties(updatableProperties);
-        }
-
-        private HashSet<string> InitializeUpdatableProperties(IEnumerable<string> updatableProperties)
-        {
-            HashSet<string> newUpdatableProperties;
             if (updatableProperties != null)
             {
-                newUpdatableProperties = new HashSet<string>(updatableProperties);
-                newUpdatableProperties.IntersectWith(_allProperties.Keys);
+                _updatableProperties = updatableProperties.Intersect(_allProperties.Keys).ToList();
             }
             else
             {
-                newUpdatableProperties = new HashSet<string>(_allProperties.Keys);
+                _updatableProperties = new List<string>(_allProperties.Keys);
             }
 
             if (_dynamicDictionaryPropertyinfo != null)
             {
-                newUpdatableProperties.Remove(_dynamicDictionaryPropertyinfo.Name);
+                _updatableProperties.Remove(_dynamicDictionaryPropertyinfo.Name);
             }
-
-            return newUpdatableProperties;
         }
 
         // Copy changed dynamic properties and leave the unchanged dynamic properties
@@ -650,7 +624,7 @@ namespace Microsoft.AspNet.OData
                 throw Error.ArgumentNull("name");
             }
 
-            if (!_updatableProperties.Contains(name))
+            if (!(_allProperties.ContainsKey(name) && _updatableProperties.Contains(name)))
             {
                 return false;
             }
@@ -680,7 +654,7 @@ namespace Microsoft.AspNet.OData
                 throw Error.ArgumentNull("name");
             }
 
-            if (!_updatableProperties.Contains(name))
+            if (!(_allProperties.ContainsKey(name) && _updatableProperties.Contains(name)))
             {
                 return false;
             }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataModelBinderProviderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataModelBinderProviderTest.cs
@@ -46,6 +46,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             _configuration.Routes.MapHttpRoute("default", "{controller}/{action}({id})");
 
             _server = new HttpServer(_configuration);
+
             _client = new HttpClient(_server);
         }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -258,7 +258,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 
 	System.Type ExpectedClrType  { public virtual get; }
 	System.Type StructuredType  { public virtual get; }
-	System.Collections.Generic.IEnumerable`1[[System.String]] UpdatableProperties  { public get; public set; }
+	System.Collections.Generic.IList`1[[System.String]] UpdatableProperties  { public get; }
 
 	public virtual void Clear ()
 	public void CopyChangedValues (TStructuralType original)

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -258,6 +258,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 
 	System.Type ExpectedClrType  { public virtual get; }
 	System.Type StructuredType  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[System.String]] UpdatableProperties  { public get; public set; }
 
 	public virtual void Clear ()
 	public void CopyChangedValues (TStructuralType original)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -273,7 +273,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 
 	System.Type ExpectedClrType  { public virtual get; }
 	System.Type StructuredType  { public virtual get; }
-	System.Collections.Generic.IEnumerable`1[[System.String]] UpdatableProperties  { public get; public set; }
+	System.Collections.Generic.IList`1[[System.String]] UpdatableProperties  { public get; }
 
 	public virtual void Clear ()
 	public void CopyChangedValues (TStructuralType original)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -273,6 +273,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 
 	System.Type ExpectedClrType  { public virtual get; }
 	System.Type StructuredType  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[System.String]] UpdatableProperties  { public get; public set; }
 
 	public virtual void Clear ()
 	public void CopyChangedValues (TStructuralType original)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -277,6 +277,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 
 	System.Type ExpectedClrType  { public virtual get; }
 	System.Type StructuredType  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[System.String]] UpdatableProperties  { public get; public set; }
 
 	public virtual void Clear ()
 	public void CopyChangedValues (TStructuralType original)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -277,7 +277,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 
 	System.Type ExpectedClrType  { public virtual get; }
 	System.Type StructuredType  { public virtual get; }
-	System.Collections.Generic.IEnumerable`1[[System.String]] UpdatableProperties  { public get; public set; }
+	System.Collections.Generic.IList`1[[System.String]] UpdatableProperties  { public get; }
 
 	public virtual void Clear ()
 	public void CopyChangedValues (TStructuralType original)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #2478

### Description

Adds a new settable property `UpdatableProperties` that allows the developer to change the list of updatable properties (`_updatableProperties`) after construction. This enables the developer to easily control which properties are updated in `Patch` and `Put` to prevent the caller from over-posting.

### Checklist (Uncheck if it is not completed)

- [ x] *Test cases added*
- [ x] *Build and test with one-click build and test script passed*

### Additional work necessary

Docs Needed:

- Update the documentation pages to include the new property.
