### PR TITLE
Tests using TimeZoneInfo fail due to race conditons

### DIFF
--- a/src/Microsoft.AspNet.OData/GlobalSuppressions.cs
+++ b/src/Microsoft.AspNet.OData/GlobalSuppressions.cs
@@ -60,3 +60,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.AspNet.OData.Builder.FunctionConfiguration.#HasDerivedTypeConstraintForReturnType`1()")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Scope = "member", Target = "Microsoft.AspNet.OData.Builder.IODataInstanceAnnotationContainer.#GetAllResourceAnnotations()")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Scope = "member", Target = "Microsoft.AspNet.OData.Builder.IODataInstanceAnnotationContainer.#GetResourceAnnotations()")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "Microsoft.AspNet.OData.Common.Error.#PropertyNullOrWhiteSpace()")]

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DateAndTimeOfDay/DateAndTimeOfDayTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DateAndTimeOfDay/DateAndTimeOfDayTest.cs
@@ -22,6 +22,7 @@ using Xunit;
 
 namespace Microsoft.Test.E2E.AspNet.OData.DateAndTimeOfDay
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class DateAndTimeOfDayTest : WebHostTestBase
     {
         public DateAndTimeOfDayTest(WebHostTestFixture fixture)

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DateTimeSupport/DateTimeTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DateTimeSupport/DateTimeTest.cs
@@ -21,6 +21,7 @@ using Xunit;
 
 namespace Microsoft.Test.E2E.AspNet.OData.DateTimeSupport
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class DateTimeTest : WebHostTestBase
     {
         public DateTimeTest(WebHostTestFixture fixture)

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ModelBoundQuerySettings/PageAttributeTest/SkipTokenTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ModelBoundQuerySettings/PageAttributeTest/SkipTokenTest.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Microsoft.Test.E2E.AspNet.OData.ModelBoundQuerySettings.PageAttributeTest.SkipTokenTest
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class SkipTokenTest : WebHostTestBase
     {
         private const string CustomerBaseUrl = "{0}/skiptokentest/Customers";

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/DateTimeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/DateTimeTest.cs
@@ -37,6 +37,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.OData.Test
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class DateTimeTest
     {
         // Note: the product uses a static TimezoneHelper class to store the timezone. As a result,

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/DefaultODataETagHandlerTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/DefaultODataETagHandlerTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Formatter
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class DefaultODataETagHandlerTests
     {
         public static TheoryDataSet<object> CreateAndParseETagForValue_DataSet

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/CollectionDeserializationHelpersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/CollectionDeserializationHelpersTest.cs
@@ -15,6 +15,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class CollectionDeserializationHelpersTest
     {
         public static TheoryDataSet<IList, IEnumerable> CopyItemsToCollectionData

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/DeserializationHelpersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/DeserializationHelpersTest.cs
@@ -27,6 +27,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class DeserializationHelpersTest
     {
         [Theory]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/ODataPrimitiveDeserializerTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/ODataPrimitiveDeserializerTests.cs
@@ -38,6 +38,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class ODataPrimitiveDeserializerTests
     {
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/EdmPrimitiveHelpersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/EdmPrimitiveHelpersTest.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Formatter
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class EdmPrimitiveHelpersTest
     {
         public static TheoryDataSet<object, object, Type> ConvertPrimitiveValue_NonStandardPrimitives_Data

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataModelBinderProviderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataModelBinderProviderTest.cs
@@ -30,6 +30,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Formatter
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class ODataModelBinderProviderTest
     {
         private HttpConfiguration _configuration;

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/CollectionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/CollectionTest.cs
@@ -33,6 +33,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class CollectionTest
     {
         [Fact]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/ODataPrimitiveSerializerTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Serialization/ODataPrimitiveSerializerTests.cs
@@ -21,6 +21,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Formatter.Serialization
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class ODataPrimitiveSerializerTests
     {
         public static IEnumerable<object[]> NonEdmPrimitiveConversionData

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/HttpConfigurationExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/HttpConfigurationExtensionsTest.cs
@@ -26,6 +26,7 @@ using ServiceLifetime = Microsoft.OData.ServiceLifetime;
 
 namespace Microsoft.AspNet.OData.Test
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class HttpConfigurationExtensionsTest
     {
         [Fact]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -25,6 +25,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.OData.Test.Query.Expressions
 {
+    [Collection("TimeZoneTests")] // TimeZoneInfo is not thread-safe. Tests in this collection will be executed sequentially 
     public class FilterBinderTests
     {
         private const string NotTesting = "";


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Fixes #2484

### Description

When running the test ODataModelBinderProvider_Works_DateTime in WebAPI it often "randomly" fails.

Details in the issue.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

Testcases run repeatedly run after the changes and the test reliably passes.
