### PR TITLE
Make the reflection more robust

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/DefaultContainerBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DefaultContainerBuilder.cs
@@ -85,9 +85,7 @@ namespace Microsoft.AspNet.OData
             * More info at https://github.com/OData/WebApi/pull/1082
             */
 
-            Assembly microsoftExtensionsDependencyInjectionAssembly = services.GetType().GetTypeInfo().Assembly;
-            TypeInfo serviceCollectionContainerBuilderExtensionsType = microsoftExtensionsDependencyInjectionAssembly.GetType(typeof(ServiceCollectionContainerBuilderExtensions).GetTypeInfo().FullName).GetTypeInfo();
-            MethodInfo buildServiceProviderMethod = serviceCollectionContainerBuilderExtensionsType.GetMethod("BuildServiceProvider", new[] { typeof(IServiceCollection) });
+            MethodInfo buildServiceProviderMethod = typeof(ServiceCollectionContainerBuilderExtensions).GetMethod(nameof(ServiceCollectionContainerBuilderExtensions.BuildServiceProvider), new[] { typeof(IServiceCollection) });
 
             return (IServiceProvider)buildServiceProviderMethod.Invoke(null, new object[] { services });
         }


### PR DESCRIPTION
- This was caught when moving ServiceCollection to another assembly (type forwarded).

<!-- markdownlint-disable MD002 MD041 -->

### Issues

Fixes https://github.com/OData/WebApi/issues/2490

### Description

Today, OData tries to make MEDI (Microsoft.Extensions.DependencyInjection) 1.0 and 2.0 work side by side (original change here https://github.com/OData/WebApi/pull/1082), to make this work it uses reflection to call BuildServiceProvider (since there was a breaking change between 1.0 and 2.0). This change makes the reflection code a bit more robust by looking for the method on the type and method where it's defined.
