### PR TITLE
Fix API Explorer usage with OData.

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataInputFormatter.cs
@@ -212,6 +212,18 @@ namespace Microsoft.AspNet.OData.Formatter
             return baseAddress[baseAddress.Length - 1] != '/' ? new Uri(baseAddress + '/') : new Uri(baseAddress);
         }
 
+        /// <inheritdoc />
+        public override IReadOnlyList<string> GetSupportedContentTypes(string contentType, Type objectType)
+        {
+            if (SupportedMediaTypes.Count == 0)
+            {
+                // note: this is parity with the base implementation when there are no matches
+                return default;
+            }
+
+            return base.GetSupportedContentTypes(contentType, objectType);
+        }
+
         internal static ODataVersion GetODataResponseVersion(HttpRequest request)
         {
             // OData protocol requires that you send the minimum version that the client needs to know to

--- a/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
+++ b/src/Microsoft.AspNetCore.OData/Formatter/ODataOutputFormatter.cs
@@ -308,6 +308,18 @@ namespace Microsoft.AspNet.OData.Formatter
             return baseAddress[baseAddress.Length - 1] != '/' ? new Uri(baseAddress + '/') : new Uri(baseAddress);
         }
 
+        /// <inheritdoc />
+        public override IReadOnlyList<string> GetSupportedContentTypes(string contentType, Type objectType)
+        {
+            if (SupportedMediaTypes.Count == 0)
+            {
+                // note: this is parity with the base implementation when there are no matches
+                return default;
+            }
+
+            return base.GetSupportedContentTypes(contentType, objectType);
+        }
+
         private MediaTypeHeaderValue GetContentType(string contentTypeValue)
         {
             MediaTypeHeaderValue contentType = null;

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataMediaTypeFormattersTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataMediaTypeFormattersTests.cs
@@ -706,6 +706,50 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             Assert.Equal(MediaTypeHeaderValue.Parse(expectedMediaType), mediaType);
         }
 
+#if NETCORE
+        [Fact]
+        public void TestGet_InputFormatterMetadata_DontError()
+        {
+            // Arrange
+            var formatters = CreateInputFormatters().ToList();
+            Assert.NotNull(formatters); // Guard assertion
+
+            // Act
+            foreach (var formatter in formatters)
+            {
+                formatter.SupportedMediaTypes.Clear();
+            }
+
+            // Assert
+            foreach (var formatter in formatters)
+            {
+                var exception = Record.Exception(() => formatter.GetSupportedContentTypes("application/json", typeof(string)));
+                Assert.Null(exception);
+            }
+        }
+
+        [Fact]
+        public void TestGet_OutputFormatterMetadata_DontError()
+        {
+            // Arrange
+            var formatters = CreateOutputFormatters().ToList();
+            Assert.NotNull(formatters); // Guard assertion
+
+            // Act
+            foreach (var formatter in formatters)
+            {
+                formatter.SupportedMediaTypes.Clear();
+            }
+
+            // Assert
+            foreach (var formatter in formatters)
+            {
+                var exception = Record.Exception(() => formatter.GetSupportedContentTypes("application/json", typeof(string)));
+                Assert.Null(exception);
+            }
+        }
+
+#endif
         private static IEdmModel CreateModel()
         {
             return new Mock<IEdmModel>().Object;

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataMediaTypeFormattersTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataMediaTypeFormattersTests.cs
@@ -725,6 +725,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             {
                 var exception = Record.Exception(() => formatter.GetSupportedContentTypes("application/json", typeof(string)));
                 Assert.Null(exception);
+                Assert.Null(formatter.GetSupportedContentTypes("application/json", typeof(string)));
             }
         }
 
@@ -746,6 +747,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             {
                 var exception = Record.Exception(() => formatter.GetSupportedContentTypes("application/json", typeof(string)));
                 Assert.Null(exception);
+                Assert.Null(formatter.GetSupportedContentTypes("application/json", typeof(string)));
             }
         }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -2354,6 +2354,7 @@ public class Microsoft.AspNet.OData.Formatter.ODataInputFormatter : Microsoft.As
 
 	public virtual bool CanRead (Microsoft.AspNetCore.Mvc.Formatters.InputFormatterContext context)
 	public static System.Uri GetDefaultBaseAddress (Microsoft.AspNetCore.Http.HttpRequest request)
+	public virtual System.Collections.Generic.IReadOnlyList`1[[System.String]] GetSupportedContentTypes (string contentType, System.Type objectType)
 	[
 	AsyncStateMachineAttribute(),
 	]
@@ -2368,6 +2369,7 @@ public class Microsoft.AspNet.OData.Formatter.ODataOutputFormatter : Microsoft.A
 
 	public virtual bool CanWriteResult (Microsoft.AspNetCore.Mvc.Formatters.OutputFormatterCanWriteContext context)
 	public static System.Uri GetDefaultBaseAddress (Microsoft.AspNetCore.Http.HttpRequest request)
+	public virtual System.Collections.Generic.IReadOnlyList`1[[System.String]] GetSupportedContentTypes (string contentType, System.Type objectType)
 	public virtual System.Threading.Tasks.Task WriteResponseBodyAsync (Microsoft.AspNetCore.Mvc.Formatters.OutputFormatterWriteContext context, System.Text.Encoding selectedEncoding)
 	public virtual void WriteResponseHeaders (Microsoft.AspNetCore.Mvc.Formatters.OutputFormatterWriteContext context)
 }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -2529,6 +2529,7 @@ public class Microsoft.AspNet.OData.Formatter.ODataInputFormatter : Microsoft.As
 
 	public virtual bool CanRead (Microsoft.AspNetCore.Mvc.Formatters.InputFormatterContext context)
 	public static System.Uri GetDefaultBaseAddress (Microsoft.AspNetCore.Http.HttpRequest request)
+	public virtual System.Collections.Generic.IReadOnlyList`1[[System.String]] GetSupportedContentTypes (string contentType, System.Type objectType)
 	[
 	AsyncStateMachineAttribute(),
 	]
@@ -2543,6 +2544,7 @@ public class Microsoft.AspNet.OData.Formatter.ODataOutputFormatter : Microsoft.A
 
 	public virtual bool CanWriteResult (Microsoft.AspNetCore.Mvc.Formatters.OutputFormatterCanWriteContext context)
 	public static System.Uri GetDefaultBaseAddress (Microsoft.AspNetCore.Http.HttpRequest request)
+	public virtual System.Collections.Generic.IReadOnlyList`1[[System.String]] GetSupportedContentTypes (string contentType, System.Type objectType)
 	public virtual System.Threading.Tasks.Task WriteResponseBodyAsync (Microsoft.AspNetCore.Mvc.Formatters.OutputFormatterWriteContext context, System.Text.Encoding selectedEncoding)
 	public virtual void WriteResponseHeaders (Microsoft.AspNetCore.Mvc.Formatters.OutputFormatterWriteContext context)
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1750.*

### Description

*This PR changes ODataInputFormatter and ODataOutputFormatter to override GetSupportedContentTypes to not throw an exception when SupportedMediaTypes is empty.*

This lead to a problem when using Swagger with a controller with both OData and non-OData routes, as seen in https://github.com/OData/WebApi/issues/1177#issuecomment-353738261.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

I don't know what the "one-click build and test script" is, but I ran the newly added unit tests and they pass with this change, and fail without.
