### PR TITLE
Fix behaviour on status code requests.

### DIFF
--- a/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
@@ -140,7 +140,7 @@ namespace Microsoft.AspNet.OData
                 {
                     elementType = TypeHelper.GetImplementedIEnumerableType(returnType);
                 }
-                else if(TypeHelper.IsGenericType(returnType) && returnType.GetGenericTypeDefinition() == typeof(Task<>))
+                else if (TypeHelper.IsGenericType(returnType) && returnType.GetGenericTypeDefinition() == typeof(Task<>))
                 {
                     elementType = returnType.GetGenericArguments().First();
                 }
@@ -228,46 +228,44 @@ namespace Microsoft.AspNet.OData
             {
                 // actionExecutedContext.Result might also indicate a status code that has not yet
                 // been applied to the result; make sure it's also successful.
-                StatusCodeResult statusCodeResult = actionExecutedContext.Result as StatusCodeResult;
-                if (statusCodeResult == null || IsSuccessStatusCode(statusCodeResult.StatusCode))
+                ObjectResult responseContent = actionExecutedContext.Result as ObjectResult;
+
+                if (responseContent != null && (responseContent.StatusCode == null || IsSuccessStatusCode(responseContent.StatusCode.Value)))
                 {
-                    ObjectResult responseContent = actionExecutedContext.Result as ObjectResult;
-                    if (responseContent != null)
+
+                    //throw Error.Argument("actionExecutedContext", SRResources.QueryingRequiresObjectContent,
+                    //    actionExecutedContext.Result.GetType().FullName);
+
+                    // Get collection from SingleResult.
+                    IQueryable singleResultCollection = null;
+                    SingleResult singleResult = responseContent.Value as SingleResult;
+                    if (singleResult != null)
                     {
-                        //throw Error.Argument("actionExecutedContext", SRResources.QueryingRequiresObjectContent,
-                        //    actionExecutedContext.Result.GetType().FullName);
+                        // This could be a SingleResult, which has the property Queryable.
+                        // But it could be a SingleResult() or SingleResult<T>. Sort by number of parameters
+                        // on the property and get the one with the most parameters.
+                        PropertyInfo propInfo = responseContent.Value.GetType().GetProperties()
+                            .OrderBy(p => p.GetIndexParameters().Count())
+                            .Where(p => p.Name.Equals("Queryable"))
+                            .LastOrDefault();
 
-                        // Get collection from SingleResult.
-                        IQueryable singleResultCollection = null;
-                        SingleResult singleResult = responseContent.Value as SingleResult;
-                        if (singleResult != null)
-                        {
-                            // This could be a SingleResult, which has the property Queryable.
-                            // But it could be a SingleResult() or SingleResult<T>. Sort by number of parameters
-                            // on the property and get the one with the most parameters.
-                            PropertyInfo propInfo = responseContent.Value.GetType().GetProperties()
-                                .OrderBy(p => p.GetIndexParameters().Count())
-                                .Where(p => p.Name.Equals("Queryable"))
-                                .LastOrDefault();
+                        singleResultCollection = propInfo.GetValue(singleResult) as IQueryable;
+                    }
 
-                            singleResultCollection = propInfo.GetValue(singleResult) as IQueryable;
-                        }
+                    // Execution the action.
+                    object queryResult = OnActionExecuted(
+                        responseContent.Value,
+                        singleResultCollection,
+                        new WebApiActionDescriptor(actionDescriptor as ControllerActionDescriptor),
+                        new WebApiRequestMessage(request),
+                        (elementClrType) => GetModel(elementClrType, request, actionDescriptor),
+                        (queryContext) => CreateAndValidateQueryOptions(request, queryContext),
+                        (statusCode) => actionExecutedContext.Result = new StatusCodeResult((int)statusCode),
+                        (statusCode, message, exception) => actionExecutedContext.Result = CreateBadRequestResult(message, exception));
 
-                        // Execution the action.
-                        object queryResult = OnActionExecuted(
-                            responseContent.Value,
-                            singleResultCollection,
-                            new WebApiActionDescriptor(actionDescriptor as ControllerActionDescriptor),
-                            new WebApiRequestMessage(request),
-                            (elementClrType) => GetModel(elementClrType, request, actionDescriptor),
-                            (queryContext) => CreateAndValidateQueryOptions(request, queryContext),
-                            (statusCode) => actionExecutedContext.Result = new StatusCodeResult((int)statusCode),
-                            (statusCode, message, exception) => actionExecutedContext.Result = CreateBadRequestResult(message, exception));
-
-                        if (queryResult != null)
-                        {
-                            responseContent.Value = queryResult;
-                        }
+                    if (queryResult != null)
+                    {
+                        responseContent.Value = queryResult;
                     }
                 }
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2511 .*

### Description

*Briefly describe the changes of this pull request.*
Fixes the usage of enable query for status code requests as they are not used within AspNetCore OData.
The api ` this.StatusCode(int, obj)` returns an `ObjectResult` instead of a `StatusCodeResult`. and Object result is not a child of status code result.

The original intent seems to be when the ObjectResult is not null proceed to apply the query options.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
