### PR TITLE
Fixed Enum.Try parse issue with .NET 6

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataModelBinderConverter.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataModelBinderConverter.cs
@@ -30,10 +30,7 @@ namespace Microsoft.AspNet.OData.Formatter
         Justification = "Relies on many ODataLib classes.")]
     public static class ODataModelBinderConverter
     {
-#if NETSTANDARD2_0
-        internal static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethods()
-            .Single(m => m.Name == "TryParse" && m.GetParameters().Length == 2);
-#else
+#if NETCOREAPP3_1
         // .NET 6 adds a new overload: TryParse<TEnum>(ReadOnlySpan<Char>, TEnum)
         // Now, with `TryParse<TEnum>(String, TEnum)`, there will have two versions with two parameters
         // So, the previous Single() will throw exception.
@@ -43,6 +40,9 @@ namespace Microsoft.AspNet.OData.Formatter
                 typeof(string),
                 Type.MakeGenericMethodParameter(0).MakeByRefType()
             });
+#else
+        internal static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethods()
+            .Single(m => m.Name == "TryParse" && m.GetParameters().Length == 2);
 #endif
 
         private static readonly MethodInfo CastMethodInfo = typeof(Enumerable).GetMethod("Cast");

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataModelBinderConverter.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataModelBinderConverter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.OData.Formatter
     public static class ODataModelBinderConverter
     {
         private static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethods()
-            .Single(m => m.Name == "TryParse" && m.GetParameters().Length == 2);
+                        .Single(m => m.Name == "TryParse" && m.IsGenericMethod && m.GetParameters().Length == 2 && m.GetParameters().First().ParameterType == typeof(string));
 
         private static readonly MethodInfo CastMethodInfo = typeof(Enumerable).GetMethod("Cast");
 

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataModelBinderConverter.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataModelBinderConverter.cs
@@ -30,8 +30,20 @@ namespace Microsoft.AspNet.OData.Formatter
         Justification = "Relies on many ODataLib classes.")]
     public static class ODataModelBinderConverter
     {
-        private static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethods()
-                        .Single(m => m.Name == "TryParse" && m.IsGenericMethod && m.GetParameters().Length == 2 && m.GetParameters().First().ParameterType == typeof(string));
+#if NETSTANDARD2_0
+        internal static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethods()
+            .Single(m => m.Name == "TryParse" && m.GetParameters().Length == 2);
+#else
+        // .NET 6 adds a new overload: TryParse<TEnum>(ReadOnlySpan<Char>, TEnum)
+        // Now, with `TryParse<TEnum>(String, TEnum)`, there will have two versions with two parameters
+        // So, the previous Single() will throw exception.
+        internal static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethod("TryParse",
+            new[]
+            {
+                typeof(string),
+                Type.MakeGenericMethodParameter(0).MakeByRefType()
+            });
+#endif
 
         private static readonly MethodInfo CastMethodInfo = typeof(Enumerable).GetMethod("Cast");
 

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         internal static readonly Expression ZeroConstant = Expression.Constant(0);
 
         internal static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethods()
-                        .Single(m => m.Name == "TryParse" && m.GetParameters().Length == 2);
+                        .Single(m => m.Name == "TryParse" && m.IsGenericMethod && m.GetParameters().Length == 2 && m.GetParameters().First().ParameterType == typeof(string));
 
         internal static readonly Dictionary<BinaryOperatorKind, ExpressionType> BinaryOperatorMapping = new Dictionary<BinaryOperatorKind, ExpressionType>
         {

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -41,10 +41,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         internal static readonly Expression TrueConstant = Expression.Constant(true);
         internal static readonly Expression ZeroConstant = Expression.Constant(0);
 
-#if NETSTANDARD2_0
-        internal static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethods()
-            .Single(m => m.Name == "TryParse" && m.GetParameters().Length == 2);
-#else
+#if NETCOREAPP3_1
         // .NET 6 adds a new overload: TryParse<TEnum>(ReadOnlySpan<Char>, TEnum)
         // Now, with `TryParse<TEnum>(String, TEnum)`, there will have two versions with two parameters
         // So, the previous Single() will throw exception.
@@ -54,6 +51,9 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 typeof(string),
                 Type.MakeGenericMethodParameter(0).MakeByRefType()
             });
+#else
+        internal static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethods()
+            .Single(m => m.Name == "TryParse" && m.GetParameters().Length == 2);
 #endif
 
         internal static readonly Dictionary<BinaryOperatorKind, ExpressionType> BinaryOperatorMapping = new Dictionary<BinaryOperatorKind, ExpressionType>

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -41,8 +41,20 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         internal static readonly Expression TrueConstant = Expression.Constant(true);
         internal static readonly Expression ZeroConstant = Expression.Constant(0);
 
+#if NETSTANDARD2_0
         internal static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethods()
-                        .Single(m => m.Name == "TryParse" && m.IsGenericMethod && m.GetParameters().Length == 2 && m.GetParameters().First().ParameterType == typeof(string));
+            .Single(m => m.Name == "TryParse" && m.GetParameters().Length == 2);
+#else
+        // .NET 6 adds a new overload: TryParse<TEnum>(ReadOnlySpan<Char>, TEnum)
+        // Now, with `TryParse<TEnum>(String, TEnum)`, there will have two versions with two parameters
+        // So, the previous Single() will throw exception.
+        internal static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethod("TryParse",
+            new[]
+            {
+                typeof(string),
+                Type.MakeGenericMethodParameter(0).MakeByRefType()
+            });
+#endif
 
         internal static readonly Dictionary<BinaryOperatorKind, ExpressionType> BinaryOperatorMapping = new Dictionary<BinaryOperatorKind, ExpressionType>
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2518.*

### Description

Changes the way OData finds Enum.TryParse using reflection which works against both .NET 6 and older versions

### Checklist (Uncheck if it is not completed)

- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

N/A
