### PR TITLE
Fix AmbiguousMatchException

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -179,13 +179,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
             // Expression:  source.Property
             string propertyName = EdmLibHelpers.GetClrPropertyName(property, _model);
-            
-            PropertyInfo propertyInfo = source.Type.GetProperty(propertyName, BindingFlags.DeclaredOnly);
-            if (propertyInfo == null)
-            {
-                propertyInfo = source.Type.GetProperty(propertyName);
-            }
-            
+            PropertyInfo propertyInfo = TypeHelper.GetProperty(source.Type, propertyName);
+
             Expression propertyValue = Expression.Property(source, propertyInfo);
             Type nullablePropertyType = TypeHelper.ToNullable(propertyValue.Type);
             Expression nullablePropertyValue = ExpressionHelpers.ToNullable(propertyValue);

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -179,7 +179,13 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
             // Expression:  source.Property
             string propertyName = EdmLibHelpers.GetClrPropertyName(property, _model);
-            PropertyInfo propertyInfo = source.Type.GetProperty(propertyName);
+            
+            PropertyInfo propertyInfo = source.Type.GetProperty(propertyName, BindingFlags.DeclaredOnly);
+            if (propertyInfo == null)
+            {
+                propertyInfo = source.Type.GetProperty(propertyName);
+            }
+            
             Expression propertyValue = Expression.Property(source, propertyInfo);
             Type nullablePropertyType = TypeHelper.ToNullable(propertyValue.Type);
             Expression nullablePropertyValue = ExpressionHelpers.ToNullable(propertyValue);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/TypeHelperTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/TypeHelperTest.cs
@@ -315,6 +315,76 @@ namespace Microsoft.AspNet.OData.Test
             Assert.DoesNotContain(typeof(TypeHelperTest), foundTypes);
         }
 
+        [Fact]
+        public void GetPropertyDeclaredOnSelf()
+        {
+            // Arrange & Act
+            var prop = TypeHelper.GetProperty(typeof(TypeA), "Prop");
+
+            // Assert
+            Assert.Equal("Prop", prop.Name);
+            Assert.Equal(typeof(int), prop.PropertyType);
+            Assert.Equal(typeof(TypeA), prop.DeclaringType);
+        }
+
+        [Fact]
+        public void GetPropertyRedeclaredOnSelf()
+        {
+            // Arrange & Act
+            var prop = TypeHelper.GetProperty(typeof(TypeB), "Prop");
+
+            // Assert
+            Assert.Equal("Prop", prop.Name);
+            Assert.Equal(typeof(string), prop.PropertyType);
+            Assert.Equal(typeof(TypeB), prop.DeclaringType);
+        }
+
+        [Fact]
+        public void GetPropertyDeclaredOnImmediateParent()
+        {
+            // Arrange & Act
+            var prop = TypeHelper.GetProperty(typeof(TypeC), "Prop");
+
+            // Assert
+            Assert.Equal("Prop", prop.Name);
+            Assert.Equal(typeof(int), prop.PropertyType);
+            Assert.Equal(typeof(TypeA), prop.DeclaringType);
+        }
+
+        [Fact]
+        public void GetPropertyRedeclaredOnImmediateParent()
+        {
+            // Arrange & Act
+            var prop = TypeHelper.GetProperty(typeof(TypeD), "Prop");
+
+            // Assert
+            Assert.Equal("Prop", prop.Name);
+            Assert.Equal(typeof(string), prop.PropertyType);
+            Assert.Equal(typeof(TypeB), prop.DeclaringType);
+        }
+
+        [Fact]
+        public void GetPropertyDeclaredOnNonImmediateParent()
+        {
+            // Arrange & Act
+            var prop = TypeHelper.GetProperty(typeof(TypeE), "Prop");
+
+            // Assert
+            Assert.Equal("Prop", prop.Name);
+            Assert.Equal(typeof(string), prop.PropertyType);
+            Assert.Equal(typeof(TypeB), prop.DeclaringType);
+        }
+
+        [Fact]
+        public void GetPropertyForNonUndeclaredProperty()
+        {
+            // Arrange & Act
+            var undeclared = TypeHelper.GetProperty(typeof(TypeA), "Undeclared");
+
+            // Assert
+            Assert.Null(undeclared);
+        }
+
         /// <summary>
         /// Custom internal class
         /// </summary>
@@ -350,6 +420,28 @@ namespace Microsoft.AspNet.OData.Test
         private class CustomConcreteClass : CustomAbstractClass
         {
             public override int Area() { return 42; }
+        }
+
+        private class TypeA
+        {
+            public int Prop { get; set; }
+        }
+
+        private class TypeB : TypeA
+        {
+            public new string Prop { get; set; }
+        }
+
+        private class TypeC : TypeA
+        {
+        }
+
+        private class TypeD : TypeB
+        {
+        }
+
+        private class TypeE : TypeD
+        {
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #2516 

### Description

Fixed AmbiguousMatchException for properties with new modifier 

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

**Be noted:** There are 2 build pipelines currently. The [.NET Foundation pipeline](https://dev.azure.com/dotnet/OData/_build?definitionId=172) is failing as a result of discontinued support for .NET 4.5. The [other pipeline](https://identitydivision.visualstudio.com/OData/_build?definitionId=1101) is completing successfully

