### PR TITLE
Fixed Enum try parse issue. This closes #2518

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataModelBinderConverter.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataModelBinderConverter.cs
@@ -31,7 +31,9 @@ namespace Microsoft.AspNet.OData.Formatter
     public static class ODataModelBinderConverter
     {
         private static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethods()
-            .Single(m => m.Name == "TryParse" && m.GetParameters().Length == 2);
+            .Single(m => m.Name.Equals("TryParse", StringComparison.Ordinal)
+                && m.GetParameters().Length == 2
+                && m.GetParameters()[0].ParameterType.Equals(typeof(string)));
 
         private static readonly MethodInfo CastMethodInfo = typeof(Enumerable).GetMethod("Cast");
 

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -42,7 +42,9 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         internal static readonly Expression ZeroConstant = Expression.Constant(0);
 
         internal static readonly MethodInfo EnumTryParseMethod = typeof(Enum).GetMethods()
-                        .Single(m => m.Name == "TryParse" && m.GetParameters().Length == 2);
+            .Single(m => m.Name.Equals("TryParse", StringComparison.Ordinal)
+                && m.GetParameters().Length == 2
+                && m.GetParameters()[0].ParameterType.Equals(typeof(string)));
 
         internal static readonly Dictionary<BinaryOperatorKind, ExpressionType> BinaryOperatorMapping = new Dictionary<BinaryOperatorKind, ExpressionType>
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2518.*

### Description

Changes the way OData finds Enum.TryParse using reflection which works against all .NET versions including recently released .NET 6

### Checklist (Uncheck if it is not completed)

- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

N/A

Note that there was another [PR](https://github.com/OData/WebApi/pull/2520) before this PR
