### PR TITLE
Fix bug in Filter Any within Expand

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -940,7 +940,9 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             foreach (RangeVariable rangeVariable in rangeVariables)
             {
                 ParameterExpression parameter;
-                if (!_lambdaParameters.TryGetValue(rangeVariable.Name, out parameter))
+
+                // Create a Parameter Expression when for rangeVariables which are not $it Lambda parameters or $this.
+                if (!_lambdaParameters.TryGetValue(rangeVariable.Name, out parameter) && rangeVariable.Name != ODataThisParameterName)
                 {
                     // Work-around issue 481323 where UriParser yields a collection parameter type
                     // for primitive collections rather than the inner element type of the collection.

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/FilterBinder.cs
@@ -941,7 +941,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             {
                 ParameterExpression parameter;
 
-                // Create a Parameter Expression when for rangeVariables which are not $it Lambda parameters or $this.
+                // Create a Parameter Expression for rangeVariables which are not $it Lambda parameters or $this.
                 if (!_lambdaParameters.TryGetValue(rangeVariable.Name, out parameter) && rangeVariable.Name != ODataThisParameterName)
                 {
                     // Work-around issue 481323 where UriParser yields a collection parameter type

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
@@ -869,6 +869,9 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         public void ProjectAsWrapper_Element_ExpandAndFilterByAny(string expand, object expected)
         {
             // Arrange
+            // Customer?$expand=Orders($filter=Customer/HomeAddress/Cities/any(e:e/CityName eq 1001))
+            // Customer?$expand=Orders($filter=Customer/HomeAddress/Cities/any(e:e/CityName eq 1002))
+            // Customer?$expand=Orders($filter=Customer/HomeAddress/Cities/any(e:e/CityName eq 1003))
 
             var city1 = new QueryCity() { Id = 1, CityName = 1001 };
             var city2 = new QueryCity() { Id = 2, CityName = 1002 };

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
@@ -862,6 +862,64 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             Assert.Equal(4, fourth.Id);
         }
 
+        [Theory]
+        [InlineData("Orders($filter=Customer/HomeAddress/Cities/any(e:e/CityName eq 1001))", new[] { "QueryOrder1" })]
+        [InlineData("Orders($filter=Customer/HomeAddress/Cities/any(e:e/CityName eq 1002))", new[] { "QueryOrder1", "QueryOrder3" })]
+        [InlineData("Orders($filter=Customer/HomeAddress/Cities/any(e:e/CityName eq 1003))", new[] { "QueryOrder2", "QueryOrder3" })]
+        public void ProjectAsWrapper_Element_ExpandAndFilterByAny(string expand, object expected)
+        {
+            // Arrange
+
+            var city1 = new QueryCity() { Id = 1, CityName = 1001 };
+            var city2 = new QueryCity() { Id = 2, CityName = 1002 };
+            var city3 = new QueryCity() { Id = 3, CityName = 1003 };
+            var city4 = new QueryCity() { Id = 4, CityName = 1004 };
+
+            QueryCustomer customer1 = new QueryCustomer
+            {
+                HomeAddress = new QueryAddress
+                {
+                    Cities = new List<QueryCity>() { city1, city2 }
+                }
+            };
+
+            QueryCustomer customer2 = new QueryCustomer
+            {
+                HomeAddress = new QueryAddress
+                {
+                    Cities = new List<QueryCity>() { city3, city4 }
+                }
+            };
+
+            QueryCustomer customer3 = new QueryCustomer
+            {
+                HomeAddress = new QueryAddress
+                {
+                    Cities = new List<QueryCity>() { city2, city3 }
+                }
+            };
+
+            var orders = new List<QueryOrder>
+            {
+               new QueryOrder{ Title = "QueryOrder1", Customer = customer1  },
+               new QueryOrder{ Title = "QueryOrder2", Customer = customer2  },
+               new QueryOrder{ Title = "QueryOrder3", Customer = customer3  },
+            };
+
+            Expression source = Expression.Constant(new QueryCustomer() { Orders = orders });
+            SelectExpandClause selectExpandClause = ParseSelectExpand(null, expand, _model, _customer, _customers);
+            Assert.NotNull(selectExpandClause);
+
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpandClause, _customer, _customers);
+
+            // Assert
+            var customerWrappers = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryCustomer>;
+            var orderWrappers = customerWrappers.Container.ToDictionary(PropertyMapper)["Orders"] as IEnumerable<SelectExpandWrapper<QueryOrder>>;
+            var orderTitleList = orderWrappers.Select(s => s.Instance.Title).ToList();
+            Assert.Equal(expected, orderTitleList);
+        }
+
         [Fact]
         public void ProjectAsWrapper_Element_ProjectedValueContainsSubKeys_IfDollarRefInDollarExpandOnSubNavigationProperty()
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue https://github.com/OData/AspNetCoreOData/issues/233*

### Description

Issue was raised in the WebAPI v8 repo. We will fix in this repo and that one too.

Generally in Select and Expand binder in ODL, we add a `$this` range variable. When binding AnyNode within expand/select in WebApi, we create parameter expression for range variables which are not `$it`. We also need to ignore the `$this` range variables. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
