### PR TITLE
Cache EDMType so that we can avoid costly linq O(n) lookup.

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
@@ -164,9 +164,9 @@ namespace Microsoft.AspNet.OData.Formatter
                     clrType = underlyingType;
                 }
 
-                if (_cache.TryGetValue(edmModel, out var cachedClrTypes))
+                if (_cache.TryGetValue(edmModel, out ConcurrentDictionary<Type, IEdmType> cachedClrTypes))
                 {
-                    if (cachedClrTypes.TryGetValue(clrType, out var cachedType))
+                    if (cachedClrTypes.TryGetValue(clrType, out IEdmType cachedType))
                     {
                         return cachedType;
                     }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

When we get the EDM type we look at all the schema elements of the model. This lookup is not only costly but also scales with O(n). Since, we use OData API for our service we have a lot of schema elements in the model and we would benefit from this scaling better. In our CPU profiling we spent close to 12% of our on CPU cycles in this method.

![image](https://user-images.githubusercontent.com/88375451/127997966-5550fcdd-d511-4957-a68c-0ab0ebe2d31d.png)


### Description

In this change we are caching the result of this method and returning the cached value in future invocations. 

I did perf testing with unit tests where I added 96 complex types to model.
Then fetched first and last object 10000 times.

Old code ran in the range 350-400 ms.
New code ran in the range 5-12 ms.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added* Not sure what tests to add here.
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
