### PR TITLE
Clone reader settings to reset the properties

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataInputFormatterHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataInputFormatterHelper.cs
@@ -76,7 +76,9 @@ namespace Microsoft.AspNet.OData.Formatter
 
             try
             {
-                ODataMessageReaderSettings oDataReaderSettings = internalRequest.ReaderSettings;
+                // Let's clone the reader setting every time to reset the base uri and others
+                ODataMessageReaderSettings oDataReaderSettings = internalRequest.ReaderSettings.Clone();
+
                 oDataReaderSettings.BaseUri = baseAddress;
                 oDataReaderSettings.Validations = oDataReaderSettings.Validations & ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
                 oDataReaderSettings.Version = version;

--- a/src/Microsoft.AspNetCore.OData/Batch/DefaultODataBatchHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/DefaultODataBatchHandler.cs
@@ -106,9 +106,8 @@ namespace Microsoft.AspNet.OData.Batch
 
             HttpRequest request = context.Request;
             IServiceProvider requestContainer = request.CreateRequestContainer(ODataRouteName);
-            requestContainer.GetRequiredService<ODataMessageReaderSettings>().BaseUri = GetBaseUri(request);
-
-            ODataMessageReader reader = request.GetODataMessageReader(requestContainer);
+            Uri baseUri =  GetBaseUri(request);
+            ODataMessageReader reader = request.GetODataMessageReader(requestContainer, baseUri);
 
             CancellationToken cancellationToken = context.RequestAborted;
             List<ODataBatchRequestItem> requests = new List<ODataBatchRequestItem>();

--- a/src/Microsoft.AspNetCore.OData/Batch/HttpRequestExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/HttpRequestExtensions.cs
@@ -42,8 +42,9 @@ namespace Microsoft.AspNet.OData.Batch
         /// </summary>
         /// <param name="request">The request.</param>
         /// <param name="requestContainer">The dependency injection container for the request.</param>
+        /// <param name="baseUri">The base uri.</param>
         /// <returns>A task object that produces an <see cref="ODataMessageReader"/> when completed.</returns>
-        public static ODataMessageReader GetODataMessageReader(this HttpRequest request, IServiceProvider requestContainer)
+        public static ODataMessageReader GetODataMessageReader(this HttpRequest request, IServiceProvider requestContainer, Uri baseUri = null)
         {
             if (request == null)
             {
@@ -51,7 +52,14 @@ namespace Microsoft.AspNet.OData.Batch
             }
 
             IODataRequestMessage oDataRequestMessage = ODataMessageWrapperHelper.Create(request.Body, request.Headers, requestContainer);
-            ODataMessageReaderSettings settings = requestContainer.GetRequiredService<ODataMessageReaderSettings>();
+
+            // Let's clone the reader setting every time to reset the base uri.
+            ODataMessageReaderSettings settings = requestContainer.GetRequiredService<ODataMessageReaderSettings>().Clone();
+            if (baseUri != null)
+            {
+                settings.BaseUri = baseUri;
+            }
+
             ODataMessageReader oDataMessageReader = new ODataMessageReader(oDataRequestMessage, settings);
             return oDataMessageReader;
         }

--- a/src/Microsoft.AspNetCore.OData/Batch/UnbufferedODataBatchHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/UnbufferedODataBatchHandler.cs
@@ -43,9 +43,9 @@ namespace Microsoft.AspNet.OData.Batch
             // This container is for the overall batch request.
             HttpRequest request = context.Request;
             IServiceProvider requestContainer = request.CreateRequestContainer(ODataRouteName);
-            requestContainer.GetRequiredService<ODataMessageReaderSettings>().BaseUri = GetBaseUri(request);
+            Uri baseUri = GetBaseUri(request);
 
-            ODataMessageReader reader = request.GetODataMessageReader(requestContainer);
+            ODataMessageReader reader = request.GetODataMessageReader(requestContainer, baseUri);
 
             ODataBatchReader batchReader = await reader.CreateODataBatchReaderAsync();
             List<ODataBatchResponseItem> responses = new List<ODataBatchResponseItem>();

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -789,7 +789,7 @@ public sealed class Microsoft.AspNet.OData.Batch.HttpRequestExtensions {
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.OData.ODataMessageReader GetODataMessageReader (Microsoft.AspNetCore.Http.HttpRequest request, System.IServiceProvider requestContainer)
+	public static Microsoft.OData.ODataMessageReader GetODataMessageReader (Microsoft.AspNetCore.Http.HttpRequest request, System.IServiceProvider requestContainer, params System.Uri baseUri)
 
 	[
 	ExtensionAttribute(),


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #7.x.*

### Description

* In normal request, we reset the baseUri and other properties in ReaderSettings
* In $batch request, we also reset the baseUri in ReaderSettings.

So, in concurrency requests, the readersettings.baseUri imfact each others.
Let's clone the setting if we want to reset the properties.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
