### PR TITLE
Fix routing error with attribute routing when action parameters don't match route keys

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Interfaces/IWebApiActionDescriptor.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Interfaces/IWebApiActionDescriptor.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Microsoft.AspNet.OData.Interfaces
 {
@@ -37,6 +38,12 @@ namespace Microsoft.AspNet.OData.Interfaces
         /// <param name="inherit">true to search this action's inheritance chain to find the attributes; otherwise, false.</param>
         /// <returns>A list of attributes of type T.</returns>
         IEnumerable<T> GetCustomAttributes<T>(bool inherit) where T : Attribute;
+
+        /// <summary>
+        /// Returns the <see cref="MethodInfo"/> representing the controller action.
+        /// </summary>
+        /// <returns>The <see cref="MethodInfo"/> representing the controller action.</returns>
+        MethodInfo GetMethodInfo();
 
         /// <summary>
         /// Determine if the Http method is a match.

--- a/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/AttributeRoutingConvention.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Routing/Conventions/AttributeRoutingConvention.cs
@@ -59,6 +59,9 @@ namespace Microsoft.AspNet.OData.Routing.Conventions
                 if (action.IsHttpMethodSupported(request.GetRequestMethodOrPreflightMethod()) && template.TryMatch(odataPath, values))
                 {
                     values["action"] = action.ActionName;
+                    // store the method info to allow the action selector to distinguish
+                    // between this action and other overloads
+                    values[ODataRouteConstants.MethodInfo] = action.GetMethodInfo();
                     SelectControllerResult result = new SelectControllerResult(action.ControllerName, values);
 
                     return result;

--- a/src/Microsoft.AspNet.OData.Shared/Routing/ODataRouteConstants.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Routing/ODataRouteConstants.cs
@@ -38,6 +38,11 @@ namespace Microsoft.AspNet.OData.Routing
         public static readonly string Action = "action";
 
         /// <summary>
+        /// Route data key for the <see cref="System.Reflection.MethodInfo"/> representing a controller action.
+        /// </summary>
+        public static readonly string MethodInfo = "methodInfo";
+
+        /// <summary>
         /// Route data key for the controller name.
         /// </summary>
         public static readonly string Controller = "controller";

--- a/src/Microsoft.AspNet.OData/Adapters/WebApiActionDescriptor.cs
+++ b/src/Microsoft.AspNet.OData/Adapters/WebApiActionDescriptor.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Reflection;
 using System.Web.Http.Controllers;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Interfaces;
@@ -87,6 +88,17 @@ namespace Microsoft.AspNet.OData.Adapters
         public IEnumerable<T> GetCustomAttributes<T>(bool inherit) where T : Attribute
         {
             return this.innerDescriptor.GetCustomAttributes<T>(inherit);
+        }
+
+        /// <inheritdoc/>
+        public MethodInfo GetMethodInfo()
+        {
+            if (this.innerDescriptor is ReflectedHttpActionDescriptor actionDescriptor)
+            {
+                return actionDescriptor.MethodInfo;
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData/Routing/ODataActionSelector.cs
+++ b/src/Microsoft.AspNet.OData/Routing/ODataActionSelector.cs
@@ -119,6 +119,13 @@ namespace Microsoft.AspNet.OData.Routing
 
         private static bool ActionParametersMatchRequest(HttpActionDescriptor action, HttpControllerContext context)
         {
+            // if attribute routing was used, accept the method
+            // regardless of parameters
+            if (action.GetCustomAttributes<ODataRouteAttribute>().Any())
+            {
+                return true;
+            }
+
             var parameters = action.GetParameters();
             var routeData = context.RouteData;
             var routingConventionsStore = context.Request.ODataProperties().RoutingConventionsStore;

--- a/src/Microsoft.AspNetCore.OData/Adapters/WebApiActionDescriptor.cs
+++ b/src/Microsoft.AspNetCore.OData/Adapters/WebApiActionDescriptor.cs
@@ -119,6 +119,13 @@ namespace Microsoft.AspNet.OData.Adapters
             return this.innerDescriptor.MethodInfo.GetCustomAttributes<T>(inherit);
         }
 
+        /// <inheritdoc/>
+        public MethodInfo GetMethodInfo()
+        {
+            return this.innerDescriptor.MethodInfo;
+        }
+
+
         /// <summary>
         /// Determine if the Http method is a match.
         /// </summary>

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
@@ -249,7 +249,6 @@ namespace Microsoft.AspNet.OData.Routing
                     }
                 }
 
-
                 // if action has [EnableNestedPaths] attribute, then it doesn't
                 // need to match parameters, since this action is expected to
                 // match arbitrarily nested paths even if it doesn't have any parameters

--- a/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
+++ b/src/Microsoft.AspNetCore.OData/Routing/ODataActionSelector.cs
@@ -186,7 +186,7 @@ namespace Microsoft.AspNet.OData.Routing
                         return bestCandidate.ActionDescriptor;
                     }
 
-                    // prioritize actions which explicitly declare the request method
+                    // Next in priority, actions which explicitly declare the request method
                     // e.g. using [AcceptVerbs("POST")], [HttpPost], etc.
                     bestCandidate = matchedCandidates.FirstOrDefault(candidate =>
                         ActionAcceptsMethod(candidate.ActionDescriptor as ControllerActionDescriptor, context.HttpContext.Request.Method));

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingModel.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingModel.cs
@@ -399,6 +399,7 @@ namespace Microsoft.AspNet.OData.Test.Routing
         {
             public int ID { get; set; }
             public string Name { get; set; }
+            public List<Product> Products { get; set; }
         }
 
         public class NestedPathsCustomer

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingTest.cs
@@ -1000,6 +1000,15 @@ namespace Microsoft.AspNet.OData.Test.Routing
             return $"Get({key})";
         }
 
+#if NETCORE
+        //NOTE: This overload is excluded in NET FX tests because
+        // the ODataActionSelector in in ASP.NET classic does
+        // not have much control in deciding which overload
+        // gets selected among a list of potential candidates
+        // and therefore it cannot prioritize
+        // an overload based on the fact that it has the ODataRoute
+        // attribute
+
         // the route AttributeCustomers(custId)/Products(prodId)
         // should not reach this action despite that its parameters
         // match the route. Priority goes to the action with
@@ -1008,6 +1017,7 @@ namespace Microsoft.AspNet.OData.Test.Routing
         {
             return $"GetProductWithConvention({custId}, {prodId})";
         }
+#endif
 
         // the route AttributeCustomers(custId)/Products(prodId)
         // should be handled by this action despite the fact that

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingTest.cs
@@ -314,6 +314,8 @@ namespace Microsoft.AspNet.OData.Test.Routing
                     // test [ODataRoute] works correctly for overloaded actions
                     { "GET", "AttributeCustomers", "Get()" },
                     { "GET", "AttributeCustomers(10)", "Get(10)" },
+                    // test [ODataROute] works regardless of action parameters
+                    { "GET", "AttributeCustomers(10)/Products(20)", "GetProductWithAttributeRouting()" },
 
 #if NETCORE // TODO enable these scenarios for NETFX when support added for AspNet classic
                     // test nested paths when there are no user-defined actions that override the [EnableNestedPaths] action
@@ -996,6 +998,26 @@ namespace Microsoft.AspNet.OData.Test.Routing
         public string Get(int key)
         {
             return $"Get({key})";
+        }
+
+        // the route AttributeCustomers(custId)/Products(prodId)
+        // should not reach this action despite that its parameters
+        // match the route. Priority goes to the action with
+        // using attribute routing
+        public string GetProduct(int custId, int prodId)
+        {
+            return $"GetProductWithConvention({custId}, {prodId})";
+        }
+
+        // the route AttributeCustomers(custId)/Products(prodId)
+        // should be handled by this action despite the fact that
+        // parameters don't match the route keys.
+        // Since attribute routing is explicit, we assume the user
+        // knows exactly what they want
+        [ODataRoute("AttributeCustomers({custId})/Products({prodId})")]
+        public string GetProduct()
+        {
+            return $"GetProductWithAttributeRouting()";
         }
     }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -2927,6 +2927,7 @@ public sealed class Microsoft.AspNet.OData.Routing.ODataRouteConstants {
 	public static readonly string DynamicProperty = "dynamicProperty"
 	public static readonly string Key = "key"
 	public static readonly string KeyCount = "ODataRouteKeyCount"
+	public static readonly string MethodInfo = "methodInfo"
 	public static readonly string NavigationProperty = "navigationProperty"
 	public static readonly string ODataPath = "odataPath"
 	public static readonly string ODataPathTemplate = "{*odataPath}"

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ODataActionSelectorTestHelper.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ODataActionSelectorTestHelper.cs
@@ -134,7 +134,10 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
             foreach (var keyValuePair in routeDataValues)
             {
                 routeData.Values[keyValuePair.Key] = keyValuePair.Value;
-                keyCount++;
+                if (keyValuePair.Key != ODataRouteConstants.MethodInfo)
+                {
+                    keyCount++;
+                }
             }
 
             routingConventionsStore[ODataRouteConstants.KeyCount] = keyCount;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -3150,6 +3150,7 @@ public sealed class Microsoft.AspNet.OData.Routing.ODataRouteConstants {
 	public static readonly string DynamicProperty = "dynamicProperty"
 	public static readonly string Key = "key"
 	public static readonly string KeyCount = "ODataRouteKeyCount"
+	public static readonly string MethodInfo = "methodInfo"
 	public static readonly string NavigationProperty = "navigationProperty"
 	public static readonly string ODataPath = "odataPath"
 	public static readonly string ODataPathTemplate = "{*odataPath}"

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -3349,6 +3349,7 @@ public sealed class Microsoft.AspNet.OData.Routing.ODataRouteConstants {
 	public static readonly string DynamicProperty = "dynamicProperty"
 	public static readonly string Key = "key"
 	public static readonly string KeyCount = "ODataRouteKeyCount"
+	public static readonly string MethodInfo = "methodInfo"
 	public static readonly string NavigationProperty = "navigationProperty"
 	public static readonly string ODataPath = "odataPath"
 	public static readonly string ODataPathTemplate = "{*odataPath}"

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Routing/ODataActionSelectorTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Routing/ODataActionSelectorTest.cs
@@ -172,6 +172,15 @@ namespace Microsoft.AspNet.OData.Test.Routing
                         ("PATCH", "{}"),
                         (typeof(ExtraParametersWithOwnModelBindersController), "Patch",
                         new[] { typeof(int), typeof(System.Threading.CancellationToken), typeof(Delta<object>) })
+                    },
+                    // exact method is specicified in route values (i.e. via attribute routing)
+                    {
+                        new Dictionary<string, object> {
+                            { "key", 1 },
+                            { "methodInfo", typeof(ExactMethodInfoController).GetMethod("Get", Type.EmptyTypes) }
+                        },
+                        ("GET", null),
+                        (typeof(ExactMethodInfoController), "Get", Type.EmptyTypes)
                     }
                 };
             }
@@ -323,6 +332,13 @@ namespace Microsoft.AspNet.OData.Test.Routing
     {
         public void Get(int key, UnknownModel other) { }
         public void Patch(int key, UnknownModel other, Delta<object> delta) { }
+    }
+
+    public class ExactMethodInfoController
+    {
+        [ODataRoute("Customers({key})")]
+        public void Get() { }
+        public void Get(int key) { }
     }
 
     public class UnknownModel { }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* Fixes #2534 

### Description

*Briefly describe the changes of this pull request.*

In brief this PR makes the following changes:
- Selects action annotated with `[ODataRoute]` regardless of its parameters (by passing the `MethodInfo` to the action selector)
- Ensures that the action with `[ODataRoute]` is selected in case of other candidate overloads

Below I share more context behind the changes in this PR:

### Context behind the changes

The `ODataActionSelector` has become strict when deciding which controller action will handle the request. In particular, it tries to ensure that the parameters of the controller action match the keys in the route/URL. The reason for this is to disambiguate between different overloads and to avoid sending the request to the wrong overload.

However, the increase in "strictness" over a number of PR has led some scenarios to fail, specifically when the user intentionally creates controller actions whose parameters don't match the keys in the route. This PR addresses this issue by ignoring the parameter matching constraints when the action was selected via attribute routing (i.e. using `ODataRoute` attribute).

The main issue that has made `ODataActionSelector` complex and brittle is the fact that it doesn't receive enough information to disambiguate between overloads in a simple way. Since attribute routing can figure out exactly which method to route to before it even reaches the action selector, I've pass this method (via its `MethodInfo` object) down to the `ODataActionSelector` so it doesn't have to do much additional work, and to make it more resilient to edge cases.

With this change in place, we can guarantee that when using `ODataRoute` attribute, the action will be selected regardless of its parameters. We assume that the user knows exactly what they want and we don't try to verify whether the parameters make sense.

This is however not enough to allow the action selector to disambiguate between overloads. The routing conventions return a list of potential action descriptors, which are usually overloads with the same name. This is also the case with `AttributeRoutingConvention`: even if the `ODataRoute` attribute is applied to a single action, the routing convention will return all actions with the same name. Let's take the following example:

```c#
public class CustomersController
{
   [ODataRoute("Customers({custId})/Products({prodId})"]
   public IActionResult GetProduct([ModelBinder] RequestData data)  { /*  ... */ }

   public IActionResult GetProduct(int custId, int prodId) { /*  ... */ }
}
```
The request `GET /Customers(10)/Products(2)` should go to the `GetProduct(RequestData)` method because it's explicitly annotated with `ODataRoute`. 

However what would happen is that the `AttributeRoutingConvention` will indeed match `GetProduct(RequestData)` action with the route. But it will return a list containing both actions. This is due to the design of routing conventions and the way it tries to reuse some logic between AspNet classic and AspNetCore: most routing conventions have 2 partial classes, one is framework agnostic that returns only the name of the selection (as a string) (via the `SelectActionImpl` method) and the other is a framework-specific class that takes this action name received from the framework-agnostic class and returns a list of framework-specific action descriptors that match that name.

Now `ODataActionSelector` will receive both actions and have to figure out which to return (this happens inside the `SelectBestCandidate` method). Before this PR, it would return the action `GetProduct(custId, prodId)` because it has more parameters and its parameters more closely match the route keys. But I've added a step to prioritize actions that have `[ODataRoute]` over actions that do not.


### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
