### PR TITLE
Fix pull request template such that referenced issue is linked and closed after pull request is merged

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 ### Issues
 
-*This pull request fixes issue #xxx.*
+*This pull request fixes #xxx.*
 
 ### Description
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Fix pull request template such that referenced issue is linked and closed after pull request is merged

### Description

Change ***This pull request fixes issue #xxx.*** to ***This pull request fixes #xxx.***

When you use the first form, the reference issue in not automatically linked such that when you merge the pull request, it's not auto-closed. The reason for that is the word "issue" between "fixes" and the issue #. [GitHub guideline on link a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
