### PR TITLE
Consider the OperationSegment when determining the TargetStructuredType

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ClrTypeCache.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ClrTypeCache.cs
@@ -71,8 +71,15 @@ namespace Microsoft.AspNet.OData.Formatter
 
             public int GetHashCode(EdmTypeCacheItem obj)
             {
-                string combined = $"{obj.EdmType.FullTypeName()}~{obj.Nullable}";
-                return combined.GetHashCode();
+                unchecked
+                {
+                    int hashCode = 17;
+                    hashCode = (hashCode * 31) + obj.EdmType.FullTypeName().GetHashCode(); // Ideally we'd avoid FullTypeName since it
+                                                                                           // allocates internally, but we cannot trust
+                                                                                           // EdmType.GetHashCode().
+                    hashCode = (hashCode * 31) + (obj.Nullable ? 1 : 0);
+                    return hashCode;
+                }
             }
         }
     }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ClrTypeCache.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ClrTypeCache.cs
@@ -74,10 +74,8 @@ namespace Microsoft.AspNet.OData.Formatter
                 unchecked
                 {
                     int hashCode = 17;
-                    hashCode = (hashCode * 31) + obj.EdmType.FullTypeName().GetHashCode(); // Ideally we'd avoid FullTypeName since it
-                                                                                           // allocates internally, but we cannot trust
-                                                                                           // EdmType.GetHashCode().
-                    hashCode = (hashCode * 31) + (obj.Nullable ? 1 : 0);
+                    hashCode = (hashCode * 31) + obj.EdmType.GetHashCode();
+                    hashCode = (hashCode * 31) + obj.Nullable.GetHashCode();
                     return hashCode;
                 }
             }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
@@ -637,15 +637,16 @@ namespace Microsoft.AspNet.OData.Formatter
         {
             property = null;
             structuredType = null;
-            name = String.Empty;
-            string typeCast = String.Empty;
+            name = string.Empty;
+
             if (segments != null)
             {
+                string typeCast = string.Empty;
+
                 IEnumerable<ODataPathSegment> reverseSegments = segments.Reverse();
-                foreach (var segment in reverseSegments)
+                foreach (ODataPathSegment segment in reverseSegments)
                 {
-                    NavigationPropertySegment navigationPathSegment = segment as NavigationPropertySegment;
-                    if (navigationPathSegment != null)
+                    if (segment is NavigationPropertySegment navigationPathSegment)
                     {
                         property = navigationPathSegment.NavigationProperty;
                         if (structuredType == null)
@@ -659,42 +660,39 @@ namespace Microsoft.AspNet.OData.Formatter
 
                     if (segment is OperationSegment operationSegment)
                     {
-                        IEdmFunction function = operationSegment.Operations.SingleOrDefault() as IEdmFunction;
-                        if (function != null &&
-                            function.ReturnType.Definition is IEdmStructuredType functionReturnType)
+                        if (structuredType == null)
                         {
-                            name = null;
-                            property = null;
-                            structuredType = functionReturnType;
-                            return;
+                            structuredType = operationSegment.EdmType as IEdmStructuredType;
                         }
+
+                        name = operationSegment.Operations.First().FullName() + typeCast;
+                        return;
                     }
 
-                    PropertySegment propertyAccessPathSegment = segment as PropertySegment;
-                    if (propertyAccessPathSegment != null)
+                    if (segment is PropertySegment propertyAccessPathSegment)
                     {
                         property = propertyAccessPathSegment.Property;
                         if (structuredType == null)
                         {
                             structuredType = GetElementType(property.Type) as IEdmStructuredType;
                         }
+
                         name = property.Name + typeCast;
                         return;
                     }
 
-                    EntitySetSegment entitySetSegment = segment as EntitySetSegment;
-                    if (entitySetSegment != null)
+                    if (segment is EntitySetSegment entitySetSegment)
                     {
                         if (structuredType == null)
                         {
                             structuredType = entitySetSegment.EntitySet.EntityType();
                         }
+
                         name = entitySetSegment.EntitySet.Name + typeCast;
                         return;
                     }
 
-                    TypeSegment typeSegment = segment as TypeSegment;
-                    if (typeSegment != null)
+                    if (segment is TypeSegment typeSegment)
                     {
                         structuredType = GetElementType(typeSegment.EdmType.ToEdmTypeReference(false)) as IEdmStructuredType;
                         typeCast = "/" + structuredType;

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/EdmLibHelpers.cs
@@ -629,8 +629,11 @@ namespace Microsoft.AspNet.OData.Formatter
             return edmTypeReference.Definition;
         }
 
-        public static void GetPropertyAndStructuredTypeFromPath(IEnumerable<ODataPathSegment> segments,
-            out IEdmProperty property, out IEdmStructuredType structuredType, out string name)
+        public static void GetPropertyAndStructuredTypeFromPath(
+            IEnumerable<ODataPathSegment> segments,
+            out IEdmProperty property,
+            out IEdmStructuredType structuredType,
+            out string name)
         {
             property = null;
             structuredType = null;
@@ -652,6 +655,19 @@ namespace Microsoft.AspNet.OData.Formatter
 
                         name = navigationPathSegment.NavigationProperty.Name + typeCast;
                         return;
+                    }
+
+                    if (segment is OperationSegment operationSegment)
+                    {
+                        IEdmFunction function = operationSegment.Operations.SingleOrDefault() as IEdmFunction;
+                        if (function != null &&
+                            function.ReturnType.Definition is IEdmStructuredType functionReturnType)
+                        {
+                            name = null;
+                            property = null;
+                            structuredType = functionReturnType;
+                            return;
+                        }
                     }
 
                     PropertySegment propertyAccessPathSegment = segment as PropertySegment;

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/EnableQueryTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/EnableQueryTests.cs
@@ -5,6 +5,23 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+#if NETCORE
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Query;
+using Microsoft.AspNet.OData.Test.Abstraction;
+using Microsoft.AspNet.OData.Test.Common;
+using Microsoft.OData.Edm;
+using Xunit;
+#else
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,6 +37,7 @@ using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
 using Microsoft.OData.Edm;
 using Xunit;
+#endif
 
 namespace Microsoft.AspNet.OData.Test
 {
@@ -522,7 +540,7 @@ namespace Microsoft.AspNet.OData.Test
             {
                 response = await client.PostAsync(
                     baseUrl + "GetCategoryViaAction" + (includeQueryString ? "?a=b" : ""),
-                    new StringContent("{\"id\":1}", Encoding.ASCII, "application/json"));
+                    new StringContent("{\"id\":1}", Encoding.UTF8, "application/json"));
             }
             else
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Fixes https://github.com/OData/WebApi/issues/1610

### Description

If you have an auto-expanded property on an object:
```
public class A
{
  [AutoExpand]
  public B B { get; set; }
}
```
And a function `F` bound to `A` that returns type `C`, the auto-expand logic incorrectly attempts to expand `B` on `C` if a (any) query string is provided:
```
GET .../A/F?a=b

The query specified in the URI is not valid. Could not find a property named 'B' on type 'C'.
```
Since the fix appeared to be pretty straight forward (make sure `OperationSegment` is handled in the path when trying to determine the `TargetStructuredType`) I've decided to push this PR.

NOTE: I'm also fixing a couple of bonus issues
1. There's a bug whereby the existing `EnableQuery_Works_WithAutoExpand` test wasn't validating auto-expand because `EnableQueryCategory` was not being registered as an `EntityType`.
2. VisualStudio complained about the string interpolation in `EdmTypeCacheItemComparer.GetHashCode`, but methods used for comparisons (e.g. `Equals` and `GetHashCode`) should NOT allocate so I rewrote it to use a hash combining algorithm instead.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
