### PR TITLE
TryGetPropertyValue on a nested ComplexType returns T, should be Delta<T>

### DIFF
--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/OpenComplexTypeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/OpenComplexTypeTest.cs
@@ -603,6 +603,17 @@ namespace Microsoft.AspNet.OData.Test
                     // Nested complex property
                     Assert.NotNull(lineA.PhoneInfo);
                     Assert.Equal(7654321, lineA.PhoneInfo.PhoneNumber);
+
+                    object nestedLineAValue;
+                    // Fetch LineA property using TryGetNestedPropertyValue
+                    Assert.True(address.TryGetNestedPropertyValue("LineA", out nestedLineAValue));
+                    Delta<LineDetails> deltaLineA = nestedLineAValue as Delta<LineDetails>;
+                    Assert.NotNull(deltaLineA);
+
+                    // Nested complex property
+                    dynamic nestedLineA = deltaLineA;
+                    Assert.NotNull(nestedLineA.PhoneInfo);
+                    Assert.Equal(7654321, nestedLineA.PhoneInfo.PhoneNumber);
                     break;
                 default:
                     // Error

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -270,6 +270,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
 	public void Patch (TStructuralType original)
 	public void Put (TStructuralType original)
+	public bool TryGetNestedPropertyValue (string name, out System.Object& value)
 	public virtual bool TryGetPropertyType (string name, out System.Type& type)
 	public virtual bool TryGetPropertyValue (string name, out System.Object& value)
 	public virtual bool TrySetPropertyValue (string name, object value)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -285,6 +285,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
 	public void Patch (TStructuralType original)
 	public void Put (TStructuralType original)
+	public bool TryGetNestedPropertyValue (string name, out System.Object& value)
 	public virtual bool TryGetPropertyType (string name, out System.Type& type)
 	public virtual bool TryGetPropertyValue (string name, out System.Object& value)
 	public virtual bool TrySetPropertyValue (string name, object value)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -289,6 +289,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
 	public void Patch (TStructuralType original)
 	public void Put (TStructuralType original)
+	public bool TryGetNestedPropertyValue (string name, out System.Object& value)
 	public virtual bool TryGetPropertyType (string name, out System.Type& type)
 	public virtual bool TryGetPropertyValue (string name, out System.Object& value)
 	public virtual bool TrySetPropertyValue (string name, object value)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2500.*

### Description

As discussed in the issue, fix `TrySetPropertyValue` to return `Delta<T>` when a nested complex property.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

**Docs Needed**


In addition to the functionality changes the following was also done:

- The Delta code in OData/WebAPI and OData/AspNetCoreOData are almost identical in functionality but have minor differences that show slow divergence.
- Minor code changes made to versions of DeltaOfT*.cs to bring back to being as close as possible.
- In addition to the tests added for this functionality change, ported all (DeltaTests) tests in OData/AspNetCoreOData missing from WebAPI.
- Minor code changes made to versions of DeltaTests.cs to bring back to being as close as possible.