### PR TITLE
Fixing Patching Complex type when using one derived type over another

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
@@ -45,11 +45,6 @@ namespace Microsoft.AspNet.OData
         private IDictionary<string, object> _dynamicDictionaryCache;
 
         /// <summary>
-        /// To determine if the StructuralType is a Complex type
-        /// </summary>
-        public bool IsComplexType { get; private set; }
-
-        /// <summary>
         /// Initializes a new instance of <see cref="Delta{TStructuralType}"/>.
         /// </summary>
         public Delta()
@@ -135,6 +130,11 @@ namespace Microsoft.AspNet.OData
         /// considered to be changed.</remarks>
         public IList<string> UpdatableProperties
             => _updatableProperties;
+
+        /// <summary>
+        /// To determine if the StructuralType is a Complex type
+        /// </summary>
+        public bool IsComplexType { get; private set; }
 
         /// <inheritdoc/>
         public override void Clear()

--- a/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
@@ -407,6 +407,8 @@ namespace Microsoft.AspNet.OData
 
                     break;
                 }
+
+                originalBaseType = originalBaseType.BaseType;
             }
 
             if (foundCommonbase)

--- a/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
@@ -396,7 +396,7 @@ namespace Microsoft.AspNet.OData
             //We will keep  going to base types and finally will get the Common Basetype for the derived complex types in to the originalType variable.
             
             //The new Original type, means the new complex type (T) which will replace the current complex type.
-            dynamic newOriginalNestedResource = null;
+            dynamic newOriginalNestedResource = originalValue;
 
             while (originalType != null)
             {

--- a/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
@@ -364,7 +364,7 @@ namespace Microsoft.AspNet.OData
                     Type newType = deltaNestedResource.StructuredType;
                     Type originalType = originalNestedResource.GetType();
 
-                    if (deltaNestedResource.IsComplexType && !newType.IsAssignableFrom(originalType))
+                    if (deltaNestedResource.IsComplexType && newType != originalType)
                     {
                         originalNestedResource = ReAssignComplexDerivedType(original, nestedResourceName, originalNestedResource, newType, originalType, deltaNestedResource.ExpectedClrType);
                     }
@@ -380,7 +380,7 @@ namespace Microsoft.AspNet.OData
             //is declared in terms of a common ancestor. The logic below checks for a common ancestor. Create a new object of the derived type in delta request.
             //And copy the common properties.
 
-            Type newBaseType = newType.BaseType;
+            Type newBaseType = newType;
             HashSet<Type> newBaseTypes = new HashSet<Type>();
 
             //Iterate till you find the declaring base type and add all that to hashset

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -235,11 +235,11 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                             structuredType.StructuredDefinition(), model);
 
                         return Activator.CreateInstance(readContext.ResourceType, clrType, structuralProperties,
-                            dynamicDictionaryPropertyInfo);
+                            dynamicDictionaryPropertyInfo, structuredType.IsComplex());
                     }
                     else
                     {
-                        return Activator.CreateInstance(readContext.ResourceType, clrType, structuralProperties);
+                        return Activator.CreateInstance(readContext.ResourceType, clrType, structuralProperties, null, structuredType.IsComplex());
                     }
                 }
                 else

--- a/src/Microsoft.AspNet.OData/GlobalSuppressions.cs
+++ b/src/Microsoft.AspNet.OData/GlobalSuppressions.cs
@@ -65,3 +65,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Scope = "member", Target = "Microsoft.AspNet.OData.Builder.IODataInstanceAnnotationContainer.#GetAllResourceAnnotations()")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Scope = "member", Target = "Microsoft.AspNet.OData.Builder.IODataInstanceAnnotationContainer.#GetResourceAnnotations()")]
 [assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "Microsoft.AspNet.OData.Common.Error.#PropertyNullOrWhiteSpace()")]
+[assembly: SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Scope = "member", Target = "Microsoft.AspNet.OData.Delta`1.#CopyChangedValues(!0)")]

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceTests.cs
@@ -332,7 +332,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance
         [InlineData("convention")]
         [InlineData("explicit")]
         // Patch ~/Widnows(3)
-        public async Task PatchContainingEntity_MismatchedRuntimeTypeError(string modelMode)
+        public async Task PatchContainingEntity_Matched_DerivedType(string modelMode)
         {
             string serviceRootUri = string.Format("{0}/{1}", BaseAddress, modelMode).ToLower();
             string requestUri = serviceRootUri + "/Windows(3)";
@@ -356,7 +356,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance
             request.Content = stringContent;
             HttpResponseMessage response = await Client.SendAsync(request);
             string contentOfString = await response.Content.ReadAsStringAsync();
-            Assert.True(HttpStatusCode.BadRequest == response.StatusCode);
+            Assert.True(HttpStatusCode.OK == response.StatusCode);
         }
 
         [Theory]

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/DeltaTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/DeltaTests.cs
@@ -395,7 +395,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter
         [Fact]
         public async Task PatchShouldSupportNonSettableCollectionProperties()
         {
-            HttpRequestMessage patch = new HttpRequestMessage(new HttpMethod("MERGE"), BaseAddress + "/odata/DeltaCustomers(6)");
+            HttpRequestMessage patch = new HttpRequestMessage(new HttpMethod("PATCH"), BaseAddress + "/odata/DeltaCustomers(6)");
             dynamic data = new ExpandoObject();
             data.Addresses = Enumerable.Range(10, 3).Select(i => new DeltaAddress { ZipCode = i });
             string content = JsonConvert.SerializeObject(data);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/Conventions/ODataConventionModelBuilderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/Conventions/ODataConventionModelBuilderTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
 {
     public class ODataConventionModelBuilderTests
     {
-        private const int _totalExpectedSchemaTypesForVehiclesModel = 14;
+        private const int _totalExpectedSchemaTypesForVehiclesModel = 19;
 
         [Fact]
         public void Ctor_ThrowsForNullConfiguration()
@@ -619,7 +619,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             var motorcycle = model.AssertHasEntityType(typeof(Motorcycle));
             Assert.Equal(vehicle, motorcycle.BaseEntityType());
             Assert.Equal(2, motorcycle.Key().Count());
-            Assert.Equal(6, motorcycle.Properties().Count());
+            Assert.Equal(7, motorcycle.Properties().Count());
             motorcycle.AssertHasPrimitiveProperty(model, "CanDoAWheelie", EdmPrimitiveTypeKind.Boolean, isNullable: false);
             motorcycle.AssertHasNavigationProperty(model, "Manufacturer", typeof(MotorcycleManufacturer), isNullable: true, multiplicity: EdmMultiplicity.ZeroOrOne);
 
@@ -633,7 +633,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             var sportbike = model.AssertHasEntityType(typeof(SportBike));
             Assert.Equal(motorcycle, sportbike.BaseEntityType());
             Assert.Equal(2, sportbike.Key().Count());
-            Assert.Equal(6, sportbike.Properties().Count());
+            Assert.Equal(7, sportbike.Properties().Count());
 
             model.AssertHasEntityType(typeof(MotorcycleManufacturer));
             model.AssertHasEntityType(typeof(CarManufacturer));
@@ -662,7 +662,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             IEdmModel model = builder.GetEdmModel();
 
             // ignore motorcycle, sportbike and MotorcycleManufacturer
-            Assert.Equal(_totalExpectedSchemaTypesForVehiclesModel - 7, model.SchemaElements.Count());
+            Assert.Equal(_totalExpectedSchemaTypesForVehiclesModel - 12, model.SchemaElements.Count());
             Assert.Single(model.EntityContainer.EntitySets());
             model.AssertHasEntitySet("Vehicles", typeof(Vehicle));
 
@@ -712,7 +712,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             var sportbike = model.AssertHasEntityType(typeof(SportBike));
             Assert.Equal(vehicle, sportbike.BaseEntityType());
             Assert.Equal(2, sportbike.Key().Count());
-            Assert.Equal(6, sportbike.Properties().Count());
+            Assert.Equal(7, sportbike.Properties().Count());
             sportbike.AssertHasNavigationProperty(model, "Manufacturer", typeof(MotorcycleManufacturer), isNullable: true, multiplicity: EdmMultiplicity.ZeroOrOne);
         }
 
@@ -768,7 +768,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             var motorcycle = model.AssertHasEntityType(typeof(Motorcycle));
             Assert.Null(motorcycle.BaseEntityType());
             Assert.Equal(2, motorcycle.Key().Count());
-            Assert.Equal(6, motorcycle.Properties().Count());
+            Assert.Equal(7, motorcycle.Properties().Count());
 
             var car = model.AssertHasEntityType(typeof(Car));
             Assert.Null(car.BaseEntityType());
@@ -778,7 +778,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             var sportbike = model.AssertHasEntityType(typeof(SportBike));
             Assert.Equal(motorcycle, sportbike.BaseEntityType());
             Assert.Equal(2, sportbike.Key().Count());
-            Assert.Equal(6, sportbike.Properties().Count());
+            Assert.Equal(7, sportbike.Properties().Count());
         }
 
         [Fact]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/Conventions/ODataConventionModelBuilderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/Conventions/ODataConventionModelBuilderTests.cs
@@ -662,7 +662,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             IEdmModel model = builder.GetEdmModel();
 
             // ignore motorcycle, sportbike and MotorcycleManufacturer
-            Assert.Equal(_totalExpectedSchemaTypesForVehiclesModel - 3, model.SchemaElements.Count());
+            Assert.Equal(_totalExpectedSchemaTypesForVehiclesModel - 7, model.SchemaElements.Count());
             Assert.Single(model.EntityContainer.EntitySets());
             model.AssertHasEntitySet("Vehicles", typeof(Vehicle));
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/Conventions/ODataConventionModelBuilderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/Conventions/ODataConventionModelBuilderTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
 {
     public class ODataConventionModelBuilderTests
     {
-        private const int _totalExpectedSchemaTypesForVehiclesModel = 10;
+        private const int _totalExpectedSchemaTypesForVehiclesModel = 14;
 
         [Fact]
         public void Ctor_ThrowsForNullConfiguration()
@@ -619,7 +619,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             var motorcycle = model.AssertHasEntityType(typeof(Motorcycle));
             Assert.Equal(vehicle, motorcycle.BaseEntityType());
             Assert.Equal(2, motorcycle.Key().Count());
-            Assert.Equal(5, motorcycle.Properties().Count());
+            Assert.Equal(6, motorcycle.Properties().Count());
             motorcycle.AssertHasPrimitiveProperty(model, "CanDoAWheelie", EdmPrimitiveTypeKind.Boolean, isNullable: false);
             motorcycle.AssertHasNavigationProperty(model, "Manufacturer", typeof(MotorcycleManufacturer), isNullable: true, multiplicity: EdmMultiplicity.ZeroOrOne);
 
@@ -633,7 +633,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             var sportbike = model.AssertHasEntityType(typeof(SportBike));
             Assert.Equal(motorcycle, sportbike.BaseEntityType());
             Assert.Equal(2, sportbike.Key().Count());
-            Assert.Equal(5, sportbike.Properties().Count());
+            Assert.Equal(6, sportbike.Properties().Count());
 
             model.AssertHasEntityType(typeof(MotorcycleManufacturer));
             model.AssertHasEntityType(typeof(CarManufacturer));
@@ -712,7 +712,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             var sportbike = model.AssertHasEntityType(typeof(SportBike));
             Assert.Equal(vehicle, sportbike.BaseEntityType());
             Assert.Equal(2, sportbike.Key().Count());
-            Assert.Equal(5, sportbike.Properties().Count());
+            Assert.Equal(6, sportbike.Properties().Count());
             sportbike.AssertHasNavigationProperty(model, "Manufacturer", typeof(MotorcycleManufacturer), isNullable: true, multiplicity: EdmMultiplicity.ZeroOrOne);
         }
 
@@ -768,7 +768,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             var motorcycle = model.AssertHasEntityType(typeof(Motorcycle));
             Assert.Null(motorcycle.BaseEntityType());
             Assert.Equal(2, motorcycle.Key().Count());
-            Assert.Equal(5, motorcycle.Properties().Count());
+            Assert.Equal(6, motorcycle.Properties().Count());
 
             var car = model.AssertHasEntityType(typeof(Car));
             Assert.Null(car.BaseEntityType());
@@ -778,7 +778,7 @@ namespace Microsoft.AspNet.OData.Test.Builder.Conventions
             var sportbike = model.AssertHasEntityType(typeof(SportBike));
             Assert.Equal(motorcycle, sportbike.BaseEntityType());
             Assert.Equal(2, sportbike.Key().Count());
-            Assert.Equal(5, sportbike.Properties().Count());
+            Assert.Equal(6, sportbike.Properties().Count());
         }
 
         [Fact]

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/TestModels/InheritanceModels.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/TestModels/InheritanceModels.cs
@@ -54,6 +54,30 @@ namespace Microsoft.AspNet.OData.Test.Builder.TestModels
 
         [NotMapped]
         public IEnumerable<MotorcycleManufacturer> Manufacturers { get; set; }
+
+        public Engine MyEngine { get; set; }
+    }
+
+    public class Engine
+    {
+        public int Hp { get; set; }
+    }
+
+
+
+    public class V2: Engine
+    {
+
+    }
+
+    public class V4 : Engine
+    {
+
+    }
+
+    public class V41: V4
+    {
+        public string MakeName { get; set; }
     }
 
     public class SportBike : Motorcycle

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/TestModels/InheritanceModels.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/TestModels/InheritanceModels.cs
@@ -56,6 +56,8 @@ namespace Microsoft.AspNet.OData.Test.Builder.TestModels
         public IEnumerable<MotorcycleManufacturer> Manufacturers { get; set; }
 
         public Engine MyEngine { get; set; }
+
+        public V4 MyV4Engine { get; set; }
     }
 
     public class Engine
@@ -78,6 +80,16 @@ namespace Microsoft.AspNet.OData.Test.Builder.TestModels
     public class V41: V4
     {
         public string MakeName { get; set; }
+    }
+
+    public class V42 : V4
+    {
+        public string Model { get; set; }
+    }
+
+    public class V422 : V42
+    {
+        
     }
 
     public class SportBike : Motorcycle

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/TestModels/InheritanceModels.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Builder/TestModels/InheritanceModels.cs
@@ -58,11 +58,29 @@ namespace Microsoft.AspNet.OData.Test.Builder.TestModels
         public Engine MyEngine { get; set; }
 
         public V4 MyV4Engine { get; set; }
+
     }
 
     public class Engine
     {
         public int Hp { get; set; }
+
+        public Transmission Transmission { get; set; }
+    }
+
+    public class Transmission
+    {
+        public int Gears { get; set; }
+    }
+
+    public class Automatic: Transmission
+    {
+
+    }
+
+    public class Manual : Transmission
+    {
+
     }
 
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/InheritanceTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/InheritanceTests.cs
@@ -554,7 +554,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
 
             vehConfig.ComplexProperty(m => m.MyEngine);
             vehConfig.ComplexProperty(m => m.MyV4Engine);
-            builder.ComplexType<Engine>().ComplexProperty(m => m.Transmission);
+            builder.ComplexType<Engine>().ComplexProperty(m => m.Transmission).IsOptional();
                      
             builder.ComplexType<Engine>().Property(m => m.Hp);
             builder.ComplexType<Transmission>().Property(m => m.Gears);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/InheritanceTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/InheritanceTests.cs
@@ -234,6 +234,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             Assert.False((bool)result.CanDoAWheelie);
             Assert.Equal(4000, (int)result.MyEngine.Hp);
             Assert.Equal("Honda", result.MyEngine.MakeName.ToString());
+
+            Assert.Equal("#Microsoft.AspNet.OData.Test.Builder.TestModels.V41", result.MyEngine["@odata.type"].ToString());
         }
 
         [Fact]
@@ -257,6 +259,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             Assert.False((bool)result.CanDoAWheelie);
             Assert.Equal(4000, (int)result.MyEngine.Hp);
             Assert.Equal("Honda", result.MyEngine.MakeName.ToString());
+            Assert.Equal("#Microsoft.AspNet.OData.Test.Builder.TestModels.V41", result.MyEngine["@odata.type"].ToString());
 
             Assert.Equal(5000, (int)result.MyV4Engine.Hp);
             Assert.Equal("Hero", result.MyV4Engine.Model.ToString());
@@ -282,6 +285,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             dynamic result = JObject.Parse(await response.Content.ReadAsStringAsync());
             Assert.False((bool)result.CanDoAWheelie);
             Assert.Equal(4000, (int)result.MyEngine.Hp);
+            Assert.Equal("#Microsoft.AspNet.OData.Test.Builder.TestModels.V41", result.MyEngine["@odata.type"].ToString());
+
             Assert.Equal("Honda", result.MyEngine.MakeName.ToString());
             Assert.Equal(7000, (int)result.MyV4Engine.Hp);
         }
@@ -307,7 +312,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             dynamic result = JObject.Parse(await response.Content.ReadAsStringAsync());
             Assert.False((bool)result.CanDoAWheelie);
             Assert.Equal(6000, (int)result.MyEngine.Hp);
-            
+            Assert.Equal("#Microsoft.AspNet.OData.Test.Builder.TestModels.V4", result.MyEngine["@odata.type"].ToString());
+
             Assert.Equal(9000, (int)result.MyV4Engine.Hp);
         }
 
@@ -331,7 +337,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             dynamic result = JObject.Parse(await response.Content.ReadAsStringAsync());
             Assert.True((bool)result.CanDoAWheelie);
             Assert.Equal(6000, (int)result.MyEngine.Hp);
-
+            
+            Assert.Equal("#Microsoft.AspNet.OData.Test.Builder.TestModels.V422", result.MyEngine["@odata.type"].ToString());
             Assert.Equal(9000, (int)result.MyV4Engine.Hp);
         }
 
@@ -356,6 +363,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             dynamic result = JObject.Parse(await response.Content.ReadAsStringAsync());
             Assert.True((bool)result.CanDoAWheelie);
             Assert.Equal(6000, (int)result.MyEngine.Hp);
+            Assert.Equal("#Microsoft.AspNet.OData.Test.Builder.TestModels.V4", result.MyEngine["@odata.type"].ToString());
 
             Assert.Equal(9000, (int)result.MyV4Engine.Hp);
         }
@@ -380,6 +388,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             dynamic result = JObject.Parse(await response.Content.ReadAsStringAsync());
             Assert.True((bool)result.CanDoAWheelie);
             Assert.Equal(6000, (int)result.MyEngine.Hp);
+            Assert.Equal("#Microsoft.AspNet.OData.Test.Builder.TestModels.V422", result.MyEngine["@odata.type"].ToString());
 
             Assert.Equal(9000, (int)result.MyV4Engine.Hp);
         }
@@ -407,6 +416,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             Assert.True((bool)result.CanDoAWheelie);
             Assert.Equal(6000, (int)result.MyEngine.Hp);
             Assert.Equal(5, (int)result.MyEngine.Transmission.Gears);
+            Assert.Equal("#Microsoft.AspNet.OData.Test.Builder.TestModels.V2", result.MyEngine["@odata.type"].ToString());
 
             Assert.Equal(9000, (int)result.MyV4Engine.Hp);
         }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/InheritanceTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/InheritanceTests.cs
@@ -312,14 +312,63 @@ namespace Microsoft.AspNet.OData.Test.Formatter
         }
 
         [Fact]
+        public async Task Can_Patch_Entity_In_Inheritance_DerivedEngine_V42CurrentDefine_V422New()
+        {
+            // Arrange
+            HttpRequestMessage request = new HttpRequestMessage(new HttpMethod("PATCH"), "http://localhost/PatchMotorcycle_When_Expecting_Motorcycle_DerivedEngine42");
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            AddRequestInfo(request);
+            request.Content = new StringContent("{ 'CanDoAWheelie' : true, 'MyEngine' : {'@odata.type' : 'Microsoft.AspNet.OData.Test.Builder.TestModels.V422' ,'Hp':6000 }," +
+                "'MyV4Engine' : {'@odata.type' : 'Microsoft.AspNet.OData.Test.Builder.TestModels.V4' ,'Hp':9000 } }");
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+
+            // Act
+            HttpResponseMessage response = await _client.SendAsync(request);
+
+            // Assert
+            ExceptionAssert.DoesNotThrow(() => response.EnsureSuccessStatusCode());
+
+            dynamic result = JObject.Parse(await response.Content.ReadAsStringAsync());
+            Assert.True((bool)result.CanDoAWheelie);
+            Assert.Equal(6000, (int)result.MyEngine.Hp);
+
+            Assert.Equal(9000, (int)result.MyV4Engine.Hp);
+        }
+
+
+        [Fact]
+        public async Task Can_Patch_Entity_In_Inheritance_DerivedEngine_V42CurrentDefine_V4New()
+        {
+            // Arrange
+            HttpRequestMessage request = new HttpRequestMessage(new HttpMethod("PATCH"), "http://localhost/PatchMotorcycle_When_Expecting_Motorcycle_DerivedEngine42");
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            AddRequestInfo(request);
+            request.Content = new StringContent("{ 'CanDoAWheelie' : true, 'MyEngine' : {'@odata.type' : 'Microsoft.AspNet.OData.Test.Builder.TestModels.V4' ,'Hp':6000 }," +
+                "'MyV4Engine' : {'@odata.type' : 'Microsoft.AspNet.OData.Test.Builder.TestModels.V4' ,'Hp':9000 } }");
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
+
+            // Act
+            HttpResponseMessage response = await _client.SendAsync(request);
+
+            // Assert
+            ExceptionAssert.DoesNotThrow(() => response.EnsureSuccessStatusCode());
+
+            dynamic result = JObject.Parse(await response.Content.ReadAsStringAsync());
+            Assert.True((bool)result.CanDoAWheelie);
+            Assert.Equal(6000, (int)result.MyEngine.Hp);
+
+            Assert.Equal(9000, (int)result.MyV4Engine.Hp);
+        }
+
+        [Fact]
         public async Task Can_Patch_Entity_In_Inheritance_DerivedEngine_MultiLevel_2Children()
         {
             // Arrange
             HttpRequestMessage request = new HttpRequestMessage(new HttpMethod("PATCH"), "http://localhost/PatchMotorcycle_When_Expecting_Motorcycle_DerivedEngine42");
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
             AddRequestInfo(request);
-            request.Content = new StringContent("{ 'CanDoAWheelie' : true, 'MyEngine' : {'@odata.type' : 'Microsoft.AspNet.OData.Test.Builder.TestModels.V2' ,'Hp':6000 }, " +
-                               "'MyV4Engine' : {'@odata.type' : 'Microsoft.AspNet.OData.Test.Builder.TestModels.V4' ,'Hp':9000 } }");
+            request.Content = new StringContent("{ 'CanDoAWheelie' : true, 'MyEngine' : {'@odata.type' : 'Microsoft.AspNet.OData.Test.Builder.TestModels.V422' ,'Hp':6000 }, " +
+                               "'MyV4Engine' : {'@odata.type' : 'Microsoft.AspNet.OData.Test.Builder.TestModels.V42' ,'Hp':9000 } }");
             request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
 
             // Act
@@ -709,15 +758,8 @@ namespace Microsoft.AspNet.OData.Test.Formatter
         {
             patch.Patch(motorcycle2);
 
-            Engine engine = null;
-            if (motorcycle2.CanDoAWheelie)
-            {
-                engine = motorcycle2.MyEngine as V2;
-            }
-            else
-            {
-                engine = motorcycle2.MyEngine as V4;
-            }
+            Engine engine = motorcycle2.MyEngine;
+            
 
             Assert.NotNull(engine);
             Assert.Equal(6000, engine.Hp);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -258,6 +258,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo, bool isComplexType)
 
 	System.Type ExpectedClrType  { public virtual get; }
+	bool IsComplexType  { public get; }
 	System.Type StructuredType  { public virtual get; }
 	System.Collections.Generic.IList`1[[System.String]] UpdatableProperties  { public get; }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -255,6 +255,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public Delta`1 (System.Type structuralType)
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties)
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo)
+	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo, bool isComplexType)
 
 	System.Type ExpectedClrType  { public virtual get; }
 	System.Type StructuredType  { public virtual get; }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -270,6 +270,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public Delta`1 (System.Type structuralType)
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties)
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo)
+	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo, bool isComplexType)
 
 	System.Type ExpectedClrType  { public virtual get; }
 	System.Type StructuredType  { public virtual get; }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -273,6 +273,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo, bool isComplexType)
 
 	System.Type ExpectedClrType  { public virtual get; }
+	bool IsComplexType  { public get; }
 	System.Type StructuredType  { public virtual get; }
 	System.Collections.Generic.IList`1[[System.String]] UpdatableProperties  { public get; }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -274,6 +274,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public Delta`1 (System.Type structuralType)
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties)
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo)
+	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo, bool isComplexType)
 
 	System.Type ExpectedClrType  { public virtual get; }
 	System.Type StructuredType  { public virtual get; }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -277,6 +277,7 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo, bool isComplexType)
 
 	System.Type ExpectedClrType  { public virtual get; }
+	bool IsComplexType  { public get; }
 	System.Type StructuredType  { public virtual get; }
 	System.Collections.Generic.IList`1[[System.String]] UpdatableProperties  { public get; }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2572 .*

### Description

This PR helps in unblocking of using one derived type to Patch over another derived complex type in the case where a common ancestor is used in declaration

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
