### PR TITLE
Fix Auto-Expand Regression

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/AutoSelectExpandHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/AutoSelectExpandHelper.cs
@@ -431,7 +431,7 @@ namespace Microsoft.AspNet.OData.Query
 
             public void Reset()
             {
-                this.stage = 0;
+                this.stage = Stage.Initial;
                 this.derivedEnumerator.Reset();
             }
         }

--- a/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
@@ -838,8 +838,7 @@ namespace Microsoft.AspNet.OData.Query
             var selectRawValue = RawValues.Select;
             if (String.IsNullOrEmpty(selectRawValue))
             {
-                IList<SelectModelPath> autoSelectProperties = null;
-
+                IEnumerable<SelectModelPath> autoSelectProperties = null;
                 if (Context.TargetStructuredType != null && Context.TargetProperty != null)
                 {
                     autoSelectProperties = Context.Model.GetAutoSelectPaths(Context.TargetStructuredType, Context.TargetProperty);
@@ -874,7 +873,7 @@ namespace Microsoft.AspNet.OData.Query
         {
             var expandRawValue = RawValues.Expand;
 
-            IList<ExpandModelPath> autoExpandNavigationProperties = null;
+            IEnumerable<ExpandModelPath> autoExpandNavigationProperties = null;
             if (Context.TargetStructuredType != null && Context.TargetProperty != null)
             {
                 autoExpandNavigationProperties = Context.Model.GetAutoExpandPaths(Context.TargetStructuredType, Context.TargetProperty, !string.IsNullOrEmpty(RawValues.Select));

--- a/src/Microsoft.AspNet.OData.Shared/Query/SelectExpandQueryOption.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/SelectExpandQueryOption.cs
@@ -372,7 +372,7 @@ namespace Microsoft.AspNet.OData.Query
             out List<SelectItem> autoExpandItems)
         {
             autoSelectItems = new List<SelectItem>();
-            IList<SelectModelPath> autoSelectProperties = model.GetAutoSelectPaths(baseEntityType, null, modelBoundQuerySettings);
+            IEnumerable<SelectModelPath> autoSelectProperties = model.GetAutoSelectPaths(baseEntityType, null, modelBoundQuerySettings);
             foreach (var autoSelectProperty in autoSelectProperties)
             {
                 ODataSelectPath odataSelectPath = BuildSelectPath(autoSelectProperty, navigationSource);
@@ -387,7 +387,7 @@ namespace Microsoft.AspNet.OData.Query
                 return;
             }
 
-            IList<ExpandModelPath> autoExpandNavigationProperties = model.GetAutoExpandPaths(baseEntityType, null, !isAllSelected, modelBoundQuerySettings);
+            IEnumerable<ExpandModelPath> autoExpandNavigationProperties = model.GetAutoExpandPaths(baseEntityType, null, !isAllSelected, modelBoundQuerySettings);
             foreach (ExpandModelPath itemPath in autoExpandNavigationProperties)
             {
                 string navigationPath = itemPath.NavigationPropertyPath;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Fixes https://github.com/OData/WebApi/issues/2584

### Description

1. Make "GetAutoSelectPaths" and "GetAutoExpandPaths" behave like "GetAutoSelectProperties" when "baseEntityType" is null
2. Avoid some unnecessary allocations

### Checklist (Uncheck if it is not completed)
- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
