### PR TITLE
Update Patch to Return TStructuralType and Handle Patch for Derived Complex type

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
@@ -402,7 +402,7 @@ namespace Microsoft.AspNet.OData
 
                     if (deltaNestedResource.IsComplexType && newType != originalType)
                     {
-                        originalNestedResource = ReAssignComplexDerivedType(original, nestedResourceName, originalNestedResource, newType, originalType, deltaNestedResource.ExpectedClrType);
+                        originalNestedResource = ReAssignComplexDerivedType(originalNestedResource, newType, originalType, deltaNestedResource.ExpectedClrType);
                         _structuredType.GetProperty(nestedResourceName).SetValue(original, (object)originalNestedResource);
                     }
 
@@ -413,7 +413,7 @@ namespace Microsoft.AspNet.OData
             return original;
         }
 
-        private dynamic ReAssignComplexDerivedType(TStructuralType parent, string nestedPropertyName, dynamic originalValue, Type newType, Type originalType, Type declaredType)
+        private dynamic ReAssignComplexDerivedType(dynamic originalValue, Type newType, Type originalType, Type declaredType)
         {
             //As per OASIS discussion, changing a complex type from 1 derived type to another is allowed if both derived type have a common ancestor and the property
             //is declared in terms of a common ancestor. The logic below checks for a common ancestor. Create a new object of the derived type in delta request.
@@ -500,11 +500,12 @@ namespace Microsoft.AspNet.OData
         /// <remarks>The semantics of this operation are equivalent to a HTTP PATCH operation, hence the name.</remarks>
         /// </summary>
         /// <param name="original">The entity to be updated.</param>
+        /// <returns>The original value after Patching</returns>
         public TStructuralType Patch(TStructuralType original)
         {
             if (IsComplexType)
             {
-                original = ReAssignComplexDerivedType(null, "", original, _structuredType, original.GetType(), ExpectedClrType) as TStructuralType;                
+                original = ReAssignComplexDerivedType(original, _structuredType, original.GetType(), ExpectedClrType) as TStructuralType;                
             }
 
             return CopyChangedValues(original);           

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceControllers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceControllers.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance
         [ODataRoute("Windows({key})/CurrentShape")]
         public ITestActionResult PatchShape(int key, [FromBody] Delta<Shape> delta)
         {
-            Window window = _windows.FirstOrDefault(e => e.Id == key);
+            Window window = _windows.First(e => e.Id == key);
             var currShape = window.CurrentShape;
             Shape newcurrShape = null;
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceControllers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceControllers.cs
@@ -117,6 +117,25 @@ namespace Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance
             return Ok(window);
         }
 
+        [ODataRoute("Windows({key})/CurrentShape")]
+        public ITestActionResult PatchShape(int key, [FromBody] Delta<Shape> delta)
+        {
+            Window window = _windows.FirstOrDefault(e => e.Id == key);
+            var currShape = window.CurrentShape;
+            Shape newcurrShape = null;
+
+            try
+            {
+                newcurrShape = delta.Patch(currShape);                
+            }
+            catch (ArgumentException ae)
+            {
+                return BadRequest(ae.Message);
+            }
+
+            return Ok(newcurrShape);
+        }
+
         public ITestActionResult Put(int key, [FromBody]Window window)
         {
             if (key != window.Id)

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceTests.cs
@@ -364,7 +364,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance
         [InlineData("convention")]
         [InlineData("explicit")]
         // Patch ~/Widnows(3)
-        public async Task Patchy_Matched_DerivedComplexType(string modelMode)
+        public async Task Patch_Matched_DerivedComplexType(string modelMode)
         {
             string serviceRootUri = string.Format("{0}/{1}", BaseAddress, modelMode).ToLower();
             string requestUri = serviceRootUri + "/Windows(3)/CurrentShape";

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ComplexTypeInheritance/ComplexTypeInheritanceTests.cs
@@ -342,22 +342,55 @@ namespace Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance
             // Attempt to PATCH nested resource with delta object of the different CLR type
             // will result an error.
             var content = @"
-{
-    'CurrentShape':
-    {
-        '@odata.type':'#Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance.Circle',
-        'Radius':2,
-        'Center':{'X':1,'Y':2},
-        'HasBorder':true
-    },
-    'OptionalShapes': [ ]
-}";
+            {
+                'CurrentShape':
+                {
+                    '@odata.type':'#Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance.Circle',
+                    'Radius':2,
+                    'Center':{'X':1,'Y':2},
+                    'HasBorder':true
+                },
+                'OptionalShapes': [ ]
+            }";
+
             StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
             request.Content = stringContent;
             HttpResponseMessage response = await Client.SendAsync(request);
             string contentOfString = await response.Content.ReadAsStringAsync();
             Assert.True(HttpStatusCode.OK == response.StatusCode);
         }
+
+        [Theory]
+        [InlineData("convention")]
+        [InlineData("explicit")]
+        // Patch ~/Widnows(3)
+        public async Task Patchy_Matched_DerivedComplexType(string modelMode)
+        {
+            string serviceRootUri = string.Format("{0}/{1}", BaseAddress, modelMode).ToLower();
+            string requestUri = serviceRootUri + "/Windows(3)/CurrentShape";
+
+            HttpRequestMessage request = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri);
+
+            // Attempt to PATCH nested resource with delta object of the different CLR type
+            // will result an error.
+            
+
+           var content = @"
+    {
+        '@odata.type':'#Microsoft.Test.E2E.AspNet.OData.ComplexTypeInheritance.Circle',
+        'Radius':2,
+        'Center':{'X':1,'Y':2},
+        'HasBorder':true
+    }";
+
+            StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
+            request.Content = stringContent;
+            HttpResponseMessage response = await Client.SendAsync(request);
+            JObject contentOfJObject = await response.Content.ReadAsObject<JObject>();
+            Assert.Equal(2, (int)contentOfJObject["Radius"]);
+            Assert.True(HttpStatusCode.OK == response.StatusCode);
+        }
+
 
         [Theory]
         [InlineData("convention")]

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/DeltaTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/DeltaTests.cs
@@ -490,8 +490,9 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter
                 return BadRequest(ModelState);
             }
             var customer = customers.Where(c => c.Id == key).FirstOrDefault();
-            patch.Patch(customer);
-            return Ok(customer);
+            var newCustomer = patch.Patch(customer);
+            Assert.True(newCustomer == customer);
+            return Ok(newCustomer);
         }
     }
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/OpenType/OpenTypeControllers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/OpenType/OpenTypeControllers.cs
@@ -488,7 +488,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.OpenType
                 account.Address = new Address();
             }
 
-            address.Patch(account.Address);
+            account.Address = address.Patch(account.Address);
 
             return Updated(account);
         }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/DeltaTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/DeltaTest.cs
@@ -468,6 +468,26 @@ namespace Microsoft.AspNet.OData.Test
         }
 
         [Fact]
+        public void CanPatch_ReturnsCorrectly()
+        {
+            AddressEntity original = new AddressEntity { ID = 1, City = "Redmond", State = "WA", StreetAddress = "21110 NE 44th St", ZipCode = 98074 };
+
+            dynamic delta = new Delta<AddressEntity>();
+            delta.City = "Sammamish";
+            delta.StreetAddress = "23213 NE 15th Ct";
+
+            var neworiginal = delta.Patch(original);
+            // unchanged
+            Assert.True(original == neworiginal);
+            Assert.Equal(1, original.ID);
+            Assert.Equal(98074, original.ZipCode);
+            Assert.Equal("WA", original.State);
+            // changed
+            Assert.Equal("Sammamish", original.City);
+            Assert.Equal("23213 NE 15th Ct", original.StreetAddress);
+        }
+
+        [Fact]
         public void CanPatch_OpenType()
         {
             // Arrange

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -263,12 +263,12 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	System.Collections.Generic.IList`1[[System.String]] UpdatableProperties  { public get; }
 
 	public virtual void Clear ()
-	public void CopyChangedValues (TStructuralType original)
+	public TStructuralType CopyChangedValues (TStructuralType original)
 	public void CopyUnchangedValues (TStructuralType original)
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
 	public TStructuralType GetInstance ()
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
-	public void Patch (TStructuralType original)
+	public TStructuralType Patch (TStructuralType original)
 	public void Put (TStructuralType original)
 	public bool TryGetNestedPropertyValue (string name, out System.Object& value)
 	public virtual bool TryGetPropertyType (string name, out System.Type& type)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -278,12 +278,12 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	System.Collections.Generic.IList`1[[System.String]] UpdatableProperties  { public get; }
 
 	public virtual void Clear ()
-	public void CopyChangedValues (TStructuralType original)
+	public TStructuralType CopyChangedValues (TStructuralType original)
 	public void CopyUnchangedValues (TStructuralType original)
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
 	public TStructuralType GetInstance ()
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
-	public void Patch (TStructuralType original)
+	public TStructuralType Patch (TStructuralType original)
 	public void Put (TStructuralType original)
 	public bool TryGetNestedPropertyValue (string name, out System.Object& value)
 	public virtual bool TryGetPropertyType (string name, out System.Type& type)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -282,12 +282,12 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	System.Collections.Generic.IList`1[[System.String]] UpdatableProperties  { public get; }
 
 	public virtual void Clear ()
-	public void CopyChangedValues (TStructuralType original)
+	public TStructuralType CopyChangedValues (TStructuralType original)
 	public void CopyUnchangedValues (TStructuralType original)
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetChangedPropertyNames ()
 	public TStructuralType GetInstance ()
 	public virtual System.Collections.Generic.IEnumerable`1[[System.String]] GetUnchangedPropertyNames ()
-	public void Patch (TStructuralType original)
+	public TStructuralType Patch (TStructuralType original)
 	public void Put (TStructuralType original)
 	public bool TryGetNestedPropertyValue (string name, out System.Object& value)
 	public virtual bool TryGetPropertyType (string name, out System.Type& type)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2590  and #2586 .*

### Description

Updated Patch to return TStructuralType
Updated Patch to handle a different derived complex type from original type (as per oasis standards)

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
