### PR TITLE
Create type annotation only with type name

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataPrimitiveSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataPrimitiveSerializer.cs
@@ -125,7 +125,10 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 typeName = primitiveType.FullName();
             }
 
-            primitive.TypeAnnotation = new ODataTypeAnnotation(typeName);
+            if (typeName != null)
+            {
+                primitive.TypeAnnotation = new ODataTypeAnnotation(typeName);
+            }
         }
 
         internal static ODataPrimitiveValue CreatePrimitive(object value, IEdmPrimitiveTypeReference primitiveType,

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/OpenType/TypedTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/OpenType/TypedTest.cs
@@ -436,7 +436,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.OpenType
                 response = await Client.SendAsync(request);
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 content = await response.Content.ReadAsObject<JObject>();
-                Assert.Equal(6, content.Count); // @odata.context + 3 declared properties + 1 dynamic properties + 1 new dynamic properties
+                Assert.Equal(7, content.Count); // @odata.context + 3 declared properties + 2 dynamic properties + 1 new dynamic properties
                 Assert.Equal("NewCity", content["City"]); // updated
                 Assert.Equal("1 Microsoft Way", content["Street"]);
                 Assert.Equal("US", content["CountryCode"]);
@@ -529,7 +529,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.OpenType
                 response = await Client.SendAsync(request);
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 content = await response.Content.ReadAsObject<JObject>();
-                Assert.Equal(5, content.Count); // @odata.context + 3 declared properties + 1 new dynamic properties
+                Assert.Equal(6, content.Count); // @odata.context + 3 declared properties + 2 new dynamic properties
                 Assert.Equal("NewCity", content["City"]); // updated
                 Assert.Equal("NewStreet", content["Street"]); // updated
                 Assert.Equal("US", content["CountryCode"]);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Port from [Create type annotation only has the type name](https://github.com/OData/AspNetCoreOData/commit/4721f7aa9b84ba5c2ff914fa4ca860d146b87534)

*This pull request fixes #xxx.*

### Description

* If the type name is null, we should not create the type annotation for primitive property and let ODL to decision the type metadata.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
