### PR TITLE
Support $id references across entire batch

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
@@ -240,6 +240,7 @@ namespace Microsoft.AspNet.OData
         /// <param name="name">The name of the nested Property</param>
         /// <param name="value">The value of the nested Property</param>
         /// <returns><c>True</c> if the Property was found and is a nested Property</returns>
+        [SuppressMessage("Microsoft.Design", "CA1007:UseGenericsWhereAppropriate")]
         public bool TryGetNestedPropertyValue(string name, out object value)
         {
             if (name == null)
@@ -643,7 +644,7 @@ namespace Microsoft.AspNet.OData
             }
         }
 
-        private bool IsIgnoredProperty(bool isTypeDataContract, PropertyInfo propertyInfo)
+        private static bool IsIgnoredProperty(bool isTypeDataContract, PropertyInfo propertyInfo)
         {
             //This is for Ignoring the property that matches below criteria
             //1. Its marked as NotMapped

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataEntityReferenceLinkDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataEntityReferenceLinkDeserializer.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             if (uri != null)
             {
                 IDictionary<string, string> contentIDToLocationMapping = readContext.InternalRequest.ODataContentIdMapping;
-                if (contentIDToLocationMapping != null)
+                if (contentIDToLocationMapping != null && contentIDToLocationMapping.Count > 0)
                 {
                     Uri baseAddress = new Uri(readContext.InternalUrlHelper.CreateODataLink());
                     string relativeUrl = uri.IsAbsoluteUri ? baseAddress.MakeRelativeUri(uri).OriginalString : uri.OriginalString;

--- a/src/Microsoft.AspNet.OData/Batch/ChangeSetRequestItem.cs
+++ b/src/Microsoft.AspNet.OData/Batch/ChangeSetRequestItem.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNet.OData.Batch
                 throw Error.ArgumentNull("invoker");
             }
 
-            Dictionary<string, string> contentIdToLocationMapping = new Dictionary<string, string>();
+            IDictionary<string, string> contentIdToLocationMapping = this.ContentIdToLocationMapping ?? new Dictionary<string, string>();
             List<HttpResponseMessage> responses = new List<HttpResponseMessage>();
 
             try

--- a/src/Microsoft.AspNet.OData/Batch/DefaultODataBatchHandler.cs
+++ b/src/Microsoft.AspNet.OData/Batch/DefaultODataBatchHandler.cs
@@ -138,6 +138,8 @@ namespace Microsoft.AspNet.OData.Batch
             List<ODataBatchRequestItem> requests = new List<ODataBatchRequestItem>();
             ODataBatchReader batchReader = await reader.CreateODataBatchReaderAsync();
             Guid batchId = Guid.NewGuid();
+            Dictionary<string, string> contentIdToLocationMapping = new Dictionary<string, string>();
+
             while (await batchReader.ReadAsync())
             {
                 if (batchReader.State == ODataBatchReaderState.ChangesetStart)
@@ -148,14 +150,19 @@ namespace Microsoft.AspNet.OData.Batch
                         changeSetRequest.CopyBatchRequestProperties(request);
                         changeSetRequest.DeleteRequestContainer(false);
                     }
-                    requests.Add(new ChangeSetRequestItem(changeSetRequests));
+
+                    ChangeSetRequestItem requestItem = new ChangeSetRequestItem(changeSetRequests);
+                    requestItem.ContentIdToLocationMapping = contentIdToLocationMapping;
+                    requests.Add(requestItem);
                 }
                 else if (batchReader.State == ODataBatchReaderState.Operation)
                 {
                     HttpRequestMessage operationRequest = await batchReader.ReadOperationRequestAsync(batchId, bufferContentStream: true, cancellationToken: cancellationToken);
                     operationRequest.CopyBatchRequestProperties(request);
                     operationRequest.DeleteRequestContainer(false);
-                    requests.Add(new OperationRequestItem(operationRequest));
+                    OperationRequestItem requestItem = new OperationRequestItem(operationRequest);
+                    requestItem.ContentIdToLocationMapping = contentIdToLocationMapping;
+                    requests.Add(requestItem);
                 }
             }
 

--- a/src/Microsoft.AspNet.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs
+++ b/src/Microsoft.AspNet.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs
@@ -164,12 +164,13 @@ namespace Microsoft.AspNet.OData.Batch
             }
 
             object contentIdMapping;
-            if (request.Properties.TryGetValue(ContentIdMappingKey, out contentIdMapping))
+            if (!request.Properties.TryGetValue(ContentIdMappingKey, out contentIdMapping))
             {
-                return contentIdMapping as IDictionary<string, string>;
+                contentIdMapping = new Dictionary<string, string>();
+                request.Properties.Add(new KeyValuePair<string, object>(ContentIdMappingKey, contentIdMapping));
             }
 
-            return null;
+            return contentIdMapping as IDictionary<string, string>;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNet.OData/Batch/ODataBatchReaderExtensions.cs
@@ -14,6 +14,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.OData.Common;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData;
 
 namespace Microsoft.AspNet.OData.Batch
@@ -155,7 +156,15 @@ namespace Microsoft.AspNet.OData.Batch
             ODataBatchOperationRequestMessage batchRequest = await reader.CreateOperationRequestMessageAsync();
             HttpRequestMessage request = new HttpRequestMessage();
             request.Method = new HttpMethod(batchRequest.Method);
-            request.RequestUri = batchRequest.Url;
+            Uri requestUri = batchRequest.Url;
+
+            if (!requestUri.IsAbsoluteUri)
+            {
+                Uri baseUri = batchRequest.Container.GetRequiredService<ODataMessageReaderSettings>().BaseUri;
+                requestUri = new Uri(baseUri, requestUri);
+            }
+
+            request.RequestUri = requestUri;
 
             if (bufferContentStream)
             {

--- a/src/Microsoft.AspNet.OData/Batch/ODataBatchRequestItem.cs
+++ b/src/Microsoft.AspNet.OData/Batch/ODataBatchRequestItem.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNet.OData.Batch
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="contentIdToLocationMapping">The Content-ID to Location mapping.</param>
         /// <returns></returns>
-        public static async Task<HttpResponseMessage> SendMessageAsync(HttpMessageInvoker invoker, HttpRequestMessage request, CancellationToken cancellationToken, Dictionary<string, string> contentIdToLocationMapping)
+        public static async Task<HttpResponseMessage> SendMessageAsync(HttpMessageInvoker invoker, HttpRequestMessage request, CancellationToken cancellationToken, IDictionary<string, string> contentIdToLocationMapping)
         {
             if (invoker == null)
             {
@@ -58,6 +58,12 @@ namespace Microsoft.AspNet.OData.Batch
 
             return response;
         }
+
+        /// <summary>
+        /// Default dictionary that ODataBatchRequestItems should use when mapping ID references to URLs
+        /// </summary>
+        [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
+        public IDictionary<string, string> ContentIdToLocationMapping { get; set; }
 
         private static void AddLocationHeaderToMapping(
             HttpResponseMessage response,

--- a/src/Microsoft.AspNet.OData/Batch/OperationRequestItem.cs
+++ b/src/Microsoft.AspNet.OData/Batch/OperationRequestItem.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNet.OData.Batch
                 throw Error.ArgumentNull("invoker");
             }
 
-            HttpResponseMessage response = await SendMessageAsync(invoker, Request, cancellationToken, null);
+            HttpResponseMessage response = await SendMessageAsync(invoker, Request, cancellationToken, this.ContentIdToLocationMapping);
             return new OperationResponseItem(response);
         }
 

--- a/src/Microsoft.AspNetCore.OData/Batch/ChangeSetRequestItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ChangeSetRequestItem.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNet.OData.Batch
                 throw Error.ArgumentNull("handler");
             }
 
-            Dictionary<string, string> contentIdToLocationMapping = new Dictionary<string, string>();
+            IDictionary<string, string> contentIdToLocationMapping = this.ContentIdToLocationMapping ?? new Dictionary<string, string>();
             List<HttpContext> responseContexts = new List<HttpContext>();
 
             foreach (HttpContext context in Contexts)

--- a/src/Microsoft.AspNetCore.OData/Batch/DefaultODataBatchHandler.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/DefaultODataBatchHandler.cs
@@ -114,6 +114,8 @@ namespace Microsoft.AspNet.OData.Batch
             List<ODataBatchRequestItem> requests = new List<ODataBatchRequestItem>();
             ODataBatchReader batchReader = await reader.CreateODataBatchReaderAsync();
             Guid batchId = Guid.NewGuid();
+            Dictionary<string, string> contentIdToLocationMapping = new Dictionary<string, string>();
+
             while (await batchReader.ReadAsync())
             {
                 if (batchReader.State == ODataBatchReaderState.ChangesetStart)
@@ -124,14 +126,19 @@ namespace Microsoft.AspNet.OData.Batch
                         changeSetContext.Request.CopyBatchRequestProperties(request);
                         changeSetContext.Request.DeleteRequestContainer(false);
                     }
-                    requests.Add(new ChangeSetRequestItem(changeSetContexts));
+
+                    ChangeSetRequestItem requestItem = new ChangeSetRequestItem(changeSetContexts);
+                    requestItem.ContentIdToLocationMapping = contentIdToLocationMapping;
+                    requests.Add(requestItem);
                 }
                 else if (batchReader.State == ODataBatchReaderState.Operation)
                 {
                     HttpContext operationContext = await batchReader.ReadOperationRequestAsync(context, batchId, true, cancellationToken);
                     operationContext.Request.CopyBatchRequestProperties(request);
                     operationContext.Request.DeleteRequestContainer(false);
-                    requests.Add(new OperationRequestItem(operationContext));
+                    OperationRequestItem requestItem = new OperationRequestItem(operationContext);
+                    requestItem.ContentIdToLocationMapping = contentIdToLocationMapping;
+                    requests.Add(requestItem);
                 }
             }
 

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -136,9 +136,16 @@ namespace Microsoft.AspNet.OData.Batch
 
             HttpContext context = CreateHttpContext(originalContext);
             HttpRequest request = context.Request;
+            Uri requestUri = batchRequest.Url;
+
+            if (!requestUri.IsAbsoluteUri)
+            {
+                Uri baseUri = batchRequest.Container.GetRequiredService<ODataMessageReaderSettings>().BaseUri;
+                requestUri = new Uri(baseUri, requestUri);
+            }
 
             request.Method = batchRequest.Method;
-            request.CopyAbsoluteUrl(batchRequest.Url);
+            request.CopyAbsoluteUrl(requestUri);
 
             // Not using bufferContentStream. Unlike AspNet, AspNetCore cannot guarantee the disposal
             // of the stream in the context of execution so there is no choice but to copy the stream

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.OData.Batch
         /// <param name="context">The context.</param>
         /// <param name="contentIdToLocationMapping">The Content-ID to Location mapping.</param>
         /// <returns></returns>
-        public static async Task SendRequestAsync(RequestDelegate handler, HttpContext context, Dictionary<string, string> contentIdToLocationMapping)
+        public static async Task SendRequestAsync(RequestDelegate handler, HttpContext context, IDictionary<string, string> contentIdToLocationMapping)
         {
             if (handler == null)
             {
@@ -72,6 +72,12 @@ namespace Microsoft.AspNet.OData.Batch
                 context.Response.StatusCode = 500;
             }
         }
+
+        /// <summary>
+        /// Default dictionary that ODataBatchRequestItems should use when mapping ID references to URLs
+        /// </summary>
+        public IDictionary<string, string> ContentIdToLocationMapping { get; set; }
+
 
         private static void AddLocationHeaderToMapping(
             HttpResponse response,

--- a/src/Microsoft.AspNetCore.OData/Batch/OperationRequestItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/OperationRequestItem.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.OData.Batch
                 throw Error.ArgumentNull("handler");
             }
 
-            await SendRequestAsync(handler, Context, null);
+            await SendRequestAsync(handler, Context, this.ContentIdToLocationMapping);
             return new OperationResponseItem(Context);
         }
     }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -676,13 +676,15 @@ public abstract class Microsoft.AspNet.OData.Batch.ODataBatchHandler : System.We
 public abstract class Microsoft.AspNet.OData.Batch.ODataBatchRequestItem : IDisposable {
 	protected ODataBatchRequestItem ()
 
+	System.Collections.Generic.IDictionary`2[[System.String],[System.String]] ContentIdToLocationMapping  { public get; public set; }
+
 	public virtual void Dispose ()
 	protected abstract void Dispose (bool disposing)
 	public abstract System.Collections.Generic.IEnumerable`1[[System.IDisposable]] GetResourcesForDisposal ()
 	[
 	AsyncStateMachineAttribute(),
 	]
-	public static System.Threading.Tasks.Task`1[[System.Net.Http.HttpResponseMessage]] SendMessageAsync (System.Net.Http.HttpMessageInvoker invoker, System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken, System.Collections.Generic.Dictionary`2[[System.String],[System.String]] contentIdToLocationMapping)
+	public static System.Threading.Tasks.Task`1[[System.Net.Http.HttpResponseMessage]] SendMessageAsync (System.Net.Http.HttpMessageInvoker invoker, System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken, System.Collections.Generic.IDictionary`2[[System.String],[System.String]] contentIdToLocationMapping)
 
 	public abstract System.Threading.Tasks.Task`1[[Microsoft.AspNet.OData.Batch.ODataBatchResponseItem]] SendRequestAsync (System.Net.Http.HttpMessageInvoker invoker, System.Threading.CancellationToken cancellationToken)
 }

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -745,11 +745,13 @@ public abstract class Microsoft.AspNet.OData.Batch.ODataBatchHandler {
 public abstract class Microsoft.AspNet.OData.Batch.ODataBatchRequestItem {
 	protected ODataBatchRequestItem ()
 
+	System.Collections.Generic.IDictionary`2[[System.String],[System.String]] ContentIdToLocationMapping  { public get; public set; }
+
 	public abstract System.Threading.Tasks.Task`1[[Microsoft.AspNet.OData.Batch.ODataBatchResponseItem]] SendRequestAsync (Microsoft.AspNetCore.Http.RequestDelegate handler)
 	[
 	AsyncStateMachineAttribute(),
 	]
-	public static System.Threading.Tasks.Task SendRequestAsync (Microsoft.AspNetCore.Http.RequestDelegate handler, Microsoft.AspNetCore.Http.HttpContext context, System.Collections.Generic.Dictionary`2[[System.String],[System.String]] contentIdToLocationMapping)
+	public static System.Threading.Tasks.Task SendRequestAsync (Microsoft.AspNetCore.Http.RequestDelegate handler, Microsoft.AspNetCore.Http.HttpContext context, System.Collections.Generic.IDictionary`2[[System.String],[System.String]] contentIdToLocationMapping)
 }
 
 public abstract class Microsoft.AspNet.OData.Batch.ODataBatchResponseItem {

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -749,11 +749,13 @@ public abstract class Microsoft.AspNet.OData.Batch.ODataBatchHandler {
 public abstract class Microsoft.AspNet.OData.Batch.ODataBatchRequestItem {
 	protected ODataBatchRequestItem ()
 
+	System.Collections.Generic.IDictionary`2[[System.String],[System.String]] ContentIdToLocationMapping  { public get; public set; }
+
 	public abstract System.Threading.Tasks.Task`1[[Microsoft.AspNet.OData.Batch.ODataBatchResponseItem]] SendRequestAsync (Microsoft.AspNetCore.Http.RequestDelegate handler)
 	[
 	AsyncStateMachineAttribute(),
 	]
-	public static System.Threading.Tasks.Task SendRequestAsync (Microsoft.AspNetCore.Http.RequestDelegate handler, Microsoft.AspNetCore.Http.HttpContext context, System.Collections.Generic.Dictionary`2[[System.String],[System.String]] contentIdToLocationMapping)
+	public static System.Threading.Tasks.Task SendRequestAsync (Microsoft.AspNetCore.Http.RequestDelegate handler, Microsoft.AspNetCore.Http.HttpContext context, System.Collections.Generic.IDictionary`2[[System.String],[System.String]] contentIdToLocationMapping)
 }
 
 public abstract class Microsoft.AspNet.OData.Batch.ODataBatchResponseItem {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Allows references to other requests across batch

### Description

-Handle relative references in $batch by making URL absolute before copying.
-Allow requests within a batch to reference other requests within the batch whether or not they are in the same changeset.
-Added a using for ODataMessageReader in UnbufferedODataBatchHandler.
-Added required suppressions in DeltaOfTStructuralType.cs

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

None