### PR TITLE
fix delta response serialization error in v4

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataOutputFormatterHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataOutputFormatterHelper.cs
@@ -156,7 +156,15 @@ namespace Microsoft.AspNet.OData.Formatter
 
             ODataMessageWriterSettings writerSettings = internalRequest.WriterSettings;
             writerSettings.BaseUri = baseAddress;
-            writerSettings.Version = version;
+            if (serializer.ODataPayloadKind == ODataPayloadKind.Delta)
+            {
+                writerSettings.Version = ODataVersion.V401;
+            }
+            else
+            {
+                writerSettings.Version = version;
+            }
+
             writerSettings.Validations = writerSettings.Validations & ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
 
             string metadataLink = internaUrlHelper.CreateODataLink(MetadataSegment.Instance);

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataOutputFormatterHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataOutputFormatterHelper.cs
@@ -156,6 +156,7 @@ namespace Microsoft.AspNet.OData.Formatter
 
             ODataMessageWriterSettings writerSettings = internalRequest.WriterSettings;
             writerSettings.BaseUri = baseAddress;
+
             if (serializer.ODataPayloadKind == ODataPayloadKind.Delta)
             {
                 writerSettings.Version = ODataVersion.V401;

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -1885,6 +1885,7 @@
     <Reference Include="Microsoft.Spatial, Version=7.11.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\sln\packages\Microsoft.Spatial.7.11.1\lib\net45\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.OData.Client, Version=7.9.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Client.7.9.1\lib\net45\Microsoft.OData.Client.dll</HintPath>
     </Reference>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/BulkOperation/EFTests/BulkInsertTestEF.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/BulkOperation/EFTests/BulkInsertTestEF.cs
@@ -144,6 +144,48 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkInsert
 
         }
 
+        [Fact]
+        public async Task PatchEmployee_WithUpdates_Employees_InV4()
+        {
+            //Arrange
+
+            string requestUri = this.BaseAddress + "/convention/Employees";
+
+            var content = @"{'@odata.context':'" + this.BaseAddress + @"/convention/$metadata#Employees/$delta',     
+                    'value':[{ '@odata.type': '#Microsoft.Test.E2E.AspNet.OData.BulkInsert.Employee', 'ID':1,'Name':'Employee1',
+                            'Friends@odata.delta':[{'Id':1,'Name':'Friend1',
+                            'Orders@odata.delta' :[{'Id':1,'Price': 10}, {'Id':2,'Price': 20} ] },{'Id':2,'Name':'Friend2'}]
+                                },
+                            {  '@odata.type': '#Microsoft.Test.E2E.AspNet.OData.BulkInsert.Employee', 'ID':2,'Name':'Employee2',
+                            'Friends@odata.delta':[{'Id':3,'Name':'Friend3',
+                            'Orders@odata.delta' :[{'Id':3,'Price': 30}, {'Id':4,'Price': 40} ]},{'Id':4,'Name':'Friend4'}]
+                                }]
+                     }";
+
+            var requestForPost = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri);
+            requestForPost.Headers.Add("OData-Version", "4.0");
+            requestForPost.Headers.Add("OData-MaxVersion", "4.0");
+
+            StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
+            requestForPost.Content = stringContent;
+
+            // Act & Assert
+            var expected = "$delta\",\"value\":[{\"ID\":1,\"Name\":\"Employee1\",\"SkillSet\":[],\"Gender\":\"0\",\"AccessLevel\":" +
+                "\"0\",\"FavoriteSports\":null,\"Friends@delta\":[{\"Id\":1,\"Name\":\"Friend1\",\"Age\":0,\"Orders@delta\":[{\"Id\":1,\"Price\":10},{\"Id\":2,\"Price\":20}]},{\"Id\":2,\"Name\":" +
+                "\"Friend2\",\"Age\":0}]},{\"ID\":2,\"Name\":\"Employee2\",\"SkillSet\":[],\"Gender\":\"0\",\"AccessLevel\":\"0\",\"FavoriteSports\":null,\"Friends@delta\":" +
+                "[{\"Id\":3,\"Name\":\"Friend3\",\"Age\":0,\"Orders@delta\":[{\"Id\":3,\"Price\":30},{\"Id\":4,\"Price\":40}]},{\"Id\":4,\"Name\":\"Friend4\",\"Age\":0}]}]}";
+
+            using (HttpResponseMessage response = await this.Client.SendAsync(requestForPost))
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                var json = response.Content.ReadAsStringAsync().Result;
+                Assert.Contains(expected, json.ToString());
+                Assert.Contains("Employee1", json);
+                Assert.Contains("Employee2", json);
+            }
+
+        }
+
 
         [Fact]
         public async Task PatchEmployee_WithDelete()

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/BulkOperation/EFTests/BulkInsertTestEF.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/BulkOperation/EFTests/BulkInsertTestEF.cs
@@ -148,7 +148,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkInsert
         public async Task PatchEmployee_WithUpdates_Employees_InV4()
         {
             //Arrange
-
             string requestUri = this.BaseAddress + "/convention/Employees";
 
             var content = @"{'@odata.context':'" + this.BaseAddress + @"/convention/$metadata#Employees/$delta',     
@@ -162,12 +161,12 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkInsert
                                 }]
                      }";
 
-            var requestForPost = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri);
-            requestForPost.Headers.Add("OData-Version", "4.0");
-            requestForPost.Headers.Add("OData-MaxVersion", "4.0");
+            var requestForPatch = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri);
+            requestForPatch.Headers.Add("OData-Version", "4.0");
+            requestForPatch.Headers.Add("OData-MaxVersion", "4.0");
 
             StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
-            requestForPost.Content = stringContent;
+            requestForPatch.Content = stringContent;
 
             // Act & Assert
             var expected = "$delta\",\"value\":[{\"ID\":1,\"Name\":\"Employee1\",\"SkillSet\":[],\"Gender\":\"0\",\"AccessLevel\":" +
@@ -175,7 +174,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkInsert
                 "\"Friend2\",\"Age\":0}]},{\"ID\":2,\"Name\":\"Employee2\",\"SkillSet\":[],\"Gender\":\"0\",\"AccessLevel\":\"0\",\"FavoriteSports\":null,\"Friends@delta\":" +
                 "[{\"Id\":3,\"Name\":\"Friend3\",\"Age\":0,\"Orders@delta\":[{\"Id\":3,\"Price\":30},{\"Id\":4,\"Price\":40}]},{\"Id\":4,\"Name\":\"Friend4\",\"Age\":0}]}]}";
 
-            using (HttpResponseMessage response = await this.Client.SendAsync(requestForPost))
+            using (HttpResponseMessage response = await this.Client.SendAsync(requestForPatch))
             {
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 var json = response.Content.ReadAsStringAsync().Result;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description
A response for a deep update of a nested delta resource set is truncated if the OData-Version is not specified as v4.01 in the request. This PR removes the check for the OData-Version. This means that the OData-Version need not be passed in the request and the response should be serialized properly.

The fix is to use version v4.01 to serialize delta responses. 
### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
