### PR TITLE
Serialize navigation properties in Deep insert responses

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/EdmChangedObjectCollection.cs
+++ b/src/Microsoft.AspNet.OData.Shared/EdmChangedObjectCollection.cs
@@ -71,7 +71,6 @@ namespace Microsoft.AspNet.OData
             _entityType = entityType;
             _edmType = new EdmDeltaCollectionType(new EdmEntityTypeReference(_entityType, isNullable: true));
             _edmTypeReference = new EdmCollectionTypeReference(_edmType);
-
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData.Shared/EdmChangedObjectCollection.cs
+++ b/src/Microsoft.AspNet.OData.Shared/EdmChangedObjectCollection.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.OData
         private IEdmEntityType _entityType;
         private EdmDeltaCollectionType _edmType;
         private IEdmCollectionTypeReference _edmTypeReference;
-    
+
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmChangedObjectCollection"/> class.
         /// </summary>
@@ -71,7 +71,7 @@ namespace Microsoft.AspNet.OData
             _entityType = entityType;
             _edmType = new EdmDeltaCollectionType(new EdmEntityTypeReference(_entityType, isNullable: true));
             _edmTypeReference = new EdmCollectionTypeReference(_edmType);
-            
+
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace Microsoft.AspNet.OData
         internal EdmChangedObjectCollection CopyChangedValues(EdmODataAPIHandler apiHandler, ODataEdmAPIHandlerFactory apiHandlerFactory = null)
         {
             EdmChangedObjectCollection changedObjectCollection = new EdmChangedObjectCollection(_entityType);
-            string[] keys = _entityType.Key().Select(x=>x.Name).ToArray();
+            string[] keys = _entityType.Key().Select(x => x.Name).ToArray();
 
             foreach (IEdmChangedObject changedObj in Items)
             {

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -129,8 +129,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             {
                 throw Error.ArgumentNull("readContext");
             }
-
-
+            
             if (!String.IsNullOrEmpty(resourceWrapper.ResourceBase.TypeName) && structuredType.FullName() != resourceWrapper.ResourceBase.TypeName)
             {
                 // received a derived type in a base type deserializer. delegate it to the appropriate derived type deserializer.
@@ -835,7 +834,6 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
 
         private void ApplyResourceProperties(object resource, ODataResourceWrapper resourceWrapper,
             IEdmStructuredTypeReference structuredType, ODataDeserializerContext readContext)
-
         {
             ApplyStructuralProperties(resource, resourceWrapper, structuredType, readContext);
             ApplyNestedProperties(resource, resourceWrapper, structuredType, readContext);

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -1411,7 +1411,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
                 foreach (IEdmNavigationProperty navigationProperty in navigationProperties)
                 {
-                    if (changedProperties == null || changedProperties.Contains(navigationProperty.Name))
+                    if (changedProperties != null && changedProperties.Contains(navigationProperty.Name))
                     {
                         yield return new KeyValuePair<IEdmNavigationProperty, Type>(navigationProperty, typeof(IEdmChangedObject));
                     }
@@ -1426,9 +1426,12 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 {
                     object obj = null;
 
-                    if (changedProperties == null || changedProperties.Contains(navigationProperty.Name) && delta.DeltaNestedResources.TryGetValue(navigationProperty.Name, out obj))
+                    if (changedProperties != null && changedProperties.Contains(navigationProperty.Name) && delta.DeltaNestedResources.TryGetValue(navigationProperty.Name, out obj))
                     {
-                        yield return new KeyValuePair<IEdmNavigationProperty, Type>(navigationProperty, obj.GetType());
+                        if (obj != null)
+                        {
+                            yield return new KeyValuePair<IEdmNavigationProperty, Type>(navigationProperty, obj.GetType());
+                        }
                     }
                 }
             }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -1378,7 +1378,8 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             if (complexProperties != null)
             {
                 IEnumerable<string> changedProperties = null;
-                if (null != resourceContext.EdmObject && resourceContext.EdmObject.IsDeltaResource())
+
+                if (resourceContext.EdmObject != null && resourceContext.EdmObject.IsDeltaResource())
                 {
                     IDelta deltaObject = resourceContext.EdmObject as IDelta;
                     changedProperties = deltaObject.GetChangedPropertyNames();
@@ -1405,7 +1406,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
             IEnumerable<string> changedProperties = null;
 
-            if (null != resourceContext.EdmObject && resourceContext.EdmObject is IDelta changedObject)
+            if (resourceContext.EdmObject != null && resourceContext.EdmObject is IDelta changedObject)
             {
                 changedProperties = changedObject.GetChangedPropertyNames();
 
@@ -1417,7 +1418,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                     }
                 }
             }
-            else if (null != resourceContext.ResourceInstance && resourceContext.ResourceInstance is IDelta deltaObject)
+            else if (resourceContext.ResourceInstance != null && resourceContext.ResourceInstance is IDelta deltaObject)
             {
                 changedProperties = deltaObject.GetChangedPropertyNames();
                 dynamic delta = deltaObject;
@@ -1825,7 +1826,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             {
                 IEnumerable<IEdmStructuralProperty> structuralProperties = selectExpandNode.SelectedStructuralProperties;
 
-                if (null != resourceContext.EdmObject && resourceContext.EdmObject.IsDeltaResource())
+                if (resourceContext.EdmObject != null && resourceContext.EdmObject.IsDeltaResource())
                 {
                     IDelta deltaObject = resourceContext.EdmObject as IDelta;
                     IEnumerable<string> changedProperties = deltaObject.GetChangedPropertyNames();

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -1651,8 +1652,8 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
         private void WriteNestedNavigationProperties(SelectExpandNode selectExpandNode, ResourceContext resourceContext, ODataWriter writer)
         {
-            Contract.Assert(resourceContext != null);
-            Contract.Assert(writer != null);
+            Debug.Assert(resourceContext != null);
+            Debug.Assert(writer != null);
 
             if (!resourceContext.IsPostRequest)
             {
@@ -1677,8 +1678,8 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
         private async Task WriteNestedNavigationPropertiesAsync(SelectExpandNode selectExpandNode, ResourceContext resourceContext, ODataWriter writer)
         {
-            Contract.Assert(resourceContext != null);
-            Contract.Assert(writer != null);
+            Debug.Assert(resourceContext != null);
+            Debug.Assert(writer != null);
 
             if (!resourceContext.IsPostRequest)
             {

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -1655,8 +1655,8 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
         private void WriteNestedNavigationProperties(SelectExpandNode selectExpandNode, ResourceContext resourceContext, ODataWriter writer)
         {
-            Debug.Assert(resourceContext != null);
-            Debug.Assert(writer != null);
+            Debug.Assert(resourceContext != null, "resourceContext != null");
+            Debug.Assert(writer != null, "writer != null");
 
             if (!resourceContext.IsPostRequest)
             {
@@ -1681,8 +1681,8 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
         private async Task WriteNestedNavigationPropertiesAsync(SelectExpandNode selectExpandNode, ResourceContext resourceContext, ODataWriter writer)
         {
-            Debug.Assert(resourceContext != null);
-            Debug.Assert(writer != null);
+            Debug.Assert(resourceContext != null, "resourceContext != null");
+            Debug.Assert(writer != null, "writer != null");
 
             if (!resourceContext.IsPostRequest)
             {

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -647,6 +647,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                         WriteDynamicComplexProperties(resourceContext, writer);
                         WriteNavigationLinks(selectExpandNode, resourceContext, writer);
                         WriteExpandedNavigationProperties(selectExpandNode, resourceContext, writer);
+                        WriteNestedNavigationProperties(selectExpandNode, resourceContext, writer);
                         WriteReferencedNavigationProperties(selectExpandNode, resourceContext, writer);
                         writer.WriteEnd();
                     }
@@ -689,6 +690,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                         await WriteDynamicComplexPropertiesAsync(resourceContext, writer);
                         await WriteNavigationLinksAsync(selectExpandNode, resourceContext, writer);
                         await WriteExpandedNavigationPropertiesAsync(selectExpandNode, resourceContext, writer);
+                        await WriteNestedNavigationPropertiesAsync(selectExpandNode, resourceContext, writer);
                         await WriteReferencedNavigationPropertiesAsync(selectExpandNode, resourceContext, writer);
                         await writer.WriteEndAsync();
                     }
@@ -1118,7 +1120,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             Contract.Assert(selectExpandNode != null);
             Contract.Assert(resourceContext != null);
 
-            if (selectExpandNode.SelectedNavigationProperties == null)
+            if (selectExpandNode.SelectedNavigationProperties == null || resourceContext.IsPostRequest)
             {
                 return;
             }
@@ -1139,7 +1141,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
             Contract.Assert(selectExpandNode != null);
             Contract.Assert(resourceContext != null);
 
-            if (selectExpandNode.SelectedNavigationProperties == null)
+            if (selectExpandNode.SelectedNavigationProperties == null || resourceContext.IsPostRequest)
             {
                 return;
             }
@@ -1396,35 +1398,65 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         {
             ISet<IEdmNavigationProperty> navigationProperties = selectExpandNode.SelectedNavigationProperties;
 
-            if (navigationProperties != null)
+            if (navigationProperties == null)
             {
-                IEnumerable<string> changedProperties = null;
-                if (null != resourceContext.EdmObject && resourceContext.EdmObject is IDelta changedObject)
-                {
-                    changedProperties = changedObject.GetChangedPropertyNames();
+                yield break;
+            }
 
-                    foreach (IEdmNavigationProperty navigationProperty in navigationProperties)
+            IEnumerable<string> changedProperties = null;
+
+            if (null != resourceContext.EdmObject && resourceContext.EdmObject is IDelta changedObject)
+            {
+                changedProperties = changedObject.GetChangedPropertyNames();
+
+                foreach (IEdmNavigationProperty navigationProperty in navigationProperties)
+                {
+                    if (changedProperties == null || changedProperties.Contains(navigationProperty.Name))
                     {
-                        if (changedProperties == null || changedProperties.Contains(navigationProperty.Name))
-                        {
-                            yield return new KeyValuePair<IEdmNavigationProperty, Type>(navigationProperty, typeof(IEdmChangedObject));
-                        }
+                        yield return new KeyValuePair<IEdmNavigationProperty, Type>(navigationProperty, typeof(IEdmChangedObject));
                     }
                 }
-                else if (null != resourceContext.ResourceInstance && resourceContext.ResourceInstance is IDelta deltaObject)
-                {
-                    changedProperties = deltaObject.GetChangedPropertyNames();
-                    dynamic delta = deltaObject;
+            }
+            else if (null != resourceContext.ResourceInstance && resourceContext.ResourceInstance is IDelta deltaObject)
+            {
+                changedProperties = deltaObject.GetChangedPropertyNames();
+                dynamic delta = deltaObject;
 
-                    foreach (IEdmNavigationProperty navigationProperty in navigationProperties)
+                foreach (IEdmNavigationProperty navigationProperty in navigationProperties)
+                {
+                    Object obj = null;
+
+                    if (changedProperties == null || changedProperties.Contains(navigationProperty.Name) && delta.DeltaNestedResources.TryGetValue(navigationProperty.Name, out obj))
                     {
-                        Object obj = null;
-                        if (changedProperties == null || changedProperties.Contains(navigationProperty.Name) && delta.DeltaNestedResources.TryGetValue(navigationProperty.Name, out obj))
+                        yield return new KeyValuePair<IEdmNavigationProperty, Type>(navigationProperty, obj.GetType());
+                    }
+                }
+            }
+            // Serializing nested navigation properties from a deep insert request.
+            // We currently don't deserialize Deep insert nested resources as Delta<T> but as T. If this was to change in the future, logic in this method will have to change.
+            else if (resourceContext.IsPostRequest)
+            {
+                object instance = resourceContext.ResourceInstance;
+                PropertyInfo[] properties = instance.GetType().GetProperties();
+                Dictionary<string, object> propertyNamesAndValues = new Dictionary<string, object>();
+
+                foreach (PropertyInfo propertyInfo in properties)
+                {
+                    string name = propertyInfo.Name;
+                    object value = propertyInfo.GetValue(instance);
+                    propertyNamesAndValues.Add(name, value);
+                }
+
+                foreach (IEdmNavigationProperty navigationProperty in navigationProperties)
+                {
+                    if (propertyNamesAndValues.TryGetValue(navigationProperty.Name, out object obj))
+                    {
+                        if (obj != null)
                         {
                             yield return new KeyValuePair<IEdmNavigationProperty, Type>(navigationProperty, obj.GetType());
                         }
                     }
-                }                
+                }
             }
         }
 
@@ -1581,7 +1613,7 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
 
             object propertyValue = resourceContext.GetPropertyValue(edmProperty.Name);
 
-            if (propertyValue == null || propertyValue is NullEdmComplexObject)
+            if (propertyValue == null || propertyValue is NullEdmComplexObject || propertyValue is ODataIdContainer)
             {
                 if (edmProperty.Type.IsCollection())
                 {
@@ -1615,6 +1647,58 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 }
 
                 await serializer.WriteObjectInlineAsync(propertyValue, edmProperty.Type, writer, nestedWriteContext);
+            }
+        }
+
+        private void WriteNestedNavigationProperties(SelectExpandNode selectExpandNode, ResourceContext resourceContext, ODataWriter writer)
+        {
+            Contract.Assert(resourceContext != null);
+            Contract.Assert(writer != null);
+
+            if (!resourceContext.IsPostRequest)
+            {
+                return;
+            }
+
+            IEnumerable<KeyValuePair<IEdmNavigationProperty, Type>> navigationProperties = GetNavigationPropertiesToWrite(selectExpandNode, resourceContext);
+
+            foreach (KeyValuePair<IEdmNavigationProperty, Type> navigationProperty in navigationProperties)
+            {
+                ODataNestedResourceInfo nestedResourceInfo = new ODataNestedResourceInfo
+                {
+                    IsCollection = navigationProperty.Key.Type.IsCollection(),
+                    Name = navigationProperty.Key.Name
+                };
+
+                writer.WriteStart(nestedResourceInfo);
+                WriteComplexAndExpandedNavigationProperty(navigationProperty.Key, null, resourceContext, writer);
+                writer.WriteEnd();
+            }
+        }
+
+        private async Task WriteNestedNavigationPropertiesAsync(SelectExpandNode selectExpandNode, ResourceContext resourceContext, ODataWriter writer)
+        {
+            Contract.Assert(resourceContext != null);
+            Contract.Assert(writer != null);
+
+            if (!resourceContext.IsPostRequest)
+            {
+                return;
+            }
+
+            IEnumerable<KeyValuePair<IEdmNavigationProperty, Type>> navigationProperties = GetNavigationPropertiesToWrite(selectExpandNode, resourceContext);
+
+            foreach (KeyValuePair<IEdmNavigationProperty, Type> navigationProperty in navigationProperties)
+            {
+                ODataNestedResourceInfo nestedResourceInfo = new ODataNestedResourceInfo
+                {
+                    IsCollection = navigationProperty.Key.Type.IsCollection(),
+                    Name = navigationProperty.Key.Name
+                };
+
+                await writer.WriteStartAsync(nestedResourceInfo);
+                await WriteComplexAndExpandedNavigationPropertyAsync(navigationProperty.Key, null, resourceContext, writer);
+                await writer.WriteEndAsync();
             }
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -1404,11 +1404,9 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 yield break;
             }
 
-            IEnumerable<string> changedProperties = null;
-
-            if (resourceContext.EdmObject != null && resourceContext.EdmObject is IDelta changedObject)
+            if (resourceContext.EdmObject is IDelta changedObject)
             {
-                changedProperties = changedObject.GetChangedPropertyNames();
+                IEnumerable<string> changedProperties = changedObject.GetChangedPropertyNames();
 
                 foreach (IEdmNavigationProperty navigationProperty in navigationProperties)
                 {
@@ -1418,14 +1416,14 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                     }
                 }
             }
-            else if (resourceContext.ResourceInstance != null && resourceContext.ResourceInstance is IDelta deltaObject)
+            else if (resourceContext.ResourceInstance is IDelta deltaObject)
             {
-                changedProperties = deltaObject.GetChangedPropertyNames();
+                IEnumerable<string> changedProperties = deltaObject.GetChangedPropertyNames();
                 dynamic delta = deltaObject;
 
                 foreach (IEdmNavigationProperty navigationProperty in navigationProperties)
                 {
-                    Object obj = null;
+                    object obj = null;
 
                     if (changedProperties == null || changedProperties.Contains(navigationProperty.Name) && delta.DeltaNestedResources.TryGetValue(navigationProperty.Name, out obj))
                     {

--- a/src/Microsoft.AspNet.OData.Shared/ResourceContext.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ResourceContext.cs
@@ -95,6 +95,18 @@ namespace Microsoft.AspNet.OData
             }
         }
 
+        internal bool IsPostRequest
+        {
+            get
+            {
+#if NETCORE
+                return Request == null ? false : String.Equals(Request.Method, "post", StringComparison.OrdinalIgnoreCase);
+#else
+                return Request == null ? false : String.Equals(Request.Method.ToString(), "post", StringComparison.OrdinalIgnoreCase);
+#endif
+            }
+        }
+
         /// <summary>
         /// Gets or sets the <see cref="IEdmNavigationSource"/> to which this instance belongs.
         /// </summary>

--- a/src/Microsoft.AspNet.OData/GlobalSuppressions.cs
+++ b/src/Microsoft.AspNet.OData/GlobalSuppressions.cs
@@ -67,7 +67,6 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "Microsoft.AspNet.OData.Common.Error.#PropertyNullOrWhiteSpace()")]
 
 [assembly: SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Scope = "member", Target = "Microsoft.AspNet.OData.Delta`1.#CopyChangedValues(!0)")]
-
 [assembly: SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Scope = "member", Target = "Microsoft.AspNet.OData.Delta`1.#Microsoft.AspNet.OData.IEdmObject.GetEdmType()")]
 [assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Upsert", Scope = "member", Target = "Microsoft.AspNet.OData.DataModificationOperationKind.#Upsert")]
 [assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Upsert", Scope = "member", Target = "Org.OData.Core.V1.DataModificationOperationKind.#Upsert")]
@@ -121,6 +120,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Scope = "member", Target = "Microsoft.AspNet.OData.ODataAPIHandler`1.#TryGet(System.Collections.Generic.IDictionary`2<System.String,System.Object>,!0&,System.String&)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "1#", Scope = "member", Target = "Microsoft.AspNet.OData.ODataAPIHandler`1.#TryDelete(System.Collections.Generic.IDictionary`2<System.String,System.Object>,System.String&)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "1#", Scope = "member", Target = "Microsoft.AspNet.OData.ODataAPIHandler`1.#TryGet(System.Collections.Generic.IDictionary`2<System.String,System.Object>,!0&,System.String&)")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Scope = "member", Target = "Microsoft.AspNet.OData.ODataAPIHandler`1.#GetODataPath(System.String,Microsoft.OData.Edm.IEdmModel)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1040:AvoidEmptyInterfaces", Scope = "type", Target = "Microsoft.AspNet.OData.IODataAPIHandler")]
 [assembly: SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Scope = "member", Target = "Microsoft.AspNet.OData.Formatter.Serialization.DefaultODataSerializerProvider.#GetODataPayloadSerializerImpl(System.Type,System.Func`1<Microsoft.OData.Edm.IEdmModel>,Microsoft.AspNet.OData.Routing.ODataPath,System.Type)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "1#", Scope = "member", Target = "Microsoft.AspNet.OData.EdmODataAPIHandler.#TryDelete(System.Collections.Generic.IDictionary`2<System.String,System.Object>,System.String&)")]

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -166,8 +166,8 @@
     <Compile Include="..\Aggregation\AggregationTests.cs">
       <Link>Aggregation\AggregationTests.cs</Link>
     </Compile>
-    <Compile Include="..\BulkOperation\BulkOperationPatchHandlers.cs">
-      <Link>BulkOperation\BulkOperationPatchHandlers.cs</Link>
+    <Compile Include="..\BulkOperation\BulkOperationTest.cs">
+      <Link>BulkOperation\BulkOperationTest.cs</Link>
     </Compile>
     <Compile Include="..\BulkOperation\BulkOperationDataModel.cs">
       <Link>BulkOperation\BulkOperationDataModel.cs</Link>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationDataModel.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNet.OData.Builder;
 
 namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
 {
-    [AutoExpand]
     public class Employee
     {
         [Key]

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationPatchHandlers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationPatchHandlers.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
+using Microsoft.Test.E2E.AspNet.OData.BulkOperation;
 
 namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
 {
@@ -139,7 +140,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
 
                                     default:
                                         return null;
-
                                 }
                             }
                         }
@@ -147,7 +147,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
 
                     default:
                         return null;
-
                 }
             }
             return null;
@@ -176,14 +175,12 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
 
                     default:
                         return null;
-
                 }
             }
 
             return null;
         }
     }
-
 
     internal class CompanyAPIHandler : ODataAPIHandler<Company>
     {
@@ -243,7 +240,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 {
                     status = ODataAPIResponseStatus.NotFound;
                 }
-
             }
             catch (Exception ex)
             {
@@ -265,7 +261,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 default:
                     return null;
             }
-
         }
     }
 
@@ -330,12 +325,10 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 var id = keyValues["Id"].ToString();
                 originalObject = parent.OverdueOrders.FirstOrDefault(x => x.Id == Int32.Parse(id));
 
-
                 if (originalObject == null)
                 {
                     status = ODataAPIResponseStatus.NotFound;
                 }
-
             }
             catch (Exception ex)
             {
@@ -350,11 +343,9 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
         {
             switch (navigationPropertyName)
             {
-
                 default:
                     return null;
             }
-
         }
     }
 
@@ -424,7 +415,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 {
                     status = ODataAPIResponseStatus.NotFound;
                 }
-
             }
             catch (Exception ex)
             {
@@ -443,10 +433,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 default:
                     return null;
             }
-
         }
     }
-
 
     internal class EmployeeAPIHandler : ODataAPIHandler<Employee>
     {
@@ -502,12 +490,10 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 var id = keyValues["ID"].ToString();
                 originalObject = EmployeesController.Employees.First(x => x.ID == Int32.Parse(id));
 
-
                 if (originalObject == null)
                 {
                     status = ODataAPIResponseStatus.NotFound;
                 }
-
             }
             catch (Exception ex)
             {
@@ -529,7 +515,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 default:
                     return null;
             }
-
         }
     }
 
@@ -598,7 +583,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 {
                     status = ODataAPIResponseStatus.NotFound;
                 }
-
             }
             catch (Exception ex)
             {
@@ -617,10 +601,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                     return new OrderAPIHandler(parent);
                 default:
                     return null;
-
             }
         }
-
     }
 
     internal class NewOrderAPIHandler : ODataAPIHandler<NewOrder>
@@ -696,7 +678,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 {
                     status = ODataAPIResponseStatus.NotFound;
                 }
-
             }
             catch (Exception ex)
             {
@@ -711,7 +692,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
         {
             throw new NotImplementedException();
         }
-
     }
 
     internal class MyNewOrderAPIHandler : ODataAPIHandler<MyNewOrder>
@@ -787,7 +767,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 {
                     status = ODataAPIResponseStatus.NotFound;
                 }
-
             }
             catch (Exception ex)
             {
@@ -802,9 +781,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
         {
             throw new NotImplementedException();
         }
-
     }
-
 
     internal class OrderAPIHandler : ODataAPIHandler<Order>
     {
@@ -879,7 +856,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 {
                     status = ODataAPIResponseStatus.NotFound;
                 }
-
             }
             catch (Exception ex)
             {
@@ -894,10 +870,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
         {
             throw new NotImplementedException();
         }
-
     }
-
-
 
     internal class NewFriendAPIHandler : ODataAPIHandler<NewFriend>
     {
@@ -971,12 +944,10 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
 
                 originalObject = employee.NewFriends.FirstOrDefault(x => x.Id == Int32.Parse(id));
 
-
                 if (originalObject == null)
                 {
                     status = ODataAPIResponseStatus.NotFound;
                 }
-
             }
             catch (Exception ex)
             {
@@ -991,9 +962,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
         {
             throw new NotImplementedException();
         }
-
     }
-
 
     internal class EmployeeEdmAPIHandler : EdmODataAPIHandler
     {
@@ -1042,7 +1011,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                     }
                 }
 
-
                 return ODataAPIResponseStatus.Success;
             }
             catch (Exception ex)
@@ -1074,12 +1042,10 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                     }
                 }
 
-
                 if (originalObject == null)
                 {
                     status = ODataAPIResponseStatus.NotFound;
                 }
-
             }
             catch (Exception ex)
             {
@@ -1100,9 +1066,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 default:
                     return null;
             }
-
         }
-
     }
 
     internal class FriendTypelessAPIHandler : EdmODataAPIHandler
@@ -1180,11 +1144,9 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                         friends.Remove(emp);
 
                         employee.TrySetPropertyValue("UnTypedFriends", friends);
-
                         break;
                     }
                 }
-
 
                 return ODataAPIResponseStatus.Success;
             }
@@ -1227,12 +1189,10 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                     }
                 }
 
-
                 if (originalObject == null)
                 {
                     status = ODataAPIResponseStatus.NotFound;
                 }
-
             }
             catch (Exception ex)
             {
@@ -1247,6 +1207,5 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
         {
             return null;
         }
-
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
@@ -593,6 +593,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 var json = response.Content.ReadAsStringAsync().Result;
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.Contains(expected, json.ToString());
+
+                // Navigation properties absent from the payload are not serialized in the response.
                 Assert.DoesNotContain("NewFriends@delta", json.ToString());
                 Assert.DoesNotContain("UntypedFriends@delta", json.ToString());
             }
@@ -632,6 +634,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 var json = response.Content.ReadAsStringAsync().Result;
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.Contains(expected, json.ToString());
+                Assert.DoesNotContain("NewFriends@delta", json.ToString());
+                Assert.DoesNotContain("UntypedFriends@delta", json.ToString());
             }
 
             //Assert

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
@@ -978,13 +978,15 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
             StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
             requestForPatch.Content = stringContent;
 
+            var expected = "Friends\":[{\"Id\":1001,\"Name\":\"Friend 1001\",\"Age\":31},{\"Id\":1002,\"Name\":\"Friend 1002\",\"Age\":32},{\"Id\":1003,\"Name\":\"Friend 1003\",\"Age\":33}]";
+
             //Act & Assert
             using (HttpResponseMessage response = await this.Client.SendAsync(requestForPatch))
             {
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 var json = response.Content.ReadAsStringAsync().Result;
                 Assert.Contains("SqlUD", json);
-                //Assert.Contains("Friends", json); // Activate after fixing serialization issue for DeepInsert nested resources
+                Assert.Contains(expected, json);
             }
         }
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
@@ -990,6 +990,118 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
             }
         }
 
+        [Fact]
+        public async Task PostEmployee_WithCreateFriendsFullMetadata()
+        {
+            //Arrange
+
+            string requestUri = this.BaseAddress + "/convention/Employees?$format=application/json;odata.metadata=full";
+
+            string content = @"{
+                    'Name':'SqlUD',
+                    'Friends':[{ 'Id':1001, 'Name' : 'Friend 1001', 'Age': 31},{ 'Id':1002, 'Name' : 'Friend 1002', 'Age': 32},{ 'Id':1003, 'Name' : 'Friend 1003', 'Age': 33}]
+                     }";
+
+            var requestForPatch = new HttpRequestMessage(new HttpMethod("POST"), requestUri);
+
+            StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
+            requestForPatch.Content = stringContent;
+
+            string friendsNavigationLink = "Friends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(0)/Friends\"";
+            string newFriendsNavigationLink = "NewFriends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(0)/NewFriends\"";
+            string untypedFriendsNavigationLink = "UnTypedFriends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(0)/UnTypedFriends\"";
+
+            string expected = "Friends\":[{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.BulkOperation.Friend\",\"@odata.id\":" +
+                "\"http://localhost:11001/convention/Friends(1001)\",\"@odata.editLink\":\"http://localhost:11001/convention/Friends(1001)\"," +
+                "\"Id\":1001,\"Name\":\"Friend 1001\",\"Age\":31,"+
+                "\"Orders@odata.associationLink\":\"http://localhost:11001/convention/Friends(1001)/Orders/$ref\"," +
+                "\"Orders@odata.navigationLink\":\"http://localhost:11001/convention/Friends(1001)/Orders\"}," +
+                "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.BulkOperation.Friend\"," +
+                "\"@odata.id\":\"http://localhost:11001/convention/Friends(1002)\"," +
+                "\"@odata.editLink\":\"http://localhost:11001/convention/Friends(1002)\"," +
+                "\"Id\":1002,\"Name\":\"Friend 1002\",\"Age\":32," +
+                "\"Orders@odata.associationLink\":\"http://localhost:11001/convention/Friends(1002)/Orders/$ref\"," +
+                "\"Orders@odata.navigationLink\":\"http://localhost:11001/convention/Friends(1002)/Orders\"}," +
+                "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.BulkOperation.Friend\"," +
+                "\"@odata.id\":\"http://localhost:11001/convention/Friends(1003)\"," +
+                "\"@odata.editLink\":\"http://localhost:11001/convention/Friends(1003)\"," +
+                "\"Id\":1003,\"Name\":\"Friend 1003\",\"Age\":33," +
+                "\"Orders@odata.associationLink\":\"http://localhost:11001/convention/Friends(1003)/Orders/$ref\"," +
+                "\"Orders@odata.navigationLink\":\"http://localhost:11001/convention/Friends(1003)/Orders\"}]";
+
+            //Act & Assert
+            using (HttpResponseMessage response = await this.Client.SendAsync(requestForPatch))
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                var json = response.Content.ReadAsStringAsync().Result;
+                Assert.Contains("SqlUD", json);
+                Assert.Contains(expected, json);
+                Assert.Contains(friendsNavigationLink, json);
+                Assert.Contains(newFriendsNavigationLink, json);
+                Assert.Contains(untypedFriendsNavigationLink, json);
+            }
+        }
+
+        [Fact]
+        public async Task PostEmployee_WithFullMetadata()
+        {
+            //Arrange
+
+            string requestUri = this.BaseAddress + "/convention/Employees?$format=application/json;odata.metadata=full";
+
+            var content = @"{
+                    'Name':'SqlUD'
+                     }";
+
+            var requestForPatch = new HttpRequestMessage(new HttpMethod("POST"), requestUri);
+
+            StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
+            requestForPatch.Content = stringContent;
+
+            string friendsNavigationLink = "Friends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(0)/Friends\"";
+            string newFriendsNavigationLink = "NewFriends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(0)/NewFriends\"";
+            string untypedFriendsNavigationLink = "UnTypedFriends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(0)/UnTypedFriends\"";
+
+            //Act & Assert
+            using (HttpResponseMessage response = await this.Client.SendAsync(requestForPatch))
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                var json = response.Content.ReadAsStringAsync().Result;
+                Assert.Contains("SqlUD", json);
+                Assert.Contains(friendsNavigationLink, json);
+                Assert.Contains(newFriendsNavigationLink, json);
+                Assert.Contains(untypedFriendsNavigationLink, json);
+            }
+        }
+
+        [Fact]
+        public async Task GetEmployee_WithFullMetadata()
+        {
+            //Arrange
+
+            //string requestUri = this.BaseAddress + "/convention/Employees(1)?$format=application/json;odata.metadata=full";
+            string requestUri = this.BaseAddress + "/convention/Employees(1)";
+
+            var requestForPatch = new HttpRequestMessage(new HttpMethod("GET"), requestUri);
+
+            string friendsNavigationLink = "Friends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(1)/Friends\"";
+            string newFriendsNavigationLink = "NewFriends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(1)/NewFriends\"";
+            string untypedFriendsNavigationLink = "UnTypedFriends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(1)/UnTypedFriends\"";
+
+            //string notexpected = "Friends\":[{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.BulkOperation.Friend\"";
+
+            //Act & Assert
+            using (HttpResponseMessage response = await this.Client.SendAsync(requestForPatch))
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                var json = response.Content.ReadAsStringAsync().Result;
+                //Assert.DoesNotContain(notexpected, json);
+                Assert.Contains(friendsNavigationLink, json);
+                Assert.Contains(newFriendsNavigationLink, json);
+                Assert.Contains(untypedFriendsNavigationLink, json);
+            }
+        }
+
         #endregion
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
@@ -566,6 +566,39 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
         }
 
         [Fact]
+        public async Task PatchEmployee_WithUnchanged_Employee()
+        {
+            //Arrange
+
+            string requestUri = this.BaseAddress + "/convention/Employees";
+
+            var content = @"{'@odata.context':'" + this.BaseAddress + @"/convention/$metadata#Employees/$delta',
+                    'value':[{ '@odata.type': '#Microsoft.Test.E2E.AspNet.OData.BulkOperation.Employee', 'ID':1,'Name':'Name1',
+                            'Friends@odata.delta':[{'Id':1,'Name':'Test0','Age':33},{'Id':2,'Name':'Test1'}]
+                                }]
+                     }";
+
+            var requestForPost = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri);
+            requestForPost.Headers.Add("OData-Version", "4.01");
+
+            StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
+            requestForPost.Content = stringContent;
+
+            var expected = "\"value\":[{\"ID\":1,\"Name\":\"Name1\",\"SkillSet\":[],\"Gender\":\"0\",\"AccessLevel\":\"0\",\"FavoriteSports\":null," +
+                "\"Friends@delta\":[{\"Id\":1,\"Name\":\"Test0\",\"Age\":33}," +
+                "{\"Id\":2,\"Name\":\"Test1\",\"Age\":0}]}]}";
+
+            using (HttpResponseMessage response = await this.Client.SendAsync(requestForPost))
+            {
+                var json = response.Content.ReadAsStringAsync().Result;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Contains(expected, json.ToString());
+                Assert.DoesNotContain("NewFriends@delta", json.ToString());
+                Assert.DoesNotContain("UntypedFriends@delta", json.ToString());
+            }
+        }
+
+        [Fact]
         public async Task PatchEmployee_WithUpdates_Employees()
         {
             //Arrange

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
@@ -613,7 +613,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
                 Assert.Contains("Friend2", json.ToString());
             }
 
-            requestUri = this.BaseAddress + "/convention/Employees(2)";
+            requestUri = this.BaseAddress + "/convention/Employees(2)?$expand=Friends";
             using (HttpResponseMessage response = await this.Client.GetAsync(requestUri))
             {
                 response.EnsureSuccessStatusCode();
@@ -642,9 +642,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
             StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
             requestForPost.Content = stringContent;
 
-            var expected = "/convention/$metadata#Employees(Friends(),NewFriends(),UnTypedFriends())/$entity\",\"ID\":1,\"Name\":\"Sql\"," +
-                "\"SkillSet\":[\"CSharp\",\"Sql\"],\"Gender\":\"Female\",\"AccessLevel\":\"Execute\",\"FavoriteSports\":{\"Sport\":\"Football\"},\"Friends\":[{\"Id\":2,\"Name\":\"Test1\",\"Age\":0}]," +
-                "\"NewFriends\":[{\"Id\":1,\"Name\":\"NewFriendTest1\",\"Age\":33}],\"UnTypedFriends\":[]}";
+            var expected = "/convention/$metadata#Employees/$entity\",\"ID\":1,\"Name\":\"Sql\"," +
+                "\"SkillSet\":[\"CSharp\",\"Sql\"],\"Gender\":\"Female\",\"AccessLevel\":\"Execute\",\"FavoriteSports\":{\"Sport\":\"Football\"}}";
 
             using (HttpResponseMessage response = await this.Client.SendAsync(requestForPost))
             {
@@ -672,7 +671,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
         {
             //Arrange
 
-            string requestUri = this.BaseAddress + "/convention/Employees(1)";
+            string requestUri = this.BaseAddress + "/convention/Employees(1)?$expand=Friends";
 
             var content = @"{
                     'Name':'Bind1'  ,
@@ -684,10 +683,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
             StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
             requestForPost.Content = stringContent;
 
-            //Act & Assert
-            var expected = "/convention/$metadata#Employees(Friends(),NewFriends(),UnTypedFriends())/$entity\",\"ID\":1,\"Name\":\"Bind1\"," +
-                "\"SkillSet\":[\"CSharp\",\"Sql\"],\"Gender\":\"Female\",\"AccessLevel\":\"Execute\",\"FavoriteSports\":{\"Sport\":\"Football\"},\"Friends\":[{\"Id\":3,\"Name\":null,\"Age\":0}]," +
-                "\"NewFriends\":[{\"Id\":1,\"Name\":\"NewFriendTest1\",\"Age\":33}],\"UnTypedFriends\":[]}";
+            var expected = "/convention/$metadata#Employees(Friends())/$entity\",\"ID\":1,\"Name\":\"Bind1\"," +
+                "\"SkillSet\":[\"CSharp\",\"Sql\"],\"Gender\":\"Female\",\"AccessLevel\":\"Execute\",\"FavoriteSports\":{\"Sport\":\"Football\"},\"Friends\":[{\"Id\":3,\"Name\":null,\"Age\":0}]}";
 
             using (HttpResponseMessage response = await this.Client.SendAsync(requestForPost))
             {
@@ -1007,27 +1004,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
             StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
             requestForPatch.Content = stringContent;
 
-            string friendsNavigationLink = "Friends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(0)/Friends\"";
-            string newFriendsNavigationLink = "NewFriends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(0)/NewFriends\"";
-            string untypedFriendsNavigationLink = "UnTypedFriends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(0)/UnTypedFriends\"";
+            string friendsNavigationLink = "Friends@odata.navigationLink";
+            string newFriendsNavigationLink = "NewFriends@odata.navigationLink";
+            string untypedFriendsNavigationLink = "UnTypedFriends@odata.navigationLink";
 
-            string expected = "Friends\":[{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.BulkOperation.Friend\",\"@odata.id\":" +
-                "\"http://localhost:11001/convention/Friends(1001)\",\"@odata.editLink\":\"http://localhost:11001/convention/Friends(1001)\"," +
-                "\"Id\":1001,\"Name\":\"Friend 1001\",\"Age\":31,"+
-                "\"Orders@odata.associationLink\":\"http://localhost:11001/convention/Friends(1001)/Orders/$ref\"," +
-                "\"Orders@odata.navigationLink\":\"http://localhost:11001/convention/Friends(1001)/Orders\"}," +
-                "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.BulkOperation.Friend\"," +
-                "\"@odata.id\":\"http://localhost:11001/convention/Friends(1002)\"," +
-                "\"@odata.editLink\":\"http://localhost:11001/convention/Friends(1002)\"," +
-                "\"Id\":1002,\"Name\":\"Friend 1002\",\"Age\":32," +
-                "\"Orders@odata.associationLink\":\"http://localhost:11001/convention/Friends(1002)/Orders/$ref\"," +
-                "\"Orders@odata.navigationLink\":\"http://localhost:11001/convention/Friends(1002)/Orders\"}," +
-                "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.BulkOperation.Friend\"," +
-                "\"@odata.id\":\"http://localhost:11001/convention/Friends(1003)\"," +
-                "\"@odata.editLink\":\"http://localhost:11001/convention/Friends(1003)\"," +
-                "\"Id\":1003,\"Name\":\"Friend 1003\",\"Age\":33," +
-                "\"Orders@odata.associationLink\":\"http://localhost:11001/convention/Friends(1003)/Orders/$ref\"," +
-                "\"Orders@odata.navigationLink\":\"http://localhost:11001/convention/Friends(1003)/Orders\"}]";
+            string expected = "Friends\":[{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.BulkOperation.Friend\"";
 
             //Act & Assert
             using (HttpResponseMessage response = await this.Client.SendAsync(requestForPatch))
@@ -1058,9 +1039,9 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
             StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
             requestForPatch.Content = stringContent;
 
-            string friendsNavigationLink = "Friends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(0)/Friends\"";
-            string newFriendsNavigationLink = "NewFriends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(0)/NewFriends\"";
-            string untypedFriendsNavigationLink = "UnTypedFriends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(0)/UnTypedFriends\"";
+            string friendsNavigationLink = "Friends@odata.navigationLink";
+            string newFriendsNavigationLink = "NewFriends@odata.navigationLink";
+            string untypedFriendsNavigationLink = "UnTypedFriends@odata.navigationLink";
 
             //Act & Assert
             using (HttpResponseMessage response = await this.Client.SendAsync(requestForPatch))
@@ -1079,23 +1060,22 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
         {
             //Arrange
 
-            //string requestUri = this.BaseAddress + "/convention/Employees(1)?$format=application/json;odata.metadata=full";
-            string requestUri = this.BaseAddress + "/convention/Employees(1)";
+            string requestUri = this.BaseAddress + "/convention/Employees(1)?$format=application/json;odata.metadata=full";
 
             var requestForPatch = new HttpRequestMessage(new HttpMethod("GET"), requestUri);
 
-            string friendsNavigationLink = "Friends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(1)/Friends\"";
-            string newFriendsNavigationLink = "NewFriends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(1)/NewFriends\"";
-            string untypedFriendsNavigationLink = "UnTypedFriends@odata.navigationLink\":\"http://localhost:11001/convention/Employees(1)/UnTypedFriends\"";
+            string friendsNavigationLink = "Friends@odata.navigationLink";
+            string newFriendsNavigationLink = "NewFriends@odata.navigationLink";
+            string untypedFriendsNavigationLink = "UnTypedFriends@odata.navigationLink";
 
-            //string notexpected = "Friends\":[{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.BulkOperation.Friend\"";
+            string notexpected = "Friends\":[{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.BulkOperation.Friend\"";
 
             //Act & Assert
             using (HttpResponseMessage response = await this.Client.SendAsync(requestForPatch))
             {
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 var json = response.Content.ReadAsStringAsync().Result;
-                //Assert.DoesNotContain(notexpected, json);
+                Assert.DoesNotContain(notexpected, json);
                 Assert.Contains(friendsNavigationLink, json);
                 Assert.Contains(newFriendsNavigationLink, json);
                 Assert.Contains(untypedFriendsNavigationLink, json);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/DeltaSetOfTTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/DeltaSetOfTTest.cs
@@ -296,8 +296,6 @@ namespace Microsoft.AspNet.OData.Test
             friends.Add(new Friend { Id = 1, Name = "Test1" });
             friends.Add(new Friend { Id = 2, Name = "Test2", NewFriends= new List<NewFriend>() { new NewFriend {Id=3, Name="Test33" }, new NewFriend { Id = 4, Name = "Test44" } } });
 
- 
-
             //Act
             deltaSet.Patch(new FriendPatchHandler(), new APIHandlerFactory(model));
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/EdmChangedObjectCollectionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/EdmChangedObjectCollectionTest.cs
@@ -176,9 +176,7 @@ namespace Microsoft.AspNet.OData.Test
             Assert.Equal("Friend1", obj );
             friends[1].TryGetPropertyValue("Name", out obj);
             Assert.Equal("Friend2", obj);
-
         }
-
 
         [Fact]
         public void EdmChangedObjectCollection_Patch_WithDeletes()
@@ -238,8 +236,6 @@ namespace Microsoft.AspNet.OData.Test
             EdmEntityType _entityType = new EdmEntityType("Microsoft.AspNet.OData.Test", "Friend");
             _entityType.AddKeys(_entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
             _entityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
-
-     
 
             var changedObjCollection = new EdmChangedObjectCollection(_entityType);
 
@@ -486,8 +482,7 @@ namespace Microsoft.AspNet.OData.Test
                         break;
                     }
                 }
-
-
+                
                 return ODataAPIResponseStatus.Success;
             }
             catch (Exception ex)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -293,7 +293,6 @@ public class Microsoft.AspNet.OData.Delta`1 : TypedDelta, IDynamicMetaObjectProv
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo)
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo, bool isComplexType)
 	public Delta`1 (System.Type structuralType, System.Collections.Generic.IEnumerable`1[[System.String]] updatableProperties, System.Reflection.PropertyInfo dynamicDictionaryPropertyInfo, bool isComplexType, System.Reflection.PropertyInfo instanceAnnotationsPropertyInfo)
-
 	EdmDeltaEntityKind DeltaKind  { public virtual get; protected set; }
 	System.Type ExpectedClrType  { public virtual get; }
 	bool IsComplexType  { public get; }
@@ -444,7 +443,6 @@ public class Microsoft.AspNet.OData.EdmEntityObject : EdmStructuredObject, IDyna
 	public EdmEntityObject (Microsoft.OData.Edm.IEdmEntityType edmType)
 	public EdmEntityObject (Microsoft.OData.Edm.IEdmEntityTypeReference edmType)
 	public EdmEntityObject (Microsoft.OData.Edm.IEdmEntityType edmType, bool isNullable)
-
 	EdmDeltaEntityKind DeltaKind  { public virtual get; }
 	IODataIdContainer ODataIdContainer  { public get; public set; }
 	IODataInstanceAnnotationContainer PersistentInstanceAnnotationsContainer  { public get; public set; }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues
In the existing implementation, we serialize navigation properties in 2 scenarios:
- Responses when we use `[AutoExpand]` attribute in controller methods.
- Responses when we use `$expand` query option in GET requests.
In Deep insert, we make a POST request that has nested resources (navigation properties). We expect the response to contain the nested resources. However the `ODataResourceSerializer`doesn't know how to handle Deep insert responses.

### Description
When serializing the response, we check if the request was a POST request. If true, we write the nested resources.
We have introduced new methods `WriteNestedNavigationProperties` and `WriteNestedNavigationPropertiesAsync` which only work when the request is a `POST` request.

Weirdly, `WriteNavigationLink` methods does the following for navigation properties that haven't been expanded:
```csharp
writer.WriteStart(navigationLink);
writer.WriteEnd()
```
We have updated the code to ensure that for `POST` requests, the above logic in `WriteNavigationLink` is not executed. We will write the `navigationLink` in the `WriteNestedNavigationProperties` method.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
