### PR TITLE
Change VmImage from latest to 2019 to finish the build pipeline build

### DIFF
--- a/pipelines/azure_pipelines.yml
+++ b/pipelines/azure_pipelines.yml
@@ -23,7 +23,7 @@ stages:
       timeoutInMinutes: 180
 
       pool:
-        vmImage: windows-latest
+        vmImage: windows-2019  # The project is still targeting on .NET 4.5, we need this vm image to finish .NET 4.5 build. We should update it later.
 
       steps:
         - template: ./common.yml

--- a/pipelines/azure_pipelines_nightly.yml
+++ b/pipelines/azure_pipelines_nightly.yml
@@ -25,8 +25,10 @@ stages:
       displayName: Main Build
       # setting a 3hour timeout as webapi tests normally take about 2hr 30 mins
       timeoutInMinutes: 180
+
+      # The project is still targeting on .NET 4.5, we need this vm image to finish .NET 4.5 build. We should update it later.
       pool:
-        vmImage: windows-latest
+        vmImage: windows-2019
       steps:
       - template: ./common.yml
       - task: MSBuild@1


### PR DESCRIPTION

<img width="716" alt="image" src="https://user-images.githubusercontent.com/9426627/200686938-a5d39454-884d-45af-afb1-ac3accbb93f8.png">


The above 'OData.WebApi-Rolling' is failing all time, because Azure BuildPipeline change the windows-latest using 2022.
On 2022, .NET 4.5 SDK is not installed by default, it makes our build pipeline failing.


This PR changes/downgrade the vmImage to use windows-2019. This vm version can help us to build the whole solution correctly.

Long term, we should update our project to target on more latest .NET version.
