### PR TITLE
Updated out-of-date .NET Foundation Code of Conduct Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Please refer to the [How to debug](https://docs.microsoft.com/en-us/odata/webapi
 
 ### Code of Conduct
 
-This project has adopted the [.NET Foundation Contributor Covenant Code of Conduct](https://dotnetfoundation.org/about/code-of-conduct). For more information see the [Code of Conduct FAQ](https://dotnetfoundation.org/about/faq).
+This project has adopted the [.NET Foundation Contributor Covenant Code of Conduct](https://dotnetfoundation.org/about/policies/code-of-conduct). For more information see the [Code of Conduct FAQ](https://dotnetfoundation.org/about/faq).
 
 ### .NET Foundation
 


### PR DESCRIPTION
Updated out-of-date .NET Foundation Code of Conduct Link 

<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #2726 
Updated the old link to be : https://dotnetfoundation.org/about/policies/code-of-conduct

### Description

We have modified the .NET Foundation Contributor Covenant Code of Conduct link under the project's root readme.md folder to point to the Foundation's new link here: https://dotnetfoundation.org/about/policies/code-of-conduct .

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added* - N/A
- [X] *Build and test with one-click build and test script passed* - N/A

### Additional work necessary

Docs Needed - readme.md updates
