### PR TITLE
Fix skiptoken paging issue when combined with $orderby involving nullable property

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
@@ -2953,6 +2953,17 @@ namespace Microsoft.AspNet.OData.Common
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Unable to get property values from the skiptoken value..
+        /// </summary>
+        internal static string SkipTokenProcessingError
+        {
+            get
+            {
+                return ResourceManager.GetString("SkipTokenProcessingError", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The limit of &apos;{0}&apos; for {1} query has been exceeded. The value from the incoming request is &apos;{2}&apos;..
         /// </summary>
         internal static string SkipTopLimitExceeded

--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
@@ -1009,4 +1009,7 @@
   <data name="ObjectToDeleteNotFound" xml:space="preserve">
     <value>Object to delete not found.</value>
   </data>
+  <data name="SkipTokenProcessingError" xml:space="preserve">
+    <value>Unable to get property values from the skiptoken value.</value>
+  </data>
 </root>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingControllers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingControllers.cs
@@ -65,4 +65,93 @@ namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
             return Ok(hiredInPeriod);
         }
     }
+
+
+    public class SkipTokenPagingS1CustomersController : TestODataController
+    {
+        private static readonly List<SkipTokenPagingCustomer> customers = new List<SkipTokenPagingCustomer>
+        {
+            new SkipTokenPagingCustomer { Id = 1, CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 2, CreditLimit = 2 },
+            new SkipTokenPagingCustomer { Id = 3, CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 4, CreditLimit = 30 },
+            new SkipTokenPagingCustomer { Id = 5, CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 6, CreditLimit = 35 },
+            new SkipTokenPagingCustomer { Id = 7, CreditLimit = 5 },
+            new SkipTokenPagingCustomer { Id = 8, CreditLimit = 50 },
+            new SkipTokenPagingCustomer { Id = 9, CreditLimit = 25 },
+        };
+
+        [EnableQuery(PageSize = 2)]
+        public ITestActionResult Get()
+        {
+            return Ok(customers);
+        }
+    }
+
+    public class SkipTokenPagingS2CustomersController : TestODataController
+    {
+        private readonly List<SkipTokenPagingCustomer> customers = new List<SkipTokenPagingCustomer>
+        {
+            new SkipTokenPagingCustomer { Id = 1, Grade = "A", CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 2, Grade = "B", CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 3, Grade = "A", CreditLimit = 10 },
+            new SkipTokenPagingCustomer { Id = 4, Grade = "C", CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 5, Grade = "A", CreditLimit = 30 },
+            new SkipTokenPagingCustomer { Id = 6, Grade = "C", CreditLimit = null },
+            new SkipTokenPagingCustomer { Id = 7, Grade = "B", CreditLimit = 5 },
+            new SkipTokenPagingCustomer { Id = 8, Grade = "C", CreditLimit = 25 },
+            new SkipTokenPagingCustomer { Id = 9, Grade = "B", CreditLimit = 50 },
+            new SkipTokenPagingCustomer { Id = 10, Grade = "D", CreditLimit = 50 },
+            new SkipTokenPagingCustomer { Id = 11, Grade = "F", CreditLimit = 35 },
+            new SkipTokenPagingCustomer { Id = 12, Grade = "F", CreditLimit = 30 },
+            new SkipTokenPagingCustomer { Id = 13, Grade = "F", CreditLimit = 55 }
+        };
+
+        [EnableQuery(PageSize = 4)]
+        public ITestActionResult Get()
+        {
+            return Ok(customers);
+        }
+    }
+
+    public class SkipTokenPagingS3CustomersController : TestODataController
+    {
+        private static readonly List<SkipTokenPagingCustomer> customers = new List<SkipTokenPagingCustomer>
+        {
+            new SkipTokenPagingCustomer { Id = 1, CustomerSince = null },
+            new SkipTokenPagingCustomer { Id = 2, CustomerSince = new DateTime(2023, 1, 2) },
+            new SkipTokenPagingCustomer { Id = 3, CustomerSince = null },
+            new SkipTokenPagingCustomer { Id = 4, CustomerSince = new DateTime(2023, 1, 30) },
+            new SkipTokenPagingCustomer { Id = 5, CustomerSince = null },
+            new SkipTokenPagingCustomer { Id = 6, CustomerSince = new DateTime(2023, 2, 4) },
+            new SkipTokenPagingCustomer { Id = 7, CustomerSince = new DateTime(2023, 1, 5) },
+            new SkipTokenPagingCustomer { Id = 8, CustomerSince = new DateTime(2023, 2, 19) },
+            new SkipTokenPagingCustomer { Id = 9, CustomerSince = new DateTime(2023, 1, 25) },
+        };
+
+        [EnableQuery(PageSize = 2)]
+        public ITestActionResult Get()
+        {
+            return Ok(customers);
+        }
+    }
+
+    public class SkipTokenPagingEdgeCase1CustomersController : TestODataController
+    {
+        private static readonly List<SkipTokenPagingEdgeCase1Customer> customers = new List<SkipTokenPagingEdgeCase1Customer>
+        {
+            new SkipTokenPagingEdgeCase1Customer { Id = 2, CreditLimit = 2 },
+            new SkipTokenPagingEdgeCase1Customer { Id = 4, CreditLimit = 30 },
+            new SkipTokenPagingEdgeCase1Customer { Id = 6, CreditLimit = 35 },
+            new SkipTokenPagingEdgeCase1Customer { Id = 7, CreditLimit = 5 },
+            new SkipTokenPagingEdgeCase1Customer { Id = 9, CreditLimit = 25 },
+        };
+
+        [EnableQuery(PageSize = 2)]
+        public ITestActionResult Get()
+        {
+            return Ok(customers);
+        }
+    }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingDataModel.cs
@@ -32,4 +32,18 @@ namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
         public int Id { get; set; }
         public DateTime HireDate { get; set; }
     }
+
+    public class SkipTokenPagingCustomer
+    {
+        public int Id { get; set; }
+        public string Grade { get; set; }
+        public decimal? CreditLimit { get; set; }
+        public DateTime? CustomerSince { get; set; }
+    }
+
+    public class SkipTokenPagingEdgeCase1Customer
+    {
+        public int Id { get; set; }
+        public decimal? CreditLimit { get; set; }
+    }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingTests.cs
@@ -6,14 +6,22 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.AspNet.OData.Builder;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNet.OData.Routing.Conventions;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
 using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Microsoft.Test.E2E.AspNet.OData.Common.Extensions;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
@@ -92,6 +100,609 @@ namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
                 "/prefix/ServerSidePagingEmployees/GetEmployeesHiredInPeriod(fromDate=@fromDate,toDate=@toDate)" +
                 "?%40fromDate=2023-01-07T00%3A00%3A00%2B00%3A00&%40toDate=2023-05-07T00%3A00%3A00%2B00%3A00&$skip=3",
                 content);
+        }
+    }
+
+    public class SkipTokenPagingTests : WebHostTestBase
+    {
+        public SkipTokenPagingTests(WebHostTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            configuration.Select().Filter().OrderBy().Expand().Count().MaxTop(null).SkipToken();
+            // NOTE: Brackets in prefix to force a call into `RouteCollection`'s `GetVirtualPath`
+            configuration.MapODataServiceRoute(
+                routeName: "bracketsInPrefix",
+                routePrefix: "{a}",
+                model: GetEdmModel(configuration),
+                pathHandler: new DefaultODataPathHandler(),
+                routingConventions: ODataRoutingConventions.CreateDefault());
+        }
+
+        protected static IEdmModel GetEdmModel(WebRouteConfiguration configuration)
+        {
+            ODataModelBuilder builder = configuration.CreateConventionModelBuilder();
+            builder.EntitySet<SkipTokenPagingCustomer>("SkipTokenPagingS1Customers");
+            builder.EntitySet<SkipTokenPagingCustomer>("SkipTokenPagingS2Customers");
+            builder.EntitySet<SkipTokenPagingCustomer>("SkipTokenPagingS3Customers");
+
+            return builder.GetEdmModel();
+        }
+
+        [Fact]
+        public async Task VerifySkipTokenPagingOrderedByNullableProperty()
+        {
+            HttpRequestMessage request;
+            HttpResponseMessage response;
+            JObject content;
+            JArray pageResult;
+
+            // NOTE: Using a loop in this test (as opposed to parameterized tests using xunit Theory attribute)
+            // is intentional. The next-link in one response is used in the next request
+            // so we need to control the execution order (unlike Theory attribute where order is random)
+            var skipTokenTestData = new List<Tuple<int, decimal?, int, decimal?>>
+            {
+                Tuple.Create<int, decimal?, int, decimal?> (1, null, 3, null),
+                Tuple.Create<int, decimal?, int, decimal?> (5, null, 2, 2),
+                Tuple.Create<int, decimal?, int, decimal?> (7, 5, 9, 25),
+                Tuple.Create<int, decimal?, int, decimal?>(4, 30, 6, 35)
+            };
+
+            string requestUri = this.BaseAddress + "/prefix/SkipTokenPagingS1Customers?$orderby=CreditLimit";
+
+            foreach (var testData in skipTokenTestData)
+            {
+                int idAt0 = testData.Item1;
+                decimal? creditLimitAt0 = testData.Item2;
+                int idAt1 = testData.Item3;
+                decimal? creditLimitAt1 = testData.Item4;
+
+                // Arrange
+                request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                string skipToken = string.Concat("$skiptoken=CreditLimit-", creditLimitAt1 != null ? creditLimitAt1.ToString() : "null", ",Id-", idAt1);
+
+                // Act
+                response = await this.Client.SendAsync(request);
+                content = await response.Content.ReadAsObject<JObject>();
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                pageResult = content["value"] as JArray;
+                Assert.NotNull(pageResult);
+                Assert.Equal(2, pageResult.Count);
+                Assert.Equal(idAt0, (pageResult[0] as JObject)["Id"].ToObject<int>());
+                Assert.Equal(creditLimitAt0, (pageResult[0] as JObject)["CreditLimit"].ToObject<decimal?>());
+                Assert.Equal(idAt1, (pageResult[1] as JObject)["Id"].ToObject<int>());
+                Assert.Equal(creditLimitAt1, (pageResult[1] as JObject)["CreditLimit"].ToObject<decimal?>());
+
+                string nextPageLink = content["@odata.nextLink"].ToObject<string>();
+                Assert.NotNull(nextPageLink);
+                Assert.EndsWith("/prefix/SkipTokenPagingS1Customers?$orderby=CreditLimit&" + skipToken, nextPageLink);
+
+                requestUri = nextPageLink;
+            }
+
+            // Fetch last page
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            response = await this.Client.SendAsync(request);
+
+            content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            pageResult = content["value"] as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult);
+            Assert.Equal(8, (pageResult[0] as JObject)["Id"].ToObject<int>());
+            Assert.Equal(50, (pageResult[0] as JObject)["CreditLimit"].ToObject<decimal?>());
+            Assert.Null(content.GetValue("@odata.nextLink"));
+        }
+
+        [Fact]
+        public async Task VerifySkipTokenPagingOrderedByNullablePropertyDescending()
+        {
+            HttpRequestMessage request;
+            HttpResponseMessage response;
+            JObject content;
+            JArray pageResult;
+
+            // NOTE: Using a loop in this test (as opposed to parameterized tests using xunit Theory attribute)
+            // is intentional. The next-link in one response is used in the next request
+            // so we need to control the execution order (unlike Theory attribute where order is random)
+            var skipTokenTestData = new List<Tuple<int, decimal?>>
+            {
+                Tuple.Create<int, decimal ?> (6, 35),
+                Tuple.Create<int, decimal?> (9, 25),
+                Tuple.Create<int, decimal?> (2, 2),
+                Tuple.Create<int, decimal?>(3, null)
+            };
+
+            string requestUri = this.BaseAddress + "/prefix/SkipTokenPagingS1Customers?$orderby=CreditLimit desc";
+
+            foreach (var testData in skipTokenTestData)
+            {
+                int idAt1 = testData.Item1;
+                decimal? creditLimitAt1 = testData.Item2;
+
+                // Arrange
+                request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                string skipToken = string.Concat("$skiptoken=CreditLimit-", creditLimitAt1 != null ? creditLimitAt1.ToString() : "null", ",Id-", idAt1);
+
+                // Act
+                response = await this.Client.SendAsync(request);
+                content = await response.Content.ReadAsObject<JObject>();
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                pageResult = content["value"] as JArray;
+                Assert.NotNull(pageResult);
+                Assert.Equal(2, pageResult.Count);
+                Assert.Equal(idAt1, (pageResult[1] as JObject)["Id"].ToObject<int>());
+                Assert.Equal(creditLimitAt1, (pageResult[1] as JObject)["CreditLimit"].ToObject<decimal?>());
+
+                string nextPageLink = content["@odata.nextLink"].ToObject<string>();
+                Assert.NotNull(nextPageLink);
+                Assert.EndsWith("/prefix/SkipTokenPagingS1Customers?$orderby=CreditLimit%20desc&" + skipToken, nextPageLink);
+
+                requestUri = nextPageLink;
+            }
+
+            // Fetch last page
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            response = await this.Client.SendAsync(request);
+
+            content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            pageResult = content["value"] as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult);
+            Assert.Equal(5, (pageResult[0] as JObject)["Id"].ToObject<int>());
+            Assert.Null((pageResult[0] as JObject)["CreditLimit"].ToObject<decimal?>());
+            Assert.Null(content.GetValue("@odata.nextLink"));
+        }
+
+        [Fact]
+        public async Task VerifySkipTokenPagingOrderedByNonNullablePropertyThenByNullableProperty()
+        {
+            HttpRequestMessage request;
+            HttpResponseMessage response;
+            JObject content;
+            JArray pageResult;
+
+            // NOTE: Using a loop in this test (as opposed to parameterized tests using xunit Theory attribute)
+            // is intentional. The next-link in one response is used in the next request
+            // so we need to control the execution order (unlike Theory attribute where order is random)
+            var skipTokenTestData = new List<Tuple<int, string, decimal?>>
+            {
+                Tuple.Create<int, string, decimal?> (2, "B", null),
+                Tuple.Create<int, string, decimal?> (6, "C", null),
+                Tuple.Create<int, string, decimal?> (11, "F", 35),
+            };
+
+            string requestUri = this.BaseAddress + "/prefix/SkipTokenPagingS2Customers?$orderby=Grade,CreditLimit";
+
+            foreach (var testData in skipTokenTestData)
+            {
+                int idAt3 = testData.Item1;
+                string gradeAt3 = testData.Item2;
+                decimal? creditLimitAt3 = testData.Item3;
+
+                // Arrange
+                request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                string skipToken = string.Concat("$skiptoken=Grade-%27", gradeAt3, "%27,CreditLimit-", creditLimitAt3 != null ? creditLimitAt3.ToString() : "null", ",Id-", idAt3);
+
+                // Act
+                response = await this.Client.SendAsync(request);
+                content = await response.Content.ReadAsObject<JObject>();
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                pageResult = content["value"] as JArray;
+                Assert.NotNull(pageResult);
+                Assert.Equal(4, pageResult.Count);
+                Assert.Equal(idAt3, (pageResult[3] as JObject)["Id"].ToObject<int>());
+                Assert.Equal(gradeAt3, (pageResult[3] as JObject)["Grade"].ToObject<string>());
+                Assert.Equal(creditLimitAt3, (pageResult[3] as JObject)["CreditLimit"].ToObject<decimal?>());
+
+                string nextPageLink = content["@odata.nextLink"].ToObject<string>();
+                Assert.NotNull(nextPageLink);
+                Assert.EndsWith("/prefix/SkipTokenPagingS2Customers?$orderby=Grade%2CCreditLimit&" + skipToken, nextPageLink);
+
+                requestUri = nextPageLink;
+            }
+
+            // Fetch last page
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            response = await this.Client.SendAsync(request);
+
+            content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            pageResult = content["value"] as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult);
+            Assert.Equal(13, (pageResult[0] as JObject)["Id"].ToObject<int>());
+            Assert.Equal("F", (pageResult[0] as JObject)["Grade"].ToObject<string>());
+            Assert.Equal(55, (pageResult[0] as JObject)["CreditLimit"].ToObject<decimal?>());
+            Assert.Null(content.GetValue("@odata.nextLink"));
+        }
+
+        [Fact]
+        public async Task VerifySkipTokenPagingOrderedByNullablePropertyThenByNonNullableProperty()
+        {
+            HttpRequestMessage request;
+            HttpResponseMessage response;
+            JObject content;
+            JArray pageResult;
+
+            // NOTE: Using a loop in this test (as opposed to parameterized tests using xunit Theory attribute)
+            // is intentional. The next-link in one response is used in the next request
+            // so we need to control the execution order (unlike Theory attribute where order is random)
+            var skipTokenTestData = new List<Tuple<int, string, decimal?>>
+            {
+                Tuple.Create<int, string, decimal?> (6, "C", null),
+                Tuple.Create<int, string, decimal?> (5, "A", 30),
+                Tuple.Create<int, string, decimal?> (10, "D", 50),
+            };
+
+            string requestUri = this.BaseAddress + "/prefix/SkipTokenPagingS2Customers?$orderby=CreditLimit,Grade";
+
+            foreach (var testData in skipTokenTestData)
+            {
+                int idAt3 = testData.Item1;
+                string gradeAt3 = testData.Item2;
+                decimal? creditLimitAt3 = testData.Item3;
+
+                // Arrange
+                request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                string skipToken = string.Concat("$skiptoken=CreditLimit-", creditLimitAt3 != null ? creditLimitAt3.ToString() : "null", ",Grade-%27", gradeAt3, "%27", ",Id-", idAt3);
+
+                // Act
+                response = await this.Client.SendAsync(request);
+                content = await response.Content.ReadAsObject<JObject>();
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                pageResult = content["value"] as JArray;
+                Assert.NotNull(pageResult);
+                Assert.Equal(4, pageResult.Count);
+                Assert.Equal(idAt3, (pageResult[3] as JObject)["Id"].ToObject<int>());
+                Assert.Equal(gradeAt3, (pageResult[3] as JObject)["Grade"].ToObject<string>());
+                Assert.Equal(creditLimitAt3, (pageResult[3] as JObject)["CreditLimit"].ToObject<decimal?>());
+
+                string nextPageLink = content["@odata.nextLink"].ToObject<string>();
+                Assert.NotNull(nextPageLink);
+                Assert.EndsWith("/prefix/SkipTokenPagingS2Customers?$orderby=CreditLimit%2CGrade&" + skipToken, nextPageLink);
+
+                requestUri = nextPageLink;
+            }
+
+            // Fetch last page
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            response = await this.Client.SendAsync(request);
+
+            content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            pageResult = content["value"] as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult);
+            Assert.Equal(13, (pageResult[0] as JObject)["Id"].ToObject<int>());
+            Assert.Equal("F", (pageResult[0] as JObject)["Grade"].ToObject<string>());
+            Assert.Equal(55, (pageResult[0] as JObject)["CreditLimit"].ToObject<decimal?>());
+            Assert.Null(content.GetValue("@odata.nextLink"));
+        }
+
+        [Fact]
+        public async Task VerifySkipTokenPagingOrderedByNullableDateTimeProperty()
+        {
+            HttpRequestMessage request;
+            HttpResponseMessage response;
+            JObject content;
+            JArray pageResult;
+
+            // NOTE: Using a loop in this test (as opposed to parameterized tests using xunit Theory attribute)
+            // is intentional. The next-link in one response is used in the next request
+            // so we need to control the execution order (unlike Theory attribute where order is random)
+            var skipTokenTestData = new List<Tuple<int, DateTime?, int, DateTime?>>
+            {
+                Tuple.Create<int, DateTime?, int, DateTime?> (1, null, 3, null),
+                Tuple.Create<int, DateTime?, int, DateTime?> (5, null, 2, new DateTime(2023, 1, 2)),
+                Tuple.Create<int, DateTime?, int, DateTime?> (7, new DateTime(2023, 1, 5), 9, new DateTime(2023, 1, 25)),
+                Tuple.Create<int, DateTime?, int, DateTime?>(4, new DateTime(2023, 1, 30), 6, new DateTime(2023, 2, 4))
+            };
+
+            string requestUri = this.BaseAddress + "/prefix/SkipTokenPagingS3Customers?$orderby=CustomerSince";
+            DateTime? customerSince;
+
+            foreach (var testData in skipTokenTestData)
+            {
+                int idAt0 = testData.Item1;
+                DateTime? customerSinceAt0 = testData.Item2;
+                int idAt1 = testData.Item3;
+                DateTime? customerSinceAt1 = testData.Item4;
+
+                // Arrange
+                request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                string skipTokenStart = string.Concat(
+                    "$skiptoken=CustomerSince-",
+                    customerSinceAt1 != null ? customerSinceAt1.Value.ToString("yyyy-MM-dd") : "null");
+                string skipTokenEnd = string.Concat(",Id-", idAt1);
+
+                // Act
+                response = await this.Client.SendAsync(request);
+                content = await response.Content.ReadAsObject<JObject>();
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                pageResult = content["value"] as JArray;
+                Assert.NotNull(pageResult);
+                Assert.Equal(2, pageResult.Count);
+
+                Assert.Equal(idAt0, (pageResult[0] as JObject)["Id"].ToObject<int>());
+                customerSince = (pageResult[0] as JObject)["CustomerSince"].ToObject<DateTime?>();
+                if (customerSinceAt0 == null)
+                {
+                    Assert.Null(customerSince);
+                }
+                else
+                {
+                    Assert.Equal(customerSinceAt0.Value.Date, customerSince.Value.Date);
+                }
+
+                Assert.Equal(idAt1, (pageResult[1] as JObject)["Id"].ToObject<int>());
+                customerSince = (pageResult[1] as JObject)["CustomerSince"].ToObject<DateTime?>();
+                if (customerSinceAt1 == null)
+                {
+                    Assert.Null(customerSince);
+                }
+                else
+                {
+                    Assert.Equal(customerSinceAt1.Value.Date, customerSince.Value.Date);
+                }
+
+                string nextPageLink = content["@odata.nextLink"].ToObject<string>();
+                Assert.NotNull(nextPageLink);
+                Assert.Contains("/prefix/SkipTokenPagingS3Customers?$orderby=CustomerSince&" + skipTokenStart, nextPageLink);
+                Assert.EndsWith(skipTokenEnd, nextPageLink);
+
+                requestUri = nextPageLink;
+            }
+
+            // Fetch last page
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            response = await this.Client.SendAsync(request);
+
+            content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            pageResult = content["value"] as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult);
+            Assert.Equal(8, (pageResult[0] as JObject)["Id"].ToObject<int>());
+            customerSince = (pageResult[0] as JObject)["CustomerSince"].ToObject<DateTime?>();
+            Assert.NotNull(customerSince);
+            Assert.Equal(new DateTime(2023, 2, 19).Date, customerSince.Value.Date);
+            Assert.Null(content.GetValue("@odata.nextLink"));
+        }
+
+        [Fact]
+        public async Task VerifySkipTokenPagingOrderedByNullableDateTimePropertyDescending()
+        {
+            HttpRequestMessage request;
+            HttpResponseMessage response;
+            JObject content;
+            JArray pageResult;
+
+            // NOTE: Using a loop in this test (as opposed to parameterized tests using xunit Theory attribute)
+            // is intentional. The next-link in one response is used in the next request
+            // so we need to control the execution order (unlike Theory attribute where order is random)
+            var skipTokenTestData = new List<Tuple<int, DateTime?>>
+            {
+                Tuple.Create<int, DateTime ?> (6, new DateTime(2023, 2, 4)),
+                Tuple.Create<int, DateTime?> (9, new DateTime(2023, 1, 25)),
+                Tuple.Create<int, DateTime?> (2, new DateTime(2023, 1, 2)),
+                Tuple.Create<int, DateTime?>(3, null)
+            };
+
+            string requestUri = this.BaseAddress + "/prefix/SkipTokenPagingS3Customers?$orderby=CustomerSince desc";
+
+            foreach (var testData in skipTokenTestData)
+            {
+                int idAt1 = testData.Item1;
+                DateTime? customerSinceAt1 = testData.Item2;
+
+                // Arrange
+                request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                string skipTokenStart = string.Concat(
+                    "$skiptoken=CustomerSince-",
+                    customerSinceAt1 != null ? customerSinceAt1.Value.ToString("yyyy-MM-dd") : "null");
+                string skipTokenEnd = string.Concat(",Id-", idAt1);
+
+                // Act
+                response = await this.Client.SendAsync(request);
+                content = await response.Content.ReadAsObject<JObject>();
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                pageResult = content["value"] as JArray;
+                Assert.NotNull(pageResult);
+                Assert.Equal(2, pageResult.Count);
+                Assert.Equal(idAt1, (pageResult[1] as JObject)["Id"].ToObject<int>());
+                DateTime? customerSince = (pageResult[1] as JObject)["CustomerSince"].ToObject<DateTime?>();
+                if (customerSinceAt1 == null)
+                {
+                    Assert.Null(customerSince);
+                }
+                else
+                {
+                    Assert.Equal(customerSinceAt1.Value.Date, customerSince.Value.Date);
+                }
+
+                string nextPageLink = content["@odata.nextLink"].ToObject<string>();
+                Assert.NotNull(nextPageLink);
+                Assert.Contains("/prefix/SkipTokenPagingS3Customers?$orderby=CustomerSince%20desc&" + skipTokenStart, nextPageLink);
+                Assert.EndsWith(skipTokenEnd, nextPageLink);
+
+                requestUri = nextPageLink;
+            }
+
+            // Fetch last page
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            response = await this.Client.SendAsync(request);
+
+            content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            pageResult = content["value"] as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult);
+            Assert.Equal(5, (pageResult[0] as JObject)["Id"].ToObject<int>());
+            Assert.Null((pageResult[0] as JObject)["CustomerSince"].ToObject<DateTime?>());
+            Assert.Null(content.GetValue("@odata.nextLink"));
+        }
+    }
+
+    public class SkipTokenPagingEdgeCaseTests : WebHostTestBase
+    {
+        public SkipTokenPagingEdgeCaseTests(WebHostTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            configuration.Select().Filter().OrderBy().Expand().Count().MaxTop(null).SkipToken();
+            // NOTE: Brackets in prefix to force a call into `RouteCollection`'s `GetVirtualPath`
+            configuration.MapODataServiceRoute(
+                routeName: "bracketsInPrefix",
+                routePrefix: "{a}",
+                model: GetEdmModel(configuration),
+                pathHandler: new DefaultODataPathHandler(),
+                routingConventions: ODataRoutingConventions.CreateDefault());
+        }
+
+        protected static IEdmModel GetEdmModel(WebRouteConfiguration configuration)
+        {
+            var csdl = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+                "<edmx:DataServices>" +
+                "<Schema Namespace=\"" + typeof(SkipTokenPagingEdgeCase1Customer).Namespace + "\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                "<EntityType Name=\"SkipTokenPagingEdgeCase1Customer\">" +
+                "<Key>" +
+                "<PropertyRef Name=\"Id\" />" +
+                "</Key>" +
+                "<Property Name=\"Id\" Type=\"Edm.Int32\" Nullable=\"false\" />" +
+                "<Property Name=\"CreditLimit\" Type=\"Edm.Decimal\" Scale=\"Variable\" Nullable=\"false\" />" + // Property is nullable on CLR type
+                "</EntityType>" +
+                "</Schema>" +
+                "<Schema Namespace=\"Default\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                "<EntityContainer Name=\"Container\">" +
+                "<EntitySet Name=\"SkipTokenPagingEdgeCase1Customers\" EntityType=\"" + typeof(SkipTokenPagingEdgeCase1Customer).FullName + "\" />" +
+                "</EntityContainer>" +
+                "</Schema>" +
+                "</edmx:DataServices>" +
+                "</edmx:Edmx>";
+
+            IEdmModel model;
+
+            using (var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(csdl)))
+            using (var reader = XmlReader.Create(memoryStream))
+            {
+                model = CsdlReader.Parse(reader);
+            }
+
+            return model;
+        }
+
+        [Fact]
+        public async Task VerifySkipTokenPagingForPropertyNullableOnClrTypeButNotNullableOnEdmType()
+        {
+            HttpRequestMessage request;
+            HttpResponseMessage response;
+            JObject content;
+            JArray pageResult;
+
+            // NOTE: Using a loop in this test (as opposed to parameterized tests using xunit Theory attribute)
+            // is intentional. The next-link in one response is used in the next request
+            // so we need to control the execution order (unlike Theory attribute where order is random)
+            var skipTokenTestData = new List<Tuple<int, decimal?, int, decimal?>>
+            {
+                Tuple.Create<int, decimal?, int, decimal?>(2, 2, 7, 5),
+                Tuple.Create<int, decimal?, int, decimal?>(9, 25, 4, 30),
+            };
+
+            string requestUri = this.BaseAddress + "/prefix/SkipTokenPagingEdgeCase1Customers?$orderby=CreditLimit";
+
+            foreach (var testData in skipTokenTestData)
+            {
+                int idAt0 = testData.Item1;
+                decimal? creditLimitAt0 = testData.Item2;
+                int idAt1 = testData.Item3;
+                decimal? creditLimitAt1 = testData.Item4;
+
+                // Arrange
+                request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                string skipToken = string.Concat("$skiptoken=CreditLimit-", creditLimitAt1 != null ? creditLimitAt1.ToString() : "null", ",Id-", idAt1);
+
+                // Act
+                response = await this.Client.SendAsync(request);
+                content = await response.Content.ReadAsObject<JObject>();
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                pageResult = content["value"] as JArray;
+                Assert.NotNull(pageResult);
+                Assert.Equal(2, pageResult.Count);
+                Assert.Equal(idAt0, (pageResult[0] as JObject)["Id"].ToObject<int>());
+                Assert.Equal(creditLimitAt0, (pageResult[0] as JObject)["CreditLimit"].ToObject<decimal?>());
+                Assert.Equal(idAt1, (pageResult[1] as JObject)["Id"].ToObject<int>());
+                Assert.Equal(creditLimitAt1, (pageResult[1] as JObject)["CreditLimit"].ToObject<decimal?>());
+
+                string nextPageLink = content["@odata.nextLink"].ToObject<string>();
+                Assert.NotNull(nextPageLink);
+                Assert.EndsWith("/prefix/SkipTokenPagingEdgeCase1Customers?$orderby=CreditLimit&" + skipToken, nextPageLink);
+
+                requestUri = nextPageLink;
+            }
+
+            // Fetch last page
+            request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            response = await this.Client.SendAsync(request);
+
+            content = await response.Content.ReadAsObject<JObject>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            pageResult = content["value"] as JArray;
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult);
+            Assert.Equal(6, (pageResult[0] as JObject)["Id"].ToObject<int>());
+            Assert.Equal(35, (pageResult[0] as JObject)["CreditLimit"].ToObject<decimal?>());
+            Assert.Null(content.GetValue("@odata.nextLink"));
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #1943, fixes #2041, and fixes #2561*

## Description
Consider a simple scenario involving a data sample comprising of `Id` key field and a non-unique nullable field `CreditLimit`:
| Id | CreditLimit |
| -- | ------------ |
| 1 | null |
| 2 | 2 |
| 3 | null |
| 4 | 30 |
| 5 | null |
| 6 | 35 |
| 7 | 5 |
| 8 | 50 |
| 9 | 25 |

From the controller action, we could configure a page size of 2:
```csharp
[EnableQuery(PageSize = 2)]
public ActionResult<IEnumerable<S1Customer>> Get()
{
    return new List<S1Customer>
    {
        new S1Customer { Id = 1, CreditLimit = null },
        new S1Customer { Id = 2, CreditLimit = 2 },
        new S1Customer { Id = 3, CreditLimit = null },
        new S1Customer { Id = 4, CreditLimit = 30 },
        new S1Customer { Id = 5, CreditLimit = null },
        new S1Customer { Id = 6, CreditLimit = 35 },
        new S1Customer { Id = 7, CreditLimit = 5 },
        new S1Customer { Id = 8, CreditLimit = 50 },
        new S1Customer { Id = 9, CreditLimit = 25 },
    };
}
```

When the data sample is ordered by `CreditLimit` field (`$orderby=CreditLimit`), and then internally by `Id` (for uniqueness and predictability - stable ordering), the ordered data sample would look at follows:
| CreditLimit | Id |
| ------------ | -- |
| null | 1 |
| null | 3 |
| null | 5 |
| 2 | 2 |
| 5 | 7 |
| 25 | 9 |
| 30 | 4 |
| 35 | 6 |
| 50 | 8 |

If we query for the `S1Customers` entity set and order by `CreditLimit`, we get the following response:
```http
GET: http://localhost:5000/odata/S1Customers?$orderby=CreditLimit
```
#### Response:
```json
{
    "@odata.context": "http://localhost:5000/odata/$metadata#S1Customers",
    "value": [
        {
            "Id": 1,
            "CreditLimit": null
        },
        {
            "Id": 3,
            "CreditLimit": null
        }
    ],
    "@odata.nextLink": "http://localhost:5000/odata/S1Customers?$orderby=CreditLimit&$skiptoken=CreditLimit-null,Id-3"
}
```

While the response is correct (including the next-link), if we attempt to use the returned next link to fetch the next batch of records, the following error message is returned:
```
The query specified in the URI is not valid. The binary operator GreaterThan is not defined for the types 'System.Nullable`1[System.Decimal]' and 'Microsoft.OData.ODataNullValue'.
```
What is happening here is that we’re mishandling the null value and attempting to apply a greater-than operator between the nullable `CreditLimit` field and the `ODataNullValue`.

This pull request fixes this issue by ensuring that a valid `Where` expression is composed as follows:
- for skiptoken value **`CreditLimit-null,Id-3`** in ascending order scenario - `$orderby=CreditLimit`, we compose the `Where` expression as: **`(CreditLimit ne null OR (CreditLimit eq null AND Id gt 3))`**
- for skiptoken value **`CreditLimit-2,Id-2`** in ascending order scenario - `$orderby=CreditLimit`, we compose the `Where` expression as: **`(CreditLimit gt 2 OR (CreditLimit eq 2 AND Id gt 2))`**
- for skiptoken value **`CreditLimit-null,Id-3`** in descending order scenario - `$orderby=CreditLimit desc`, we compose the `Where` expression as: **`(CreditLimit eq null AND Id gt 3)`**
- for skiptoken value **`CreditLimit-35,Id-6`** in descending order scenario - `$orderby=CreditLimit desc`, we compose the `Where` expression as: **`(CreditLimit lt 35 OR (CreditLimit eq 35 AND Id gt 6))`**


Consider also a more advanced scenario involving a data sample comprising of `Id` key field, a non-nullable field `Grade`, and a non-unique nullable field `CreditLimit`:
| Id | Grade | CreditLimit |
| -- | ----- | ------------ |
| 1 | A | null |
| 2 | B | null |
| 3 | A | 10 |
| 4 | C | null |
| 5 | A | 30 |
| 6 | C | null |
| 7 | B | 5 |
| 8 | C | 25 |
| 9 | B | 50 |
| 10 | D | 50 |
| 11 | F | 35 |
| 12 | F | 30 |
| 13 | F | 55 |

From the controller action, we would configure a page size of 4 as follows:
```csharp
[EnableQuery(PageSize = 4)]
public ActionResult<IEnumerable<S2Customer>> Get()
{
    return new List<S2Customer>
    {
        new S2Customer { Id = 1, Grade = "A", CreditLimit = null },
        new S2Customer { Id = 2, Grade = "B", CreditLimit = null },
        new S2Customer { Id = 3, Grade = "A", CreditLimit = 10 },
        new S2Customer { Id = 4, Grade = "C", CreditLimit = null },
        new S2Customer { Id = 5, Grade = "A", CreditLimit = 30 },
        new S2Customer { Id = 6, Grade = "C", CreditLimit = null },
        new S2Customer { Id = 7, Grade = "B", CreditLimit = 5 },
        new S2Customer { Id = 8, Grade = "C", CreditLimit = 25 },
        new S2Customer { Id = 9, Grade = "B", CreditLimit = 50 },
        new S2Customer { Id = 10, Grade = "D", CreditLimit = 50 },
        new S2Customer { Id = 11, Grade = "F", CreditLimit = 35 },
        new S2Customer { Id = 12, Grade = "F", CreditLimit = 30 }
    };
}
```

When the data sample is ordered by `Grade` and then by `CreditLimit` field ($orderby=Grade,CreditLimit), and then internally by `Id` (for uniqueness and predictability - stable ordering), the ordered data sample would look at follows:
| Grade | CreditLimit | Id |
| ----- | ----------- | -- |
| A | null | 1 |
| A | 10 | 3 |
| A | 30 | 5 |
| B | null | 2 |
| B | 5 | 7 |
| B | 50 | 9 |
| C | null | 4 |
| C | null | 6 |
| C | 25 | 8 |
| D | 50 | 10 |
| F | 30 | 12 |
| F | 35 | 11 |
| F | 55 | 13 |

If we query for the `S2Customers` entity set and orderby `Grade` and then by `CreditLimit`, we get the following response:
```http
GET: http://localhost:5000/odata/S2Customers?$orderby=Grade,CreditLimit
```
#### Response
```json
{
    "@odata.context": "http://localhost:5000/odata/$metadata#S2Customers",
    "value": [
        {
            "Id": 1,
            "Grade": "A",
            "CreditLimit": null
        },
        {
            "Id": 3,
            "Grade": "A",
            "CreditLimit": 10.00
        },
        {
            "Id": 5,
            "Grade": "A",
            "CreditLimit": 30.00
        },
        {
            "Id": 2,
            "Grade": "B",
            "CreditLimit": null
        }
    ],
    "@odata.nextLink": "http://localhost:5000/odata/S2Customers?$orderby=Grade%2CCreditLimit&$skiptoken=Grade-%27B%27,CreditLimit-null,Id-2"
}
```

Again, the response is correct (including the next-link), but if we attempt to use the returned next link to fetch the next batch of records, the following error message is returned:
```
The query specified in the URI is not valid. The binary operator GreaterThan is not defined for the types 'System.Nullable`1[System.Decimal]' and 'Microsoft.OData.ODataNullValue'.
```

Again, this is due to mishandling of the null value.

In this pull request we ensure that a valid `Where` expression is composed as follows:
- for skiptoken value of **`Grade-B,CreditLimit-null,Id-2`** in ascending order scenario - `$orderby=Grade,CreditLimit`, we compose the `Where` expression as: **`Grade gt B OR (Grade eq B AND (CreditLimit ne null OR (CreditLimit eq null AND Id gt 2)))`**
- for skiptoken value of **`Grade-F,CreditLimit-30,Id-12`** in ascending order scenario - `$orderby=Grade,CreditLimit`, we compose the `Where` expression as: **`Grade gt F OR (Grade eq F AND (CreditLimit gt 30 OR (CreditLimit eq 30 AND Id gt 12)))`**
- for skiptoken value of **`CreditLimit-null,Grade-C,Id-6`** in ascending order scenario - `$orderby=CreditLimit,Grade`, we compose the `Where` expression as: **`CreditLimit ne null OR (CreditLimit eq null AND (Grade gt C OR (Grade eq C AND Id gt 6)))`**
- for skiptoken value of **`CreditLimit-30,Grade-A,Id-5`** in ascending order scenario - `$orderby=CreditLimit,Grade`, we compose the `Where` expression as: **`CreditLimit gt 30 OR (CreditLimit eq 30 AND (Grade gt A OR (Grade eq A AND Id gt 5)))`**

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
