### PR TITLE
Fixes #2737: Support getting navigation source for complex types

### DIFF
--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/ODataResourceDeserializerTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/ODataResourceDeserializerTests.cs
@@ -1674,7 +1674,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
         [Fact]
         public void GenerateNestedReadContext_Generates_NestedDeserializerContextForUnboundNavigationProperty()
         {
-            //Arrange
+            // Arrange
             IEdmEntitySet suppliersEntitySet = _edmModel.EntityContainer.FindEntitySet("Suppliers");
             IEdmEntityTypeReference supplierTypeReference = _edmModel.GetEdmTypeReference(typeof(Supplier)).AsEntity();
             IEdmStructuralProperty addressProperty = supplierTypeReference.FindProperty("Address") as IEdmStructuralProperty;
@@ -1702,11 +1702,11 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
                 Request = RequestFactory.Create(),
             };
 
-            //Act
+            // Act
             ODataDeserializerContext addressNestedContext = ODataResourceDeserializerHelpers.GenerateNestedReadContext(addressNestedResourceInfoWrapper, currentContext, addressProperty);
             ODataDeserializerContext suppliersNestedContext = ODataResourceDeserializerHelpers.GenerateNestedReadContext(suppliersNestedResourceInfoWrapper, addressNestedContext, suppliersProperty);
 
-            ///Assert
+            // Assert
             Assert.NotNull(suppliersNestedContext.Path);
             Assert.Equal(expectedOdataPath.ToString(), suppliersNestedContext.Path.ToString());
         }
@@ -1714,7 +1714,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
         [Fact]
         public void GenerateNestedReadContext_Generates_NestedDeserializerContextForDerivedComplexType()
         {
-            //Arrange
+            // Arrange
             IEdmEntitySet suppliersEntitySet = _edmModel.EntityContainer.FindEntitySet("Suppliers");
             IEdmEntityTypeReference supplierTypeReference = _edmModel.GetEdmTypeReference(typeof(Supplier)).AsEntity();
             IEdmProperty addressProperty = supplierTypeReference.FindProperty("Address");
@@ -1736,11 +1736,11 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
                 Request = RequestFactory.Create(),
             };
 
-            //Act
+            // Act
             ODataDeserializerContext addressNestedContext = ODataResourceDeserializerHelpers.GenerateNestedReadContext(addressNestedResourceInfoWrapper, currentContext, addressProperty);
             ODataDeserializerContext derivedSuppliersNestedContext = ODataResourceDeserializerHelpers.GenerateNestedReadContext(suppliersNestedResourceInfoWrapper, addressNestedContext, derivedSuppliersProperty);
 
-            ///Assert
+            // Assert
             Assert.NotNull(derivedSuppliersNestedContext.Path);
             Assert.Equal(expectedOdataPath.ToString(), derivedSuppliersNestedContext.Path.ToString());
         }
@@ -1748,7 +1748,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
         [Fact]
         public void GenerateNestedReadContext_Generates_NestedDeserializerContextOnDynamicType()
         {
-            //Arrange
+            // Arrange
             IEdmEntitySet suppliersEntitySet = _edmModel.EntityContainer.FindEntitySet("Suppliers");
             IEdmComplexTypeReference addressTypeReference = _edmModel.GetEdmTypeReference(typeof(Address)).AsComplex();
             IEdmNavigationProperty suppliersProperty = addressTypeReference.FindNavigationProperty("Suppliers");
@@ -1775,13 +1775,13 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
                 Request = RequestFactory.Create(),
             };
 
-            //Act
+            // Act
             // Dynamic
             ODataDeserializerContext dynamicNestedContext = ODataResourceDeserializerHelpers.GenerateNestedReadContext(dynamicNestedResourceInfoWrapper, currentContext, null);
             // Supplier
             ODataDeserializerContext suppliersNestedContext = ODataResourceDeserializerHelpers.GenerateNestedReadContext(supplierNestedResourceInfoWrapper, dynamicNestedContext, suppliersProperty);
 
-            ///Assert
+            // Assert
             Assert.NotNull(suppliersNestedContext.Path);
             Assert.Equal(expectedOdataPath.ToString(), suppliersNestedContext.Path.ToString());
         }
@@ -1789,7 +1789,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
         [Fact(Skip = "Navigation property bindings ending in cast segments not yet fully supported.")]
         public void GenerateNestedReadContext_Generates_NestedDeserializerContextWithSingleBindingEndingInCastSegment()
         {
-            //Arrange
+            // Arrange
             IEdmEntitySet suppliersEntitySet = _edmModel.EntityContainer.FindEntitySet("Suppliers");
             IEdmEntitySet productsEntitySet = _edmModel.EntityContainer.FindEntitySet("Products");
             IEdmEntitySet preferredProductsEntitySet = _edmModel.EntityContainer.FindEntitySet("PreferredProducts");
@@ -1811,12 +1811,12 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
                 Request = RequestFactory.Create(),
             };
 
-            ///Act
+            // Act
             ODataDeserializerContext productsNestedContext = ODataResourceDeserializerHelpers.GenerateNestedReadContext(productsNestedResourceInfoWrapper, currentContext, productsProperty);
             ODataDeserializerContext preferredProductsNestedContext = ODataResourceDeserializerHelpers.GenerateNestedReadContext(preferredProductsNestedResourceInfoWrapper, currentContext, productsProperty);
             ODataDeserializerContext preferredProductNestedContext = ODataResourceDeserializerHelpers.GenerateNestedReadContext(preferredProductsNestedResourceInfoWrapper, preferredProductsNestedContext, productsProperty);
 
-            ///Assert
+            // Assert
             Assert.NotNull(productsNestedContext.Path);
             Assert.Equal(expectedOdataPath.ToString(), productsNestedContext.Path.ToString());
             Assert.NotNull(preferredProductsNestedContext.Path);
@@ -1826,7 +1826,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
         [Fact(Skip = "Bindings ending in cast segments not fully supported yet.")]
         public void GenerateNestedReadContext_Generates_NestedDeserializerContextWithBindingEndingInCastSegment()
         {
-            //Arrange
+            // Arrange
             IEdmEntitySet suppliersEntitySet = _edmModel.EntityContainer.FindEntitySet("Suppliers");
             IEdmEntitySet preferredSuppliersEntitySet = _edmModel.EntityContainer.FindEntitySet("PreferredSuppliers");
             IEdmEntityTypeReference supplierTypeReference = _edmModel.GetEdmTypeReference(typeof(Supplier)).AsEntity();
@@ -1852,11 +1852,11 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
             ODataDeserializerContext addressNestedContext = ODataResourceDeserializerHelpers.GenerateNestedReadContext(addressNestedResourceInfoWrapper, currentContext, addressProperty);
             ODataDeserializerContext suppliersNestedContext = ODataResourceDeserializerHelpers.GenerateNestedReadContext(suppliersNestedResourceInfoWrapper, addressNestedContext, suppliersProperty);
 
-            ///Act
+            // Act
             ODataResourceSetDeserializer deserializer = new ODataResourceSetDeserializer(ODataDeserializerProviderFactory.Create());
             deserializer.ReadInline(suppliersNestedResourceSetWrapper, supplierTypeReference, suppliersNestedContext);
 
-            ///Assert
+            // Assert
             Assert.NotNull(suppliersNestedContext.Path);
             Assert.Equal(expectedOdataPath.ToString(), suppliersNestedContext.Path.ToString());
         }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Resources/ProductsCsdl.xml
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Resources/ProductsCsdl.xml
@@ -20,6 +20,7 @@
         <NavigationProperty Name="Category" Type="ODataDemo.Category" Partner="Products" />
         <NavigationProperty Name="Supplier" Type="ODataDemo.Supplier" Partner="Products" />
       </EntityType>
+      <EntityType Name="PreferredProduct" BaseType="ODataDemo.Product"/>
       <EntityType Name="Category">
         <Key>
           <PropertyRef Name="ID" />
@@ -39,6 +40,7 @@
         <Property Name="Concurrency" Type="Edm.Int32" Nullable="false" />
         <NavigationProperty Name="Products" Type="Collection(ODataDemo.Product)" Partner="Supplier" />
       </EntityType>
+      <EntityType Name="PreferredSuppliers" BaseType="ODataDemo.Suppliers"/>
       <ComplexType Name="Address">
         <Property Name="Street" Type="Edm.String" />
         <Property Name="City" Type="Edm.String" />
@@ -46,7 +48,13 @@
         <Property Name="ZipCode" Type="Edm.String" />
         <Property Name="CountryOrRegion" Type="Edm.String" />
         <NavigationProperty Name="Suppliers" Type="Collection(ODataDemo.Supplier)"/>
+        <NavigationProperty Name="UnboundSuppliers" Type="Collection(ODataDemo.Supplier)"/>
+        <NavigationProperty Name="HeterogenousSuppliers" Type="Collection(ODataDemo.Supplier)"/>
 	  </ComplexType>
+      <ComplexType Name="DerivedAddress" BaseType="ODataDemo.Address">
+        <NavigationProperty Name="DerivedSuppliers" Type="Collection(ODataDemo.Supplier)"/>
+        <NavigationProperty Name="DerivedUnboundSuppliers" Type="Collection(ODataDemo.Supplier)"/>
+      </ComplexType>
       <Function Name="GetProductsByRating" m:HttpMethod="GET">
         <ReturnType Type="Collection(ODataDemo.Product)" />
         <Parameter Name="rating" Type="Edm.Int32" Nullable="false" />
@@ -59,15 +67,22 @@
         <EntitySet Name="Categories" EntityType="ODataDemo.Category">
           <NavigationPropertyBinding Path="Products" Target="Products" />
         </EntitySet>
-        <EntitySet Name="Suppliers" EntityType="ODataDemo.Supplier">
+        <EntitySet Name="PreferredSuppliers" EntityType="ODataDemo.PreferredSuppliers"/>
+        <EntitySet Name="PreferredProducts" EntityType="ODataDemo.PreferredProduct"/>
+		  <EntitySet Name="Suppliers" EntityType="ODataDemo.Supplier">
           <NavigationPropertyBinding Path="Products" Target="Products" />
           <Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
             <Collection>
               <PropertyPath>Concurrency</PropertyPath>
             </Collection>
           </Annotation>
+          <NavigationPropertyBinding Path="Products" Target="Products" />
+		  <NavigationPropertyBinding Path="Products/ODataDemo.PreferredProducts" Target="PreferredProducts" />
 		  <NavigationPropertyBinding Path="Address/Suppliers" Target="Suppliers" />
-		</EntitySet>
+          <NavigationPropertyBinding Path="Address/ODataDemo.DerivedAddress/DerivedSuppliers" Target="Suppliers" />
+          <NavigationPropertyBinding Path="Address/HeterogenousSuppliers" Target="Suppliers" />
+          <NavigationPropertyBinding Path="Address/HeterogenousSuppliers/ODataDemo.PreferredSuppliers" Target="PreferredSuppliers" />
+		  </EntitySet>
         <FunctionImport Name="GetProductsByRating" Function="ODataDemo.GetProductsByRating" EntitySet="Products" IncludeInServiceDocument="true" />
       </EntityContainer>
     </Schema>

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Resources/ProductsCsdl.xml
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Resources/ProductsCsdl.xml
@@ -45,7 +45,8 @@
         <Property Name="State" Type="Edm.String" />
         <Property Name="ZipCode" Type="Edm.String" />
         <Property Name="CountryOrRegion" Type="Edm.String" />
-      </ComplexType>
+        <NavigationProperty Name="Suppliers" Type="Collection(ODataDemo.Supplier)"/>
+	  </ComplexType>
       <Function Name="GetProductsByRating" m:HttpMethod="GET">
         <ReturnType Type="Collection(ODataDemo.Product)" />
         <Parameter Name="rating" Type="Edm.Int32" Nullable="false" />
@@ -65,7 +66,8 @@
               <PropertyPath>Concurrency</PropertyPath>
             </Collection>
           </Annotation>
-        </EntitySet>
+		  <NavigationPropertyBinding Path="Address/Suppliers" Target="Suppliers" />
+		</EntitySet>
         <FunctionImport Name="GetProductsByRating" Function="ODataDemo.GetProductsByRating" EntitySet="Products" IncludeInServiceDocument="true" />
       </EntityContainer>
     </Schema>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2737*

### Description

New code for keeping accurate path for deserialization context assumed navigation property was on entity.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

Could use more tests:
- [x] no nav prop binding
- [x] nav prop on derived type
- [ ] bindingpath ends in type segment
- [x] nav property on a dynamic type
