### PR TITLE
AutoExpand does not expand beyond non-default MaxExpansionDepth

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/ODataQueryContext.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ODataQueryContext.cs
@@ -156,6 +156,11 @@ namespace Microsoft.AspNet.OData
 
         internal string TargetName { get; private set; }
 
+        /// <summary>
+        /// Gets or sets the query validation settings.
+        /// </summary>
+        internal ODataValidationSettings ValidationSettings { get; set; }
+
         private static IEdmNavigationSource GetNavigationSource(IEdmModel model, IEdmType elementType, ODataPath odataPath)
         {
             Contract.Assert(model != null);

--- a/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ODataQueryOptions.cs
@@ -585,6 +585,8 @@ namespace Microsoft.AspNet.OData.Query
                 throw Error.ArgumentNull("validationSettings");
             }
 
+            Context.ValidationSettings = validationSettings;
+
             if (Validator != null)
             {
                 Validator.Validate(this, validationSettings);
@@ -792,6 +794,10 @@ namespace Microsoft.AspNet.OData.Query
                 if (originalSelectExpand != null && originalSelectExpand.LevelsMaxLiteralExpansionDepth > 0)
                 {
                     SelectExpand.LevelsMaxLiteralExpansionDepth = originalSelectExpand.LevelsMaxLiteralExpansionDepth;
+                }
+                else if (Context.ValidationSettings != null && Context.ValidationSettings.MaxExpansionDepth > 0)
+                {
+                    SelectExpand.LevelsMaxLiteralExpansionDepth = Context.ValidationSettings.MaxExpansionDepth;
                 }
             }
         }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/AutoExpand/AutoExpandController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/AutoExpand/AutoExpandController.cs
@@ -6,8 +6,10 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Query;
 using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
 
 namespace Microsoft.Test.E2E.AspNet.OData.AutoExpand
@@ -272,5 +274,89 @@ namespace Microsoft.Test.E2E.AspNet.OData.AutoExpand
             //_db.Dispose();
         }
 #endif
+    }
+
+    public class EnableQueryMenusController : TestODataController
+    {
+        private static readonly List<Menu> menus = new List<Menu>
+        {
+            new Menu
+            {
+                Id = 1,
+                Tabs = new List<Tab>
+                {
+                    new Tab
+                    {
+                        Id = 1,
+                        Items = new List<Item>
+                        {
+                            new Item
+                            {
+                                Id = 1,
+                                Notes = new List<Note>
+                                {
+                                    new Note { Id = 1 }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        [EnableQuery(MaxExpansionDepth = 4)]
+        public ITestActionResult Get()
+        {
+            return Ok(menus);
+        }
+    }
+
+    public class QueryOptionsOfTMenusController : TestODataController
+    {
+        private static readonly List<Menu> menus = new List<Menu>
+        {
+            new Menu
+            {
+                Id = 1,
+                Tabs = new List<Tab>
+                {
+                    new Tab
+                    {
+                        Id = 1,
+                        Items = new List<Item>
+                        {
+                            new Item
+                            {
+                                Id = 1,
+                                Notes = new List<Note>
+                                {
+                                    new Note { Id = 1 }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        public ITestActionResult Get(ODataQueryOptions<Menu> queryOptions)
+        {
+            var validationSettings = new ODataValidationSettings
+            {
+                MaxExpansionDepth = 4
+            };
+
+            queryOptions.Validate(validationSettings);
+
+            var result = queryOptions.ApplyTo(menus.AsQueryable()).AsQueryable();
+
+            return Ok(result, result.GetType());
+        }
+
+        private ITestActionResult Ok(object content, Type type)
+        {
+            var resultType = typeof(TestOkObjectResult<>).MakeGenericType(type);
+            return Activator.CreateInstance(resultType, content, this) as ITestActionResult;
+        }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/AutoExpand/AutoExpandDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/AutoExpand/AutoExpandDataModel.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Data.Entity;
 using Microsoft.AspNet.OData.Builder;
 
@@ -123,5 +124,31 @@ namespace Microsoft.Test.E2E.AspNet.OData.AutoExpand
         public int Id { get; set; }
 
         public string Description { get; set; }
+    }
+
+    public class Menu
+    {
+        public int Id { get; set; }
+        [AutoExpand]
+        public List<Tab> Tabs { get; set; }
+    }
+
+    public class Tab
+    {
+        public int Id { get; set; }
+        [AutoExpand]
+        public List<Item> Items { get; set; }
+    }
+
+    public class Item
+    {
+        public int Id { get; set; }
+        [AutoExpand]
+        public List<Note> Notes { get; set; }
+    }
+
+    public class Note
+    {
+        public int Id { get; set; }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/AutoExpand/AutoExpandEdmModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/AutoExpand/AutoExpandEdmModel.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.AutoExpand
             builder.EntityType<DerivedOrder2>();
             builder.EntitySet<OrderDetail>("OrderDetails");
             builder.EntitySet<People>("People");
+            builder.EntitySet<Menu>("EnableQueryMenus");
+            builder.EntitySet<Menu>("QueryOptionsOfTMenus");
+            builder.EntitySet<Tab>("Tabs");
+            builder.EntitySet<Item>("Items");
+            builder.EntitySet<Note>("Notes");
             IEdmModel model = builder.GetEdmModel();
             return model;
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2748.*

### Description

We set the default MaxExpansionDepth when the Validate method of the ODataQueryOptions object is called. The problem currently is that when the MaxExpansionDepth is overridden, for instance by assigning the value from the EnableQuery attribute ([EnableQuery(MaxExpansionDepth = 4)]), we call the Validate method before the AutoExpand navigation properties have been added to the SelectExpandQueryOption object. For that reason, the specified MaxExpansionDepth ends up not being respected for the auto-expanded navigation properties.

This pull request fixes that by calling ODataQueryOptions.AddAutoSelectExpandProperties prior to validating the SelectExpand query option.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
