### PR TITLE
update the CreateODataDeltaResourceSetReaderAsync method

### DIFF
--- a/samples/AspNetODataSample.Web/AspNetODataSample.Web.csproj
+++ b/samples/AspNetODataSample.Web/AspNetODataSample.Web.csproj
@@ -88,20 +88,20 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.OData.Core, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.OData.Core.7.13.0\lib\net45\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.OData.Core.7.15.0\lib\net45\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.OData.Edm.7.13.0\lib\net45\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.OData.Edm.7.15.0\lib\net45\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.Spatial.7.13.0\lib\net45\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.Spatial.7.15.0\lib\net45\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\sln\packages\Newtonsoft.Json.15.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/samples/AspNetODataSample.Web/packages.config
+++ b/samples/AspNetODataSample.Web/packages.config
@@ -15,9 +15,9 @@
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net461" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net461" developmentDependency="true" />
-  <package id="Microsoft.OData.Core" version="7.12.1" targetFramework="net461" />
-  <package id="Microsoft.OData.Edm" version="7.12.1" targetFramework="net461" />
-  <package id="Microsoft.Spatial" version="7.12.1" targetFramework="net461" />
+  <package id="Microsoft.OData.Core" version="7.15.0" targetFramework="net461" />
+  <package id="Microsoft.OData.Edm" version="7.15.0" targetFramework="net461" />
+  <package id="Microsoft.Spatial" version="7.15.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.Memory" version="4.5.4" targetFramework="net461" />

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceSetDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceSetDeserializer.cs
@@ -54,7 +54,8 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                 throw Error.Argument("edmType", SRResources.ArgumentMustBeOfType, EdmTypeKind.Complex + " or " + EdmTypeKind.Entity);
             }
 
-            ODataReader resourceSetReader = readContext.IsChangedObjectCollection ? messageReader.CreateODataDeltaResourceSetReader() : messageReader.CreateODataResourceSetReader();
+            // If we want to support '#$delta' context URL, then we need to pass the EntitySet and StructuredType params to the CreateODataDeltaResourceSetReader method. 
+            ODataReader resourceSetReader = readContext.IsChangedObjectCollection ? messageReader.CreateODataDeltaResourceSetReader(readContext.Path?.NavigationSource as IEdmEntitySetBase, edmType.AsEntity() as IEdmStructuredType) : messageReader.CreateODataResourceSetReader();
             object resourceSet = resourceSetReader.ReadResourceOrResourceSet();
             return ReadInline(resourceSet, edmType, readContext);
         }
@@ -76,7 +77,8 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                 throw Error.Argument("edmType", SRResources.ArgumentMustBeOfType, EdmTypeKind.Complex + " or " + EdmTypeKind.Entity);
             }
 
-            ODataReader resourceSetReader = readContext.IsChangedObjectCollection ? await messageReader.CreateODataDeltaResourceSetReaderAsync() : await messageReader.CreateODataResourceSetReaderAsync();
+            // If we want to support '#$delta' context URL, then we need to pass the EntitySet and StructuredType params to the CreateODataDeltaResourceSetReaderAsync method. 
+            ODataReader resourceSetReader = readContext.IsChangedObjectCollection ? await messageReader.CreateODataDeltaResourceSetReaderAsync(readContext.Path?.NavigationSource as IEdmEntitySetBase, edmType.AsEntity() as IEdmStructuredType) : await messageReader.CreateODataResourceSetReaderAsync();
             object resourceSet = await resourceSetReader.ReadResourceOrResourceSetAsync();
             return ReadInline(resourceSet, edmType, readContext);
         }

--- a/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
+++ b/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
@@ -33,16 +33,16 @@
       <HintPath>..\..\sln\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.OData.Core.7.13.0\lib\net45\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.OData.Core.7.15.0\lib\net45\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.OData.Edm.7.13.0\lib\net45\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.OData.Edm.7.15.0\lib\net45\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\Microsoft.Spatial.7.13.0\lib\net45\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\Microsoft.Spatial.7.15.0\lib\net45\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/Microsoft.AspNet.OData/packages.config
+++ b/src/Microsoft.AspNet.OData/packages.config
@@ -6,10 +6,10 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="7.13.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.13.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.15.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.15.0" targetFramework="net45" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.Spatial" version="7.13.0" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.15.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -42,9 +42,9 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.78.0" />
-    <PackageReference Include="Microsoft.OData.Core" Version="7.13.0" />
-    <PackageReference Include="Microsoft.OData.Edm" Version="7.13.0" />
-    <PackageReference Include="Microsoft.Spatial" Version="7.13.0" />
+    <PackageReference Include="Microsoft.OData.Core" Version="7.15.0" />
+    <PackageReference Include="Microsoft.OData.Edm" Version="7.15.0" />
+    <PackageReference Include="Microsoft.Spatial" Version="7.15.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -46,16 +46,16 @@
       <HintPath>..\..\..\..\sln\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Client, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Client.7.13.0\lib\net45\Microsoft.OData.Client.dll</HintPath>
+    <Reference Include="Microsoft.OData.Client, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Client.7.15.0\lib\net45\Microsoft.OData.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Core.7.13.0\lib\net45\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Core.7.15.0\lib\net45\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Edm.7.13.0\lib\net45\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Edm.7.15.0\lib\net45\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -70,8 +70,8 @@
       <HintPath>..\..\..\..\sln\packages\Microsoft.Owin.Hosting.2.0.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\sln\packages\Microsoft.Spatial.7.13.0\lib\net45\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\Microsoft.Spatial.7.15.0\lib\net45\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/packages.config
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/packages.config
@@ -13,13 +13,13 @@
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Client" version="7.13.0" targetFramework="net452" />
-  <package id="Microsoft.OData.Core" version="7.13.0" targetFramework="net452" />
-  <package id="Microsoft.OData.Edm" version="7.13.0" targetFramework="net452" />
+  <package id="Microsoft.OData.Client" version="7.15.0" targetFramework="net452" />
+  <package id="Microsoft.OData.Core" version="7.15.0" targetFramework="net452" />
+  <package id="Microsoft.OData.Edm" version="7.15.0" targetFramework="net452" />
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net452" />
   <package id="Microsoft.Owin.Host.HttpListener" version="2.0.2" targetFramework="net452" />
   <package id="Microsoft.Owin.Hosting" version="2.0.2" targetFramework="net452" />
-  <package id="Microsoft.Spatial" version="7.13.0" targetFramework="net452" />
+  <package id="Microsoft.Spatial" version="7.15.0" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net452" />

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -1858,20 +1858,20 @@
     <Reference Include="Microsoft.Net.Http.Headers, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\sln\packages\Microsoft.Net.Http.Headers.2.2.0\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Client, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Client.7.13.0\lib\net45\Microsoft.OData.Client.dll</HintPath>
+    <Reference Include="Microsoft.OData.Client, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Client.7.15.0\lib\net45\Microsoft.OData.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Core.7.13.0\lib\net45\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Core.7.15.0\lib\net45\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Edm.7.13.0\lib\net45\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\Microsoft.OData.Edm.7.15.0\lib\net45\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\sln\packages\Microsoft.Spatial.7.13.0\lib\net45\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\Microsoft.Spatial.7.15.0\lib\net45\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/packages.config
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/packages.config
@@ -65,10 +65,10 @@
   <package id="Microsoft.Extensions.Primitives" version="2.2.0" targetFramework="net461" />
   <package id="Microsoft.Net.Http.Headers" version="2.2.0" targetFramework="net461" />
   <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net461" />
-  <package id="Microsoft.OData.Client" version="7.13.0" targetFramework="net461" />
-  <package id="Microsoft.OData.Core" version="7.13.0" targetFramework="net461" />
-  <package id="Microsoft.OData.Edm" version="7.13.0" targetFramework="net461" />
-  <package id="Microsoft.Spatial" version="7.13.0" targetFramework="net461" />
+  <package id="Microsoft.OData.Client" version="7.15.0" targetFramework="net461" />
+  <package id="Microsoft.OData.Core" version="7.15.0" targetFramework="net461" />
+  <package id="Microsoft.OData.Edm" version="7.15.0" targetFramework="net461" />
+  <package id="Microsoft.Spatial" version="7.15.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.2.0" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.OData.Client" Version="7.13.0" />
+    <PackageReference Include="Microsoft.OData.Client" Version="7.15.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="4.7.0" />

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
@@ -165,6 +165,94 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
         }
 
         [Fact]
+        public async Task PatchEmployee_WithUpdates_Friends_WithRelativeContextURL()
+        {
+            //Arrange
+            string requestUri = this.BaseAddress + "/convention/Employees(1)/Friends";
+
+            var content = @"{
+                            '@odata.context':'Employees(1)/Friends/$delta',     
+                    'value':[{ 'Id':1,'Name':'Friend1'}, { 'Id':2,'Name':'Friend2'}]
+                     }";
+
+            var requestForPatch = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri);
+            requestForPatch.Headers.Add("OData-Version", "4.01");
+
+            StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
+            requestForPatch.Content = stringContent;
+            Client.DefaultRequestHeaders.Add("Prefer", @"odata.include-annotations=""*""");
+
+            //Act & Assert
+            var expected = "$delta\",\"value\":[{\"Id\":1,\"Name\":\"Friend1\",\"Age\":0}," +
+                "{\"Id\":2,\"Name\":\"Friend2\",\"Age\":0}]}";
+
+            using (HttpResponseMessage response = await this.Client.SendAsync(requestForPatch))
+            {
+                var json = response.Content.ReadAsStringAsync().Result;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Contains(expected, json.ToString());
+            }
+
+            //Act & Assert
+            requestUri = this.BaseAddress + "/convention/Employees(1)/Friends";
+            using (HttpResponseMessage response = await this.Client.GetAsync(requestUri))
+            {
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsObject<JObject>();
+                var result = json.GetValue("value") as JArray;
+
+                Assert.Equal(2, result.Count);
+                Assert.Contains("Friend1", result.ToString());
+                Assert.Contains("Friend2", result.ToString());
+            }
+        }
+
+        [Fact]
+        public async Task PatchEmployee_WithUpdates_Friends_WithOnlyDeltaContextURL()
+        {
+            //Arrange
+            string requestUri = this.BaseAddress + "/convention/Employees(1)/Friends";
+
+            var content = @"{
+                            '@odata.context':'#$delta',     
+                    'value':[{ 'Id':1,'Name':'Friend1'}, { 'Id':2,'Name':'Friend2'}]
+                     }";
+
+            var requestForPatch = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri);
+            requestForPatch.Headers.Add("OData-Version", "4.01");
+
+            StringContent stringContent = new StringContent(content: content, encoding: Encoding.UTF8, mediaType: "application/json");
+            requestForPatch.Content = stringContent;
+            Client.DefaultRequestHeaders.Add("Prefer", @"odata.include-annotations=""*""");
+
+            //Act & Assert
+            var expected = "$delta\",\"value\":[{\"Id\":1,\"Name\":\"Friend1\",\"Age\":0}," +
+                "{\"Id\":2,\"Name\":\"Friend2\",\"Age\":0}]}";
+
+            using (HttpResponseMessage response = await this.Client.SendAsync(requestForPatch))
+            {
+                var json = response.Content.ReadAsStringAsync().Result;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Contains(expected, json.ToString());
+            }
+
+            //Act & Assert
+            requestUri = this.BaseAddress + "/convention/Employees(1)/Friends";
+            using (HttpResponseMessage response = await this.Client.GetAsync(requestUri))
+            {
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsObject<JObject>();
+                var result = json.GetValue("value") as JArray;
+
+                Assert.Equal(2, result.Count);
+                Assert.Contains("Friend1", result.ToString());
+                Assert.Contains("Friend2", result.ToString());
+            }
+        }
+
+        [Fact]
         public async Task PatchEmployee_WithDeletes_Friends()
         {
             //Arrange

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -2363,10 +2363,10 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             // Arrange & Act & Assert
 #if NETCOREAPP3_1
             ExceptionAssert.Throws<ArgumentNullException>(() => Bind<Product>(filter),
-                "Value cannot be null. (Parameter 'qualifiedName')");
+                "Value cannot be null. (Parameter 'typeName')");
 #else
             ExceptionAssert.Throws<ArgumentNullException>(() => Bind<Product>(filter),
-                "Value cannot be null.\r\nParameter name: qualifiedName");
+                "Value cannot be null.\r\nParameter name: typeName");
 #endif
         }
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/Microsoft.AspNet.OData.Test.csproj
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/Microsoft.AspNet.OData.Test.csproj
@@ -24,16 +24,16 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.OData.Core, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.13.0\lib\net45\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Core.7.15.0\lib\net45\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.13.0\lib\net45\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.OData.Edm.7.15.0\lib\net45\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.13.0\lib\net45\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\sln\packages\Microsoft.Spatial.7.15.0\lib\net45\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq, Version=4.7.137.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/packages.config
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/packages.config
@@ -8,9 +8,9 @@
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="7.13.0" targetFramework="net452" />
-  <package id="Microsoft.OData.Edm" version="7.13.0" targetFramework="net452" />
-  <package id="Microsoft.Spatial" version="7.13.0" targetFramework="net452" />
+  <package id="Microsoft.OData.Core" version="7.15.0" targetFramework="net452" />
+  <package id="Microsoft.OData.Edm" version="7.15.0" targetFramework="net452" />
+  <package id="Microsoft.Spatial" version="7.15.0" targetFramework="net452" />
   <package id="Moq" version="4.7.137" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net452" />

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
@@ -16,9 +16,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
-    <PackageReference Include="Microsoft.OData.Core" Version="7.13.0" />
-    <PackageReference Include="Microsoft.OData.Edm" Version="7.13.0" />
-    <PackageReference Include="Microsoft.Spatial" Version="7.13.0" />
+    <PackageReference Include="Microsoft.OData.Core" Version="7.15.0" />
+    <PackageReference Include="Microsoft.OData.Edm" Version="7.15.0" />
+    <PackageReference Include="Microsoft.Spatial" Version="7.15.0" />
     <PackageReference Include="Moq" Version="4.7.137" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
@@ -33,9 +33,9 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Microsoft.OData.Core" Version="7.13.0" />
-    <PackageReference Include="Microsoft.OData.Edm" Version="7.13.0" />
-    <PackageReference Include="Microsoft.Spatial" Version="7.13.0" />
+    <PackageReference Include="Microsoft.OData.Core" Version="7.15.0" />
+    <PackageReference Include="Microsoft.OData.Edm" Version="7.15.0" />
+    <PackageReference Include="Microsoft.Spatial" Version="7.15.0" />
     <PackageReference Include="Moq" Version="4.7.137" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

For us to support this `#$delta` context URL value with bulk updates, we have to pass the `EdmEntitySet` and `EdmStructuredType` to the `CreateODataDeltaResourceSetReaderAsync` method.  This information will give more information about the type being deserialized

Have updated the ODL version since we supported reading relative context URLs in the latest ODL version. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
