### PR TITLE
support writing datamodififcation exception message

### DIFF
--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationTest.cs
@@ -445,8 +445,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
             Client.DefaultRequestHeaders.Add("Prefer", @"odata.include-annotations=""*""");
 
             //Act & Assert
-            var expected = "$delta\",\"value\":[{\"@NS.Test\":1,\"@Core.DataModificationException\":" +
-                "{\"@type\":\"#Org.OData.Core.V1.DataModificationExceptionType\"},\"Id\":2,\"Name\":null,\"Age\":15}]}";
+            var expected = "{\"@context\":\"" + this.BaseAddress + "/convention/$metadata#NewFriends/$delta\",\"value\":[{\"@NS.Test\":1,\"@Core.DataModificationException\":{\"@type\":\"#Org.OData.Core.V1.DataModificationExceptionType\",\"FailedOperation\":\"Delete\",\"ResponseCode\":0,\"MessageType\":{\"Code\":null,\"Message\":\"The method or operation is not implemented.\",\"Severity\":null,\"Target\":null,\"Details\":null}},\"Id\":2,\"Name\":null,\"Age\":15}]}";
 
             using (HttpResponseMessage response = await this.Client.SendAsync(requestForPatch))
             {
@@ -474,8 +473,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
             Client.DefaultRequestHeaders.Add("Prefer", @"odata.include-annotations=""*""");
 
             //Act & Assert
-            var expected = "/convention/$metadata#NewFriends/$delta\",\"value\":[{\"@NS.Test2\":\"testing\",\"@Core.ContentID\":3," +
-                "\"@Core.DataModificationException\":{\"@type\":\"#Org.OData.Core.V1.DataModificationExceptionType\"},\"Id\":2,\"Name\":null,\"Age\":15}]}";
+            var expected = "{\"@context\":\"" + this.BaseAddress + "/convention/$metadata#NewFriends/$delta\",\"value\":[{\"@NS.Test2\":\"testing\",\"@Core.ContentID\":3,\"@Core.DataModificationException\":{\"@type\":\"#Org.OData.Core.V1.DataModificationExceptionType\",\"FailedOperation\":\"Delete\",\"ResponseCode\":0,\"MessageType\":{\"Code\":null,\"Message\":\"The method or operation is not implemented.\",\"Severity\":null,\"Target\":null,\"Details\":null}},\"Id\":2,\"Name\":null,\"Age\":15}]}";
 
             using (HttpResponseMessage response = await this.Client.SendAsync(requestForPatch))
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues
The `@Core.DataModificationException` annotation is not written properly in a bulk update response. Some information doesn't get written and only the type is written. This fix ensures that the entire annotation is written with all it's properties,, like the `MessageType`, the `FailedOperation` etc. 
### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
