### PR TITLE
fix regression issue.

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSerializer.cs
@@ -1743,9 +1743,9 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
                 {
                     if (changedProperties == null || changedProperties.Contains(complexProperty.Key.Name))
                     {
-                        IEdmTypeReference type = complexProperty.Key == null ? null : complexProperty.Key.Type;
+                        IEdmTypeReference type = complexProperty.Key?.Type;
 
-                        if (type != null && resourceContext.EdmModel != null)
+                        if (type != null && type.IsStructured() && resourceContext.EdmModel != null)
                         {
                             Type clrType = EdmLibHelpers.GetClrType(type.AsStructured(), resourceContext.EdmModel);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2745.*

### Description

*Briefly describe the changes of this pull request.*

With the bulk operations we added logic for ensuring that the `ODataIdContainer` does not get written on the response payload. And the `ODataIdContainer` is represented as a complex property on the `EdmModel`.  The logic that was added was to get the `ClrType` then we check whether it is of type `ODataIdContainer`. 

```csharp
IEdmTypeReference type = complexProperty.Key == null ? null : complexProperty.Key.Type;
if (type != null && resourceContext.EdmModel != null)
{
    Type clrType = EdmLibHelpers.GetClrType(type.AsStructured(), resourceContext.EdmModel);
}
```
doing `type.AsStructured()` on a collection of complex types returns a `BadEntityTypeReference` error. We pass this error to the `GetClrType` method which end ups doing some expensive computations trying to find the `ClrType`. 

This fix ensures that `type.AsStructured()` is not performed on collections of complex properties. 

This is how the `WriteComplexPropertiesAsync` performs `before the fix`

|Function Name|Total CPU \[unit, %\]|Self CPU \[unit, %\]|Module|Category|
|-|-|-|-|-|
|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\| + Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSerializer.WriteComplexPropertiesAsync\(\)|141 \(11.60%\)|2 \(0.16%\)|microsoft.aspnetcore.odata||

And this is how it performs `after the fix`: 

|Function Name|Total CPU \[unit, %\]|Self CPU \[unit, %\]|Module|Category|
|-|-|-|-|-|
|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\| + Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSerializer.WriteComplexPropertiesAsync\(\)|30 \(2.87%\)|1 \(0.10%\)|microsoft.aspnetcore.odata||

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
