### PR TITLE
Fix invalid partial json generated when serverside paging is applied in multi-level containment scenarios

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Builder/NavigationSourceAndAnnotations.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Builder/NavigationSourceAndAnnotations.cs
@@ -10,8 +10,8 @@ using Microsoft.OData.Edm;
 namespace Microsoft.AspNet.OData.Builder
 {
     /// <summary>
-    /// This class is used in internal as a helper class to build the Edm model.
-    /// This class wrappers a relationship between Edm type and the CLR type configuration.
+    /// This class is used internally as a helper class to build the Edm model.
+    /// This class wraps a relationship between Edm type and the CLR type configuration.
     /// This relationship is used to builder the navigation property and the corresponding links.
     /// </summary>
     internal class NavigationSourceAndAnnotations

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSetSerializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Serialization/ODataResourceSetSerializer.cs
@@ -481,26 +481,12 @@ namespace Microsoft.AspNet.OData.Formatter.Serialization
         private static Uri GetNestedNextPageLink(ODataSerializerContext writeContext, int pageSize, object obj)
         {
             Contract.Assert(writeContext.ExpandedResource != null);
-            Uri navigationLink = null;
             IEdmNavigationSource sourceNavigationSource = writeContext.ExpandedResource.NavigationSource;
             NavigationSourceLinkBuilderAnnotation linkBuilder = writeContext.Model.GetNavigationSourceLinkBuilder(sourceNavigationSource);
 
-            // In Contained Navigation, we don't have navigation property binding,
-            // Hence we cannot get the NavigationLink from the NavigationLinkBuilder
-            if (writeContext.NavigationSource.NavigationSourceKind() == EdmNavigationSourceKind.ContainedEntitySet)
-            {
-                // Contained navigation.
-                Uri idlink = linkBuilder.BuildIdLink(writeContext.ExpandedResource);
-
-                var link = idlink.ToString() + "/" + writeContext.NavigationProperty.Name;
-                navigationLink = new Uri(link);
-            }
-            else
-            {
-                // Non-Contained navigation.
-                navigationLink =
-                    linkBuilder.BuildNavigationLink(writeContext.ExpandedResource, writeContext.NavigationProperty);
-            }
+            Uri navigationLink = linkBuilder.BuildNavigationLink(
+                writeContext.ExpandedResource,
+                writeContext.NavigationProperty);
 
             Uri nestedNextLink = GenerateQueryFromExpandedItem(writeContext, navigationLink);
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -1705,6 +1705,9 @@
     <Compile Include="..\ServerSidePaging\ServerSidePagingDataModel.cs">
       <Link>ServerSidePaging\ServerSidePagingDataModel.cs</Link>
     </Compile>
+    <Compile Include="..\ServerSidePaging\ServerSidePagingDataSource.cs">
+      <Link>ServerSidePaging\ServerSidePagingDataSource.cs</Link>
+    </Compile>
     <Compile Include="..\ServerSidePaging\ServerSidePagingTests.cs">
       <Link>ServerSidePaging\ServerSidePagingTests.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -1561,6 +1561,9 @@
     <Compile Include="..\ServerSidePaging\ServerSidePagingDataModel.cs">
       <Link>ServerSidePaging\ServerSidePagingDataModel.cs</Link>
     </Compile>
+    <Compile Include="..\ServerSidePaging\ServerSidePagingDataSource.cs">
+      <Link>ServerSidePaging\ServerSidePagingDataSource.cs</Link>
+    </Compile>
     <Compile Include="..\ServerSidePaging\ServerSidePagingTests.cs">
       <Link>ServerSidePaging\ServerSidePagingTests.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
@@ -1559,6 +1559,9 @@
     <Compile Include="..\ServerSidePaging\ServerSidePagingDataModel.cs">
       <Link>ServerSidePaging\ServerSidePagingDataModel.cs</Link>
     </Compile>
+    <Compile Include="..\ServerSidePaging\ServerSidePagingDataSource.cs">
+      <Link>ServerSidePaging\ServerSidePagingDataSource.cs</Link>
+    </Compile>
     <Compile Include="..\ServerSidePaging\ServerSidePagingTests.cs">
       <Link>ServerSidePaging\ServerSidePagingTests.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Containment/ContainmentEdmModels.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Containment/ContainmentEdmModels.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
+using System;
+using Microsoft.AspNet.OData;
 using Microsoft.AspNet.OData.Builder;
 using Microsoft.OData.Edm;
 using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
@@ -42,15 +44,29 @@ namespace Microsoft.Test.E2E.AspNet.OData.Containment
             statementType.Property(s => s.TransactionDescription);
             statementType.Property(s => s.Amount);
 
+            Func<ResourceContext<Account>, IEdmNavigationProperty, Uri> navigationPropertyLinkFactory = (
+                resourceContext, navigationProperty) => resourceContext.GenerateNavigationPropertyLink(navigationProperty, false);
+            Func<ResourceContext<Account>, IEdmNavigationProperty, Uri> navigationPropertyLinkFactoryWithCast = (
+                resourceContext, navigationProperty) => resourceContext.GenerateNavigationPropertyLink(navigationProperty, true);
+
             var accounts = builder.EntitySet<Account>("Accounts"); 
             accounts.HasIdLink(c => c.GenerateSelfLink(false), true);
             accounts.HasEditLink(c => c.GenerateSelfLink(true), true);
+            accounts.HasNavigationPropertyLink(payoutPI, navigationPropertyLinkFactory, followsConventions: true);
+            accounts.HasNavigationPropertyLink(payinPIs, navigationPropertyLinkFactory, followsConventions: true);
+            accounts.HasNavigationPropertyLink(giftCard, navigationPropertyLinkFactoryWithCast, true);
 
             var paginatedAccounts = builder.EntitySet<Account>("PaginatedAccounts");
             paginatedAccounts.HasIdLink(c => c.GenerateSelfLink(true), true);
             paginatedAccounts.HasEditLink(c => c.GenerateSelfLink(true), true);
+            paginatedAccounts.HasNavigationPropertyLink(payoutPI, navigationPropertyLinkFactory, followsConventions: true);
+            paginatedAccounts.HasNavigationPropertyLink(payinPIs, navigationPropertyLinkFactory, followsConventions: true);
+            paginatedAccounts.HasNavigationPropertyLink(giftCard, navigationPropertyLinkFactoryWithCast, true);
 
-            builder.Singleton<Account>("AnonymousAccount");
+            var accountSingleton = builder.Singleton<Account>("AnonymousAccount");
+            accountSingleton.HasNavigationPropertyLink(payoutPI, navigationPropertyLinkFactory, followsConventions: true);
+            accountSingleton.HasNavigationPropertyLink(payinPIs, navigationPropertyLinkFactory, followsConventions: true);
+            accountSingleton.HasNavigationPropertyLink(giftCard, navigationPropertyLinkFactoryWithCast, true);
 
             AddBoundActionsAndFunctions(builder);
 

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingControllers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingControllers.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Routing;
 using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
 
 namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
@@ -65,7 +66,6 @@ namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
             return Ok(hiredInPeriod);
         }
     }
-
 
     public class SkipTokenPagingS1CustomersController : TestODataController
     {
@@ -152,6 +152,141 @@ namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
         public ITestActionResult Get()
         {
             return Ok(customers);
+        }
+    }
+
+    public class ContainmentPagingCustomersController : TestODataController
+    {
+        [EnableQuery(PageSize = 2)]
+        public ITestActionResult Get()
+        {
+            return Ok(ContainmentPagingDataSource.Customers);
+        }
+
+        [EnableQuery(PageSize = 2)]
+        public ITestActionResult GetOrders(int key)
+        {
+            var customer = ContainmentPagingDataSource.Customers.SingleOrDefault(d => d.Id == key);
+
+            if (customer == null)
+            {
+                return BadRequest();
+            }
+
+            return Ok(customer.Orders);
+        }
+    }
+
+    public class ContainmentPagingCompanyController : TestODataController
+    {
+        private static readonly ContainmentPagingCustomer company = new ContainmentPagingCustomer
+        {
+            Id = 1,
+            Orders = ContainmentPagingDataSource.Orders.Take(ContainmentPagingDataSource.TargetSize).ToList()
+        };
+
+        [EnableQuery(PageSize = 2)]
+        public ITestActionResult Get()
+        {
+            return Ok(company);
+        }
+
+        [EnableQuery(PageSize = 2)]
+        public ITestActionResult GetOrders()
+        {
+            return Ok(company.Orders);
+        }
+    }
+
+    public class NoContainmentPagingCustomersController : TestODataController
+    {
+        [EnableQuery(PageSize = 2)]
+        public ITestActionResult Get()
+        {
+            return Ok(NoContainmentPagingDataSource.Customers);
+        }
+
+        [EnableQuery(PageSize = 2)]
+        public ITestActionResult GetOrders(int key)
+        {
+            var customer = NoContainmentPagingDataSource.Customers.SingleOrDefault(d => d.Id == key);
+
+            if (customer == null)
+            {
+                return BadRequest();
+            }
+
+            return Ok(customer.Orders);
+        }
+    }
+
+    public class ContainmentPagingMenusController : TestODataController
+    {
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        public ITestActionResult Get()
+        {
+            return Ok(ContainmentPagingDataSource.Menus);
+        }
+
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        public ITestActionResult GetFromContainmentPagingExtendedMenu()
+        {
+            return Ok(ContainmentPagingDataSource.Menus.OfType<ContainmentPagingExtendedMenu>());
+        }
+
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        public ITestActionResult GetTabsFromContainmentPagingExtendedMenu(int key)
+        {
+            var menu = ContainmentPagingDataSource.Menus.OfType<ContainmentPagingExtendedMenu>().SingleOrDefault(d => d.Id == key);
+
+            if (menu == null)
+            {
+                return BadRequest();
+            }
+
+            return Ok(menu.Tabs);
+        }
+
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        public ITestActionResult GetPanelsFromContainmentPagingExtendedMenu(int key)
+        {
+            var menu = ContainmentPagingDataSource.Menus.OfType<ContainmentPagingExtendedMenu>().SingleOrDefault(d => d.Id == key);
+
+            if (menu == null)
+            {
+                return BadRequest();
+            }
+
+            return Ok(menu.Panels);
+        }
+    }
+
+    public class ContainmentPagingRibbonController : TestODataController
+    {
+        private static readonly ContainmentPagingMenu ribbon = new ContainmentPagingExtendedMenu
+        {
+            Id = 1,
+            Tabs = ContainmentPagingDataSource.Tabs.Take(ContainmentPagingDataSource.TargetSize).ToList()
+        };
+
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        public ITestActionResult Get()
+        {
+            return Ok(ribbon);
+        }
+
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        public ITestActionResult GetFromContainmentPagingExtendedMenu()
+        {
+            return Ok(ribbon as ContainmentPagingExtendedMenu);
+        }
+
+        [EnableQuery(PageSize = 2, MaxExpansionDepth = 4)]
+        [HttpGet]
+        [ODataRoute("ContainmentPagingRibbon/Microsoft.Test.E2E.AspNet.OData.ServerSidePaging.ContainmentPagingExtendedMenu/Tabs")]
+        public ITestActionResult GetTabsFromContainmentPagingExtendedMenu()
+        {
+            return Ok((ribbon as ContainmentPagingExtendedMenu).Tabs);
         }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingDataModel.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNet.OData.Builder;
 
 namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
 {
@@ -45,5 +46,92 @@ namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
     {
         public int Id { get; set; }
         public decimal? CreditLimit { get; set; }
+    }
+
+    public class ContainmentPagingCustomer
+    {
+        public int Id { get; set; }
+        [Contained]
+        public List<ContainedPagingOrder> Orders { get; set; }
+    }
+
+    public class ContainedPagingOrder
+    {
+        public int Id { get; set; }
+        [Contained]
+        public List<ContainedPagingOrderItem> Items { get; set; }
+    }
+
+    public class ContainedPagingOrderItem
+    {
+        public int Id { get; set; }
+    }
+
+    public class NoContainmentPagingCustomer
+    {
+        public int Id { get; set; }
+        public List<NoContainmentPagingOrder> Orders { get; set; }
+    }
+
+    public class NoContainmentPagingOrder
+    {
+        public int Id { get; set; }
+        public List<NoContainmentPagingOrderItem> Items { get; set; }
+    }
+
+    public class NoContainmentPagingOrderItem
+    {
+        public int Id { get; set; }
+    }
+
+    public class ContainmentPagingMenu
+    {
+        public int Id { get; set; }
+    }
+
+    public class ContainmentPagingExtendedMenu : ContainmentPagingMenu
+    {
+        [Contained]
+        public List<ContainedPagingTab> Tabs { get; set; }
+        // Non-contained
+        public List<ContainmentPagingPanel> Panels { get; set; }
+    }
+
+    public class ContainedPagingTab
+    {
+        public int Id { get; set; }
+    }
+
+    public class ContainedPagingExtendedTab : ContainedPagingTab
+    {
+        [Contained]
+        public List<ContainedPagingItem> Items { get; set; }
+    }
+
+    public class ContainedPagingItem
+    {
+        public int Id { get; set; }
+    }
+
+    public class ContainedPagingExtendedItem : ContainedPagingItem
+    {
+        [Contained]
+        public List<ContainedPagingNote> Notes { get; set; }
+    }
+
+    public class ContainedPagingNote
+    {
+        public int Id { get; set; }
+    }
+
+    public class ContainmentPagingPanel
+    {
+        public int Id { get; set; }
+    }
+
+    public class ContainmentPagingExtendedPanel : ContainmentPagingPanel
+    {
+        [Contained]
+        public List<ContainedPagingItem> Items { get; set; }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingDataSource.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingDataSource.cs
@@ -1,0 +1,109 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ServerSidePagingDataSource.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
+{
+    public static class ContainmentPagingDataSource
+    {
+        internal const int TargetSize = 3;
+
+        private static readonly List<ContainedPagingOrderItem> orderItems = new List<ContainedPagingOrderItem>(
+            Enumerable.Range(1, TargetSize * TargetSize * TargetSize).Select(idx => new ContainedPagingOrderItem
+            {
+                Id = idx
+            }));
+
+        private static readonly List<ContainedPagingOrder> orders = new List<ContainedPagingOrder>(
+            Enumerable.Range(1, TargetSize * TargetSize).Select(idx => new ContainedPagingOrder
+            {
+                Id = idx,
+                Items = orderItems.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        private static readonly List<ContainmentPagingCustomer> customers = new List<ContainmentPagingCustomer>(
+            Enumerable.Range(1, TargetSize).Select(idx => new ContainmentPagingCustomer
+            {
+                Id = idx,
+                Orders = orders.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        private static readonly List<ContainedPagingNote> notes = new List<ContainedPagingNote>(
+            Enumerable.Range(1, TargetSize * TargetSize * TargetSize * TargetSize).Select(idx => new ContainedPagingNote
+            {
+                Id = idx
+            }));
+
+        private static readonly List<ContainedPagingItem> items = new List<ContainedPagingItem>(
+            Enumerable.Range(1, TargetSize * TargetSize * TargetSize).Select(idx => new ContainedPagingExtendedItem
+            {
+                Id = idx,
+                Notes = notes.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        private static readonly List<ContainedPagingTab> tabs = new List<ContainedPagingTab>(
+            Enumerable.Range(1, TargetSize * TargetSize).Select(idx => new ContainedPagingExtendedTab
+            {
+                Id = idx,
+                Items = items.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        private static readonly List<ContainmentPagingPanel> panels = new List<ContainmentPagingPanel>(
+            Enumerable.Range(1, TargetSize * TargetSize).Select(idx => new ContainmentPagingExtendedPanel
+            {
+                Id = idx,
+                Items = items.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        private static readonly List<ContainmentPagingMenu> menus = new List<ContainmentPagingMenu>(
+            Enumerable.Range(1, TargetSize).Select(idx => new ContainmentPagingExtendedMenu
+            {
+                Id = idx,
+                Tabs = tabs.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList(),
+                Panels = panels.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        public static List<ContainmentPagingCustomer> Customers => customers;
+
+        public static List<ContainedPagingOrder> Orders => orders;
+
+        public static List<ContainmentPagingMenu> Menus => menus;
+
+        public static List<ContainedPagingTab> Tabs => tabs;
+    }
+
+    public static class NoContainmentPagingDataSource
+    {
+        private const int TargetSize = 3;
+
+        private static readonly List<NoContainmentPagingOrderItem> orderItems = new List<NoContainmentPagingOrderItem>(
+            Enumerable.Range(1, TargetSize * TargetSize * TargetSize).Select(idx => new NoContainmentPagingOrderItem
+            {
+                Id = idx
+            }));
+
+        private static readonly List<NoContainmentPagingOrder> orders = new List<NoContainmentPagingOrder>(
+            Enumerable.Range(1, TargetSize * TargetSize).Select(idx => new NoContainmentPagingOrder
+            {
+                Id = idx,
+                Items = orderItems.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        private static readonly List<NoContainmentPagingCustomer> customers = new List<NoContainmentPagingCustomer>(
+            Enumerable.Range(1, TargetSize).Select(idx => new NoContainmentPagingCustomer
+            {
+                Id = idx,
+                Orders = orders.Skip((idx - 1) * TargetSize).Take(TargetSize).ToList()
+            }));
+
+        public static List<NoContainmentPagingCustomer> Customers => customers;
+
+        public static List<NoContainmentPagingOrder> Orders => orders;
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingTests.cs
@@ -50,6 +50,14 @@ namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
             ODataModelBuilder builder = configuration.CreateConventionModelBuilder();
             builder.EntitySet<ServerSidePagingOrder>("ServerSidePagingOrders").EntityType.HasRequired(d => d.ServerSidePagingCustomer);
             builder.EntitySet<ServerSidePagingCustomer>("ServerSidePagingCustomers").EntityType.HasMany(d => d.ServerSidePagingOrders);
+            builder.EntitySet<ContainmentPagingCustomer>("ContainmentPagingCustomers");
+            builder.Singleton<ContainmentPagingCustomer>("ContainmentPagingCompany");
+            builder.EntitySet<NoContainmentPagingCustomer>("NoContainmentPagingCustomers");
+            builder.EntitySet<NoContainmentPagingOrder>("NoContainmentPagingOrders");
+            builder.EntitySet<NoContainmentPagingOrderItem>("NoContainmentPagingOrderItems");
+            builder.EntitySet<ContainmentPagingMenu>("ContainmentPagingMenus");
+            builder.EntitySet<ContainmentPagingPanel>("ContainmentPagingPanels");
+            builder.Singleton<ContainmentPagingMenu>("ContainmentPagingRibbon");
 
             var getEmployeesHiredInPeriodFunction = builder.EntitySet<ServerSidePagingEmployee>(
                 "ServerSidePagingEmployees").EntityType.Collection.Function("GetEmployeesHiredInPeriod");
@@ -100,6 +108,295 @@ namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
                 "/prefix/ServerSidePagingEmployees/GetEmployeesHiredInPeriod(fromDate=@fromDate,toDate=@toDate)" +
                 "?%40fromDate=2023-01-07T00%3A00%3A00%2B00%3A00&%40toDate=2023-05-07T00%3A00%3A00%2B00%3A00&$skip=3",
                 content);
+        }
+
+        [Fact]
+        public async Task VerifyExpectedNextLinksGeneratedForNestedExpandInContainmentScenario()
+        {
+            // Arrange
+            var requestUri = this.BaseAddress + "/prefix/ContainmentPagingCustomers?$expand=Orders($expand=Items)";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains("/prefix/ContainmentPagingCustomers(1)/Orders(1)/Items?$skip=2", content);
+            Assert.Contains("/prefix/ContainmentPagingCustomers(1)/Orders(2)/Items?$skip=2", content);
+            Assert.Contains("/prefix/ContainmentPagingCustomers(1)/Orders?$expand=Items&$skip=2", content);
+
+            Assert.Contains("/prefix/ContainmentPagingCustomers(2)/Orders(4)/Items?$skip=2", content);
+            Assert.Contains("/prefix/ContainmentPagingCustomers(2)/Orders(5)/Items?$skip=2", content);
+            Assert.Contains("/prefix/ContainmentPagingCustomers(2)/Orders?$expand=Items&$skip=2", content);
+
+            Assert.Contains("/prefix/ContainmentPagingCustomers?$expand=Orders", content);
+        }
+
+        [Fact]
+        public async Task VerifyExpectedNextLinksGeneratedForContainedNavigationPropertyAsODataPathSegment()
+        {
+            // Arrange
+            var requestUri = this.BaseAddress + "/prefix/ContainmentPagingCustomers(2)/Orders?$expand=Items";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains("/prefix/ContainmentPagingCustomers(2)/Orders(4)/Items?$skip=2", content);
+            Assert.Contains("/prefix/ContainmentPagingCustomers(2)/Orders(5)/Items?$skip=2", content);
+            Assert.Contains("/prefix/ContainmentPagingCustomers(2)/Orders?$expand=Items&$skip=2", content);
+        }
+
+        [Fact]
+        public async Task VerifyExpectedNextLinksGeneratedForContainedNavigationPropertyInSingletonScenario()
+        {
+            // Arrange
+            var requestUri = this.BaseAddress + "/prefix/ContainmentPagingCompany?$expand=Orders($expand=Items)";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains("/prefix/ContainmentPagingCompany/Orders(1)/Items?$skip=2", content);
+            Assert.Contains("/prefix/ContainmentPagingCompany/Orders(2)/Items?$skip=2", content);
+            Assert.Contains("/prefix/ContainmentPagingCompany/Orders?$expand=Items&$skip=2", content);
+        }
+
+        [Fact]
+        public async Task VerifyExpectedNextLinksGeneratedForContainedNavigationPropertyAsODataPathSegmentInSingletonScenario()
+        {
+            // Arrange
+            var requestUri = this.BaseAddress + "/prefix/ContainmentPagingCompany/Orders?$expand=Items";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains("/prefix/ContainmentPagingCompany/Orders(1)/Items?$skip=2", content);
+            Assert.Contains("/prefix/ContainmentPagingCompany/Orders(2)/Items?$skip=2", content);
+        }
+
+        [Fact]
+        public async Task VerifyExpectedNextLinksGeneratedForNestedExpandInNoContainmentScenario()
+        {
+            // Arrange
+            var requestUri = this.BaseAddress + "/prefix/NoContainmentPagingCustomers?$expand=Orders($expand=Items)";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains("/prefix/NoContainmentPagingOrders(1)/Items?$skip=2", content);
+            Assert.Contains("/prefix/NoContainmentPagingOrders(2)/Items?$skip=2", content);
+            Assert.Contains("/prefix/NoContainmentPagingCustomers(1)/Orders?$expand=Items&$skip=2", content);
+
+            Assert.Contains("/prefix/NoContainmentPagingOrders(4)/Items?$skip=2", content);
+            Assert.Contains("/prefix/NoContainmentPagingOrders(5)/Items?$skip=2", content);
+            Assert.Contains("/prefix/NoContainmentPagingCustomers(2)/Orders?$expand=Items&$skip=2", content);
+
+            Assert.Contains("/prefix/NoContainmentPagingCustomers?$expand=Orders", content);
+        }
+
+        [Fact]
+        public async Task VerifyExpectedNextLinksGeneratedForNonContainedNavigationPropertyAsODataPathSegment()
+        {
+            // Arrange
+            var requestUri = this.BaseAddress + "/prefix/NoContainmentPagingCustomers(2)/Orders?$expand=Items";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains("/prefix/NoContainmentPagingOrders(4)/Items?$skip=2", content);
+            Assert.Contains("/prefix/NoContainmentPagingOrders(5)/Items?$skip=2", content);
+            Assert.Contains("/prefix/NoContainmentPagingCustomers(2)/Orders?$expand=Items&$skip=2", content);
+        }
+
+        [Fact]
+        public async Task VerifyExpectedNextLinksGeneratedForContainedNavigationPropertyDeclaredOnDerivedType()
+        {
+            // Arrange
+            var extendedMenuTypeName = typeof(ContainmentPagingExtendedMenu).FullName;
+            var extendedTabTypeName = typeof(ContainedPagingExtendedTab).FullName;
+            var extendedItemTypeName = typeof(ContainedPagingExtendedItem).FullName;
+            var menusResourcePath = $"/prefix/ContainmentPagingMenus";
+            var menu1ResourcePath = $"/prefix/ContainmentPagingMenus(1)/{extendedMenuTypeName}";
+            var menu2ResourcePath = $"/prefix/ContainmentPagingMenus(2)/{extendedMenuTypeName}";
+
+            var requestUri = $"{this.BaseAddress}{menusResourcePath}?$expand={extendedMenuTypeName}/Tabs($expand={extendedTabTypeName}/Items($expand={extendedItemTypeName}/Notes))";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains($"{menu1ResourcePath}/Tabs(1)/{extendedTabTypeName}/Items(1)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Tabs(1)/{extendedTabTypeName}/Items(2)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Tabs(1)/{extendedTabTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Tabs(2)/{extendedTabTypeName}/Items(4)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Tabs(2)/{extendedTabTypeName}/Items(5)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Tabs(2)/{extendedTabTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Tabs?$expand={extendedTabTypeName}%2FItems%28%24expand%3D{extendedItemTypeName}%2FNotes%29&$skip=2", content);
+
+            Assert.Contains($"{menu2ResourcePath}/Tabs(4)/{extendedTabTypeName}/Items(10)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{menu2ResourcePath}/Tabs(4)/{extendedTabTypeName}/Items(11)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{menu2ResourcePath}/Tabs(4)/{extendedTabTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{menu2ResourcePath}/Tabs(5)/{extendedTabTypeName}/Items(13)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{menu2ResourcePath}/Tabs(5)/{extendedTabTypeName}/Items(14)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{menu2ResourcePath}/Tabs(5)/{extendedTabTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{menu2ResourcePath}/Tabs?$expand={extendedTabTypeName}%2FItems%28%24expand%3D{extendedItemTypeName}%2FNotes%29&$skip=2", content);
+        }
+
+        [Fact]
+        public async Task VerifyExpectedNextLinksGeneratedForContainedNavigationPropertyDeclaredOnDerivedTypeAsODataPathSegment()
+        {
+            // Arrange
+            var extendedMenuTypeName = typeof(ContainmentPagingExtendedMenu).FullName;
+            var extendedTabTypeName = typeof(ContainedPagingExtendedTab).FullName;
+            var extendedItemTypeName = typeof(ContainedPagingExtendedItem).FullName;
+            var menu1ResourcePath = $"/prefix/ContainmentPagingMenus(1)/{extendedMenuTypeName}";
+
+            var requestUri = $"{this.BaseAddress}{menu1ResourcePath}/Tabs?$expand={extendedTabTypeName}/Items($expand={extendedItemTypeName}/Notes)";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains($"{menu1ResourcePath}/Tabs(1)/{extendedTabTypeName}/Items(1)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Tabs(1)/{extendedTabTypeName}/Items(2)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Tabs(1)/{extendedTabTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Tabs(2)/{extendedTabTypeName}/Items(4)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Tabs(2)/{extendedTabTypeName}/Items(5)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Tabs(2)/{extendedTabTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Tabs?$expand={extendedTabTypeName}%2FItems%28%24expand%3D{extendedItemTypeName}%2FNotes%29&$skip=2", content);
+        }
+
+        [Fact]
+        public async Task VerifyExpectedNextLinksGeneratedForContainedNavigationPropertyDeclaredOnDerivedTypeInSingletonScenario()
+        {
+            // Arrange
+            var extendedMenuTypeName = typeof(ContainmentPagingExtendedMenu).FullName;
+            var extendedTabTypeName = typeof(ContainedPagingExtendedTab).FullName;
+            var extendedItemTypeName = typeof(ContainedPagingExtendedItem).FullName;
+            var ribbonResourcePath = $"/prefix/ContainmentPagingRibbon";
+
+            var requestUri = $"{this.BaseAddress}{ribbonResourcePath}?$expand={extendedMenuTypeName}/Tabs($expand={extendedTabTypeName}/Items($expand={extendedItemTypeName}/Notes))";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains($"{ribbonResourcePath}/{extendedMenuTypeName}/Tabs(1)/{extendedTabTypeName}/Items(1)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{ribbonResourcePath}/{extendedMenuTypeName}/Tabs(1)/{extendedTabTypeName}/Items(2)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{ribbonResourcePath}/{extendedMenuTypeName}/Tabs(1)/{extendedTabTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{ribbonResourcePath}/{extendedMenuTypeName}/Tabs(2)/{extendedTabTypeName}/Items(4)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{ribbonResourcePath}/{extendedMenuTypeName}/Tabs(2)/{extendedTabTypeName}/Items(5)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{ribbonResourcePath}/{extendedMenuTypeName}/Tabs(2)/{extendedTabTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{ribbonResourcePath}/{extendedMenuTypeName}/Tabs?$expand={extendedTabTypeName}%2FItems%28%24expand%3D{extendedItemTypeName}%2FNotes%29&$skip=2", content);
+        }
+
+        [Fact]
+        public async Task VerifyExpectedNextLinksGeneratedForContainedNavigationPropertyDeclaredOnDerivedTypeAsODataPathSegmentInSingletonScenario()
+        {
+            // Arrange
+            var extendedMenuTypeName = typeof(ContainmentPagingExtendedMenu).FullName;
+            var extendedTabTypeName = typeof(ContainedPagingExtendedTab).FullName;
+            var extendedItemTypeName = typeof(ContainedPagingExtendedItem).FullName;
+            var ribbonResourcePath = $"/prefix/ContainmentPagingRibbon/{extendedMenuTypeName}";
+
+            var requestUri = $"{this.BaseAddress}{ribbonResourcePath}/Tabs?$expand={extendedTabTypeName}/Items($expand={extendedItemTypeName}/Notes)";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains($"{ribbonResourcePath}/Tabs(1)/{extendedTabTypeName}/Items(1)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{ribbonResourcePath}/Tabs(1)/{extendedTabTypeName}/Items(2)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{ribbonResourcePath}/Tabs(1)/{extendedTabTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{ribbonResourcePath}/Tabs(2)/{extendedTabTypeName}/Items(4)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{ribbonResourcePath}/Tabs(2)/{extendedTabTypeName}/Items(5)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"{ribbonResourcePath}/Tabs(2)/{extendedTabTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{ribbonResourcePath}/Tabs?$expand={extendedTabTypeName}%2FItems%28%24expand%3D{extendedItemTypeName}%2FNotes%29&$skip=2", content);
+        }
+
+        [Fact]
+        public async Task VerifyExpectedNextLinksGeneratedForNonContainedNavigationPropertyDeclaredOnDerivedType()
+        {
+            // Arrange
+            var extendedMenuTypeName = typeof(ContainmentPagingExtendedMenu).FullName;
+            var extendedPanelTypeName = typeof(ContainmentPagingExtendedPanel).FullName;
+            var extendedItemTypeName = typeof(ContainedPagingExtendedItem).FullName;
+            var menusResourcePath = $"/prefix/ContainmentPagingMenus";
+            var menu1ResourcePath = $"/prefix/ContainmentPagingMenus(1)/{extendedMenuTypeName}";
+            var menu2ResourcePath = $"/prefix/ContainmentPagingMenus(2)/{extendedMenuTypeName}";
+
+            var requestUri = $"{this.BaseAddress}{menusResourcePath}?$expand={extendedMenuTypeName}/Panels($expand={extendedPanelTypeName}/Items($expand={extendedItemTypeName}/Notes))";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains($"/prefix/ContainmentPagingPanels(1)/{extendedPanelTypeName}/Items(1)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(1)/{extendedPanelTypeName}/Items(2)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(1)/{extendedPanelTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(2)/{extendedPanelTypeName}/Items(4)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(2)/{extendedPanelTypeName}/Items(5)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(2)/{extendedPanelTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Panels?$expand={extendedPanelTypeName}%2FItems%28%24expand%3D{extendedItemTypeName}%2FNotes%29&$skip=2", content);
+
+            Assert.Contains($"/prefix/ContainmentPagingPanels(4)/{extendedPanelTypeName}/Items(10)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(4)/{extendedPanelTypeName}/Items(11)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(4)/{extendedPanelTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(5)/{extendedPanelTypeName}/Items(13)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(5)/{extendedPanelTypeName}/Items(14)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(5)/{extendedPanelTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{menu2ResourcePath}/Panels?$expand={extendedPanelTypeName}%2FItems%28%24expand%3D{extendedItemTypeName}%2FNotes%29&$skip=2", content);
+        }
+
+        [Fact]
+        public async Task VerifyExpectedNextLinksGeneratedForNonContainedNavigationPropertyDeclaredOnDerivedTypeAsODataPathSegment()
+        {
+            // Arrange
+            var extendedMenuTypeName = typeof(ContainmentPagingExtendedMenu).FullName;
+            var extendedPanelTypeName = typeof(ContainmentPagingExtendedPanel).FullName;
+            var extendedItemTypeName = typeof(ContainedPagingExtendedItem).FullName;
+            var menu1ResourcePath = $"/prefix/ContainmentPagingMenus(1)/{extendedMenuTypeName}";
+
+            var requestUri = $"{this.BaseAddress}{menu1ResourcePath}/Panels?$expand={extendedPanelTypeName}/Items($expand={extendedItemTypeName}/Notes)";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains($"/prefix/ContainmentPagingPanels(1)/{extendedPanelTypeName}/Items(1)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(1)/{extendedPanelTypeName}/Items(2)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(1)/{extendedPanelTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(2)/{extendedPanelTypeName}/Items(4)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(2)/{extendedPanelTypeName}/Items(5)/{extendedItemTypeName}/Notes?$skip=2", content);
+            Assert.Contains($"/prefix/ContainmentPagingPanels(2)/{extendedPanelTypeName}/Items?$expand={extendedItemTypeName}%2FNotes&$skip=2", content);
+            Assert.Contains($"{menu1ResourcePath}/Panels?$expand={extendedPanelTypeName}%2FItems%28%24expand%3D{extendedItemTypeName}%2FNotes%29&$skip=2", content);
         }
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes [2262](https://github.com/OData/WebApi/issues/2262).*
*This pull request closes https://github.com/OData/WebApi/pull/2400.*

### Description

Consider the following data model where `Orders` and `Items` are contained navigation properties in `Customer` and `Order` entities respectively.

```csharp
public class Customer
{
    public int Id { get; set; }
    [Contained]
    public List<Order> Orders { get; set; }
}

public class Order
{
    public int Id { get; set; }

    [Contained]
    public List<OrderItem> Items { get; set; }
}

public class OrderItem
{
    public int Id { get; set; }
}
```

The Edm configuration would look as follows:

```csharp
ODataModelBuilder modelBuilder = new ODataConventionModelBuilder();
modelBuilder.EntitySet<Customer>("Customers");
IEdmModel model = modelBuilder.GetEdmModel();
```

Consider also a request for `Customer` resources with a nested `$expand` on the contained navigation properties as follows:

```http
http://localhost:5000/Customers?$expand=Orders($expand=Items)
```

The follow exception is observed:

> Microsoft.OData.UriParser.ODataUnrecognizedPathException: Resource not found for the segment 'Orders'.
   at Microsoft.OData.UriParser.ODataPathParser.CreateDynamicPathSegment(ODataPathSegment previous, String identifier, String parenthesisExpression)
   at Microsoft.OData.UriParser.ODataPathParser.CreateFirstSegment(String segmentText)
   at Microsoft.OData.UriParser.ODataPathParser.ParsePath(ICollection`1 segments)
   at Microsoft.OData.UriParser.ODataPathFactory.BindPath(ICollection`1 segments, ODataUriParserConfiguration configuration)
   at Microsoft.OData.UriParser.ODataUriParser.ParsePathImplementation()
   at Microsoft.OData.UriParser.ODataUriParser.Initialize()
   at Microsoft.OData.UriParser.ODataUriParser.ParsePath()
   at Microsoft.OData.UriParser.ODataUriParser.ParseUri()
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSetSerializer.GenerateQueryFromExpandedItem(ODataSerializerContext writeContext, Uri navigationLink) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSetSerializer.cs:line 539
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSetSerializer.GetNestedNextPageLink(ODataSerializerContext writeContext, Int32 pageSize, Object obj) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSetSerializer.cs:line 505
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSetSerializer.<>c__DisplayClass9_3.<GetNextLinkGenerator>b__3(Object obj) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSetSerializer.cs:line 358
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSetSerializer.WriteResourceSetAsync(IEnumerable enumerable, IEdmTypeReference resourceSetType, ODataWriter writer, ODataSerializerContext writeContext) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSetSerializer.cs:line 255
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSerializer.WriteComplexAndExpandedNavigationPropertyAsync(IEdmProperty edmProperty, SelectItem selectItem, ResourceContext resourceContext, ODataWriter writer) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSerializer.cs:line 1991
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSerializer.WriteExpandedNavigationPropertiesAsync(SelectExpandNode selectExpandNode, ResourceContext resourceContext, ODataWriter writer) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSerializer.cs:line 1849
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSerializer.WriteResourceAsync(Object graph, ODataWriter writer, ODataSerializerContext writeContext, IEdmTypeReference expectedType) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSerializer.cs:line 1461
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSetSerializer.WriteResourceSetAsync(IEnumerable enumerable, IEdmTypeReference resourceSetType, ODataWriter writer, ODataSerializerContext writeContext) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSetSerializer.cs:line 246
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSerializer.WriteComplexAndExpandedNavigationPropertyAsync(IEdmProperty edmProperty, SelectItem selectItem, ResourceContext resourceContext, ODataWriter writer) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSerializer.cs:line 1991
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSerializer.WriteExpandedNavigationPropertiesAsync(SelectExpandNode selectExpandNode, ResourceContext resourceContext, ODataWriter writer) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSerializer.cs:line 1849
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSerializer.WriteResourceAsync(Object graph, ODataWriter writer, ODataSerializerContext writeContext, IEdmTypeReference expectedType) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSerializer.cs:line 1461
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSetSerializer.WriteResourceSetAsync(IEnumerable enumerable, IEdmTypeReference resourceSetType, ODataWriter writer, ODataSerializerContext writeContext) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSetSerializer.cs:line 246
   at Microsoft.AspNet.OData.Formatter.Serialization.ODataResourceSetSerializer.WriteObjectAsync(Object graph, Type type, ODataMessageWriter messageWriter, ODataSerializerContext writeContext) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\Serialization\ODataResourceSetSerializer.cs:line 86
   at Microsoft.AspNet.OData.Formatter.ODataOutputFormatterHelper.WriteToStreamAsync(Type type, Object value, IEdmModel model, ODataVersion version, Uri baseAddress, MediaTypeHeaderValue contentType, IWebApiUrlHelper internaUrlHelper, IWebApiRequestMessage internalRequest, IWebApiHeaders internalRequestHeaders, Func`2 getODataMessageWrapper, Func`2 getEdmTypeSerializer, Func`2 getODataPayloadSerializer, Func`1 getODataSerializerContext) in C:\Users\jogathog\Projects\WebApi\src\Microsoft.AspNet.OData.Shared\Formatter\ODataOutputFormatterHelper.cs:line 228
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeResultAsync>g__Logged|21_0(ResourceInvoker invoker, IActionResult result)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResultFilterAsync>g__Awaited|29_0[TFilter,TFilterAsync](ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResultExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResultNext[TFilter,TFilterAsync](State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeResultFilters()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeFilterPipelineAsync>g__Awaited|19_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
   at Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserRefreshMiddleware.InvokeAsync(HttpContext context)
   at Microsoft.AspNetCore.Builder.Extensions.MapWhenMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)

This exception is observed specifically when nested `$expand` is applied on a contained navigation property.
The following requests with no nested `$expand` are handled okay:
```
1. http://localhost:5000/Customers?$expand=Orders
2. http://localhost:5000/Customers(2)/Orders?$expand=Items
```
The fix for non-nested containment $expand was implemented in [this pull request](https://github.com/OData/WebApi/pull/2287)

The exception affecting nested containment $expand is observed due to a bug in existing logic when trying to come up with the OData path segments required to correctly generate the next-link for the expanded containment navigation property.

The existing logic in `EdmModelHelperMethods.AddNavigationBindings` was only adding navigation property link builders for non-contained navigation properties since contained navigation properties do not have navigation property bindings. The logic was as below:
```csharp
foreach (NavigationPropertyBindingConfiguration binding in navigationSourceConfiguration.Bindings)
{
    // HERE: Add navigation property link builders
}
```
This pull request fixes the issue by moving the logic for adding navigation property link builders to a different method `EdmModelHelperMethods.AddNavigationPropertyLinkBuilders` that handles both contained and non-contained navigation properties.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
