### PR TITLE
Check HandleNullPropagation in ProjectElement

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -350,7 +350,17 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
             Type wrapperGenericType = GetWrapperGenericType(isInstancePropertySet, isTypeNamePropertySet, isContainerPropertySet);
             wrapperType = wrapperGenericType.MakeGenericType(elementType);
-            return Expression.MemberInit(Expression.New(wrapperType), wrapperTypeMemberAssignments);
+            Expression propertyValue = Expression.MemberInit(Expression.New(wrapperType), wrapperTypeMemberAssignments);
+
+            if (_settings.HandleNullPropagation == HandleNullPropagationOption.True && !source.Type.IsValueType)
+            {
+                propertyValue = Expression.Condition(
+                    test: Expression.Equal(source, Expression.Constant(null)),
+                    ifTrue: Expression.Constant(null, propertyValue.Type),
+                    ifFalse: propertyValue);
+            }
+
+            return propertyValue;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -352,7 +352,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             wrapperType = wrapperGenericType.MakeGenericType(elementType);
             Expression propertyValue = Expression.MemberInit(Expression.New(wrapperType), wrapperTypeMemberAssignments);
 
-            if (_settings.HandleNullPropagation == HandleNullPropagationOption.True && !source.Type.IsValueType)
+            if (_settings.HandleNullPropagation == HandleNullPropagationOption.True &&
+                (!source.Type.IsValueType || Nullable.GetUnderlyingType(source.Type) != null))
             {
                 propertyValue = Expression.Condition(
                     test: Expression.Equal(source, Expression.Constant(null)),

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/SelectImprovementOnComplexTypeTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/NavigationPropertyOnComplexType/SelectImprovementOnComplexTypeTests.cs
@@ -395,7 +395,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
             string value = "\"value\":[" +
                 "{\"HomeLocation\":{\"Street\":\"110th\"}}," +
                 "{\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Street\":\"110th\"}}," +
-                "{\"HomeLocation\":{\"Street\":null}}," +
+                "{\"HomeLocation\":null}," +
                 "{\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Street\":\"120th\"}}," +
                 "{\"HomeLocation\":{\"Street\":\"130th\"}}," +
                 "{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.VipPerson\",\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeometryLocation\",\"Street\":\"130th\"}}]";
@@ -489,7 +489,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType
                     "\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Latitude\":\"12.211\"}" +
                 "}," +
                 "{" +
-                    "\"HomeLocation\":{}" +
+                    "\"HomeLocation\":null" +
                 "}," +
                 "{" +
                     "\"HomeLocation\":{\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.NavigationPropertyOnComplexType.GeoLocation\",\"Latitude\":\"12.8\"}" +

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/ApplyQueryOptionTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/ApplyQueryOptionTest.cs
@@ -1275,9 +1275,9 @@ namespace Microsoft.AspNet.OData.Test.Query
             var options = new ODataQueryOptions(context, request);
 
             IEnumerable<Customer> customers = CustomerApplyTestData;
+
             // Act
             IQueryable queryable = options.ApplyTo(customers.AsQueryable(), new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.True });
-
 
             // Assert
             Assert.NotNull(queryable);

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
@@ -177,12 +177,7 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
 
             // Assert
             SelectExpandWrapper<QueryOrder> projectedOrder = Expression.Lambda(projection).Compile().DynamicInvoke() as SelectExpandWrapper<QueryOrder>;
-            Assert.NotNull(projectedOrder);
-            Assert.Null(projectedOrder.Instance);
-
-            SelectExpandWrapper<QueryCustomer> projectCustomer = projectedOrder.Container.ToDictionary(PropertyMapper)["Customer"] as SelectExpandWrapper<QueryCustomer>;
-            Assert.NotNull(projectCustomer);
-            Assert.Null(projectCustomer.Instance);
+            Assert.Null(projectedOrder);
         }
 
         [Fact]


### PR DESCRIPTION
### Issues

If an object is null, but a `$select` is provided that specifically requests a property on that object the results are unexpected. At the minimum it'll return an empty instance of the object, but if there's a required property defined for the object's type it'll result in a failed request.

Consider the following request where `foo` exists with `id` "blah", but `bah` is null:

`.../foo?$select=id,bah($select=baz)`

Expected:
```
{
  "id": "blah",
  "bah": null
}
```

Actual:
```
{
  "id": "blah",
  "bah": { }
}
```

The following issue goes into a lot of detail for the scenario that results in request failure: https://github.com/OData/WebApi/issues/2413

### Description

The problem appears to be that `HandleNullPropagation` is not applied in `ProjectElement` - after doing so both of the problematic scenarios mentioned above are resolved.

I'd say it's pretty cut and dry if it weren't for the fact that there's a unit test asserting the old behavior... does that mean it's deliberate? I'm hoping the test was just written to code and not to an actual expectation of behavior.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*