### PR TITLE
Server-side paging should not apply to collections of non-entity types

### DIFF
--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingControllers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingControllers.cs
@@ -289,4 +289,32 @@ namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
             return Ok((ribbon as ContainmentPagingExtendedMenu).Tabs);
         }
     }
+
+    public class CollectionPagingCustomersController : TestODataController
+    {
+        private const int TargetSize = 3;
+        private static readonly List<CollectionPagingCustomer> customers = new List<CollectionPagingCustomer>(
+            Enumerable.Range(1, TargetSize).Select(idx => new CollectionPagingCustomer
+            {
+                Id = idx,
+                Tags = new List<string> { "Tier 1", "Gen-Z", "HNW" },
+                Categories = new List<CollectionPagingCategory>
+                {
+                    CollectionPagingCategory.Retailer,
+                    CollectionPagingCategory.Wholesaler,
+                    CollectionPagingCategory.Distributor
+                },
+                Locations = new List<CollectionPagingLocation>(
+                    Enumerable.Range(1, TargetSize).Select(dx => new CollectionPagingLocation
+                    {
+                        Street = $"Street {idx}{dx}"
+                    }))
+            }));
+
+        [EnableQuery(PageSize = 2)]
+        public ITestActionResult Get()
+        {
+            return Ok(customers);
+        }
+    }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingDataModel.cs
@@ -134,4 +134,24 @@ namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
         [Contained]
         public List<ContainedPagingItem> Items { get; set; }
     }
+
+    public enum CollectionPagingCategory
+    {
+        Retailer,
+        Wholesaler,
+        Distributor
+    }
+
+    public class CollectionPagingLocation
+    {
+        public string Street { get; set; }
+    }
+
+    public class CollectionPagingCustomer
+    {
+        public int Id { get; set; }
+        public List<string> Tags { get; set; }
+        public List<CollectionPagingCategory> Categories { get; set; }
+        public List<CollectionPagingLocation> Locations { get; set; }
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2738.*

### Description

Server-side paging should not apply to collections of non-entity types.

Currently, if a primitive, enum or complex collection property is included in the `$select` property list and server-side paging is configured, the `SelectExpandBinder` applies paging to the collection if the items exceed the configured `PageSize`. In the case of complex collection property, the attempt fails with an exception since the next-link can't be successfully generated.

When the `$select` query option is not present on the URL, no paging is applied for non-entity type collections. This should be the expected behaviour even when a `$select` is present.

This pull request addresses the described issue.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
