### PR TITLE
Null check in GenerateExpandQueryStringInternal

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/ExpandQueryBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ExpandQueryBuilder.cs
@@ -59,19 +59,7 @@ namespace Microsoft.AspNet.OData.Query
 
             string edmFullName = type.EdmFullName();
 
-            if (string.IsNullOrEmpty(edmFullName))
-            {
-                return expandString;
-            }
-
-            IEdmSchemaType schemaType = model.FindType(edmFullName);
-
-            if (schemaType == null)
-            {
-                return expandString;
-            }
-
-            IEdmStructuredType edmStructuredType = schemaType as IEdmStructuredType;
+            IEdmStructuredType edmStructuredType = model.FindType(edmFullName) as IEdmStructuredType;
 
             if (edmStructuredType == null)
             {

--- a/src/Microsoft.AspNet.OData.Shared/Query/ExpandQueryBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ExpandQueryBuilder.cs
@@ -40,9 +40,17 @@ namespace Microsoft.AspNet.OData.Query
 
         private string GenerateExpandQueryStringInternal(object value, IEdmModel model, bool isNestedExpand)
         {
+            string expandString = "";
+
+            if (value == null || model == null)
+            {
+                return expandString;
+            }
+
             Type type = value.GetType();
             bool isCollection = TypeHelper.IsCollection(type, out Type elementType);
             IEnumerable collection = null;
+
             if (isCollection)
             {
                 type = elementType;
@@ -50,11 +58,27 @@ namespace Microsoft.AspNet.OData.Query
             }
 
             string edmFullName = type.EdmFullName();
+
+            if (string.IsNullOrEmpty(edmFullName))
+            {
+                return expandString;
+            }
+
             IEdmSchemaType schemaType = model.FindType(edmFullName);
+
+            if (schemaType == null)
+            {
+                return expandString;
+            }
+
             IEdmStructuredType edmStructuredType = schemaType as IEdmStructuredType;
 
+            if (edmStructuredType == null)
+            {
+                return expandString;
+            }
+
             IEnumerable<IEdmNavigationProperty> navigationProperties = edmStructuredType.NavigationProperties();
-            string expandString = "";
 
             int count = 0;
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2794 .*
*This pull request fixes #2787 .*

### Description

This issue is caused when we try to call extension method `edmStructuredType.NavigationProperties();` when `edmStructuredType` is `null`.
https://github.com/OData/WebApi/blob/8c03a9077020859096a65a49bcc6e6e68429ab98/src/Microsoft.AspNet.OData.Shared/Query/ExpandQueryBuilder.cs#L56

This PR adds all the necessary null checks and we return an empty string if we are unable to generate `ExpandQueryString`.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
