### PR TITLE
Fix broken serialization for $select used in non-Edm scenarios

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
@@ -3347,5 +3347,16 @@ namespace Microsoft.AspNet.OData.Common
                 return ResourceManager.GetString("QueryOptionsNotInExpectedFormat", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to '{0}' is internal and should never be deserialized into..
+        /// </summary>
+        internal static string JsonConverterDoesNotSupportRead
+        {
+            get
+            {
+                return ResourceManager.GetString("JsonConverterDoesNotSupportRead", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
@@ -1012,4 +1012,7 @@
   <data name="SkipTokenProcessingError" xml:space="preserve">
     <value>Unable to get property values from the skiptoken value.</value>
   </data>
+  <data name="JsonConverterDoesNotSupportRead" xml:space="preserve">
+    <value>'{0}' is internal and should never be deserialized into.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
+++ b/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
@@ -279,6 +279,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\ModelContainer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandWrapperConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandWrapperJsonConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\ITruncatedCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\TruncatedCollectionOfT.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\SelectExpandQueryOption.cs" />

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -1234,7 +1234,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             }
         }
 
-        /* Entityframework requires that the two different type initializers for a given type in the same query have the
+        /* EntityFramework requires that the two different type initializers for a given type in the same query have the
         same set of properties in the same order.
 
         A ~/People?$select=Name&$expand=Friend results in a select expression that has two SelectExpandWrapper<Person>
@@ -1242,22 +1242,34 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         The first wrapper has the Container property set (contains Name and Friend values) where as the second wrapper
         has the Instance property set as it contains all the properties of the expanded person.
 
-        The below four classes workaround that entity framework limitation by defining a seperate type for each
+        The below four classes workaround that EntityFramework limitation by defining a separate type for each
         property selection combination possible. */
 
-        private class SelectAllAndExpand<TEntity> : SelectExpandWrapper<TEntity>
+#if NETCOREAPP3_1_OR_GREATER
+    [System.Text.Json.Serialization.JsonConverter(typeof(SelectExpandWrapperJsonConverter))]
+#endif
+        internal class SelectAllAndExpand<TEntity> : SelectExpandWrapper<TEntity>
         {
         }
 
-        private class SelectAll<TEntity> : SelectExpandWrapper<TEntity>
+#if NETCOREAPP3_1_OR_GREATER
+    [System.Text.Json.Serialization.JsonConverter(typeof(SelectExpandWrapperJsonConverter))]
+#endif
+        internal class SelectAll<TEntity> : SelectExpandWrapper<TEntity>
         {
         }
 
-        private class SelectSomeAndInheritance<TEntity> : SelectExpandWrapper<TEntity>
+#if NETCOREAPP3_1_OR_GREATER
+    [System.Text.Json.Serialization.JsonConverter(typeof(SelectExpandWrapperJsonConverter))]
+#endif
+        internal class SelectSomeAndInheritance<TEntity> : SelectExpandWrapper<TEntity>
         {
         }
 
-        private class SelectSome<TEntity> : SelectAllAndExpand<TEntity>
+#if NETCOREAPP3_1_OR_GREATER
+    [System.Text.Json.Serialization.JsonConverter(typeof(SelectExpandWrapperJsonConverter))]
+#endif
+        internal class SelectSome<TEntity> : SelectAllAndExpand<TEntity>
         {
         }
     }

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapperJsonConverter.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapperJsonConverter.cs
@@ -1,0 +1,311 @@
+//-----------------------------------------------------------------------------
+// <copyright file="SelectExpandWrapperJsonConverter.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+#if NETCOREAPP3_1_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNet.OData.Common;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.AspNet.OData.Query.Expressions
+{
+    /// <summary>
+    /// Represents a custom <see cref="JsonConverter"/> to serialize <see cref="SelectExpandWrapper{TElement}"/> instances to JSON.
+    /// </summary>
+    internal class SelectExpandWrapperJsonConverter : JsonConverterFactory
+    {
+        private static readonly Func<IEdmModel, IEdmStructuredType, IPropertyMapper> _mapperProvider =
+            (IEdmModel model, IEdmStructuredType type) => new JsonPropertyNameMapper(model, type);
+
+        /// <inheritdoc/>
+        public override bool CanConvert(Type typeToConvert)
+        {
+            if (typeToConvert == null)
+            {
+                throw Error.ArgumentNull(nameof(typeToConvert));
+            }
+
+            if (!typeToConvert.IsGenericType)
+            {
+                return false;
+            }
+
+            return typeof(ISelectExpandWrapper).IsAssignableFrom(typeToConvert);
+        }
+
+        /// <inheritdoc/>
+        public override JsonConverter CreateConverter(
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            if (typeToConvert == null || !typeToConvert.IsGenericType)
+            {
+                return null;
+            }
+
+            Type genericType = typeToConvert.GetGenericTypeDefinition();
+            Type type = typeToConvert.GetGenericArguments()[0];
+
+            if (genericType == typeof(SelectExpandBinder.SelectSome<>))
+            {
+                return (JsonConverter)Activator.CreateInstance(
+                    typeof(SelectSomeOfTJsonConverter<>).MakeGenericType(new Type[] { type }));
+            }
+
+            if (genericType == typeof(SelectExpandBinder.SelectSomeAndInheritance<>))
+            {
+                return (JsonConverter)Activator.CreateInstance(
+                    typeof(SelectSomeAndInheritanceOfTJsonConverter<>).MakeGenericType(new Type[] { type }));
+            }
+
+            if (genericType == typeof(SelectExpandBinder.SelectAll<>))
+            {
+                return (JsonConverter)Activator.CreateInstance(
+                    typeof(SelectAllOfTJsonConverter<>).MakeGenericType(new Type[] { type }));
+            }
+
+            if (genericType == typeof(SelectExpandBinder.SelectAllAndExpand<>))
+            {
+                return (JsonConverter)Activator.CreateInstance(
+                    typeof(SelectAllAndExpandOfTJsonConverter<>).MakeGenericType(new Type[] { type }));
+            }
+
+            if (genericType == typeof(SelectExpandWrapper<>))
+            {
+                return (JsonConverter)Activator.CreateInstance(
+                    typeof(SelectExpandWrapperOfTJsonConverter<>).MakeGenericType(new Type[] { type }));
+            }
+
+            return null;
+        }
+
+        private class JsonPropertyNameMapper : IPropertyMapper
+        {
+            private IEdmModel _model;
+            private IEdmStructuredType _type;
+
+            public JsonPropertyNameMapper(IEdmModel model, IEdmStructuredType type)
+            {
+                _model = model;
+                _type = type;
+            }
+
+            public string MapProperty(string propertyName)
+            {
+                IEdmProperty property = _type.Properties().First(s => s.Name == propertyName);
+                PropertyInfo propertyInfo = GetPropertyInfo(property);
+
+                Newtonsoft.Json.JsonPropertyAttribute jsonPropertyAttribute;
+                JsonPropertyNameAttribute jsonPropertyNameAttribute;
+
+                // NOTE: Preceding .NET Core 3.1 Newtonsoft was the default serialization library
+                // We check the Newtonsoft JsonPropertyAttribute first to prevent breaking changes
+                if ((jsonPropertyAttribute = GetNewtonsoftJsonPropertyAttribute(propertyInfo)) != null && !string.IsNullOrWhiteSpace(jsonPropertyAttribute.PropertyName))
+                {
+                    return jsonPropertyAttribute.PropertyName;
+                }
+
+                if ((jsonPropertyNameAttribute = GetSystemTextJsonPropertyNameAttribute(propertyInfo)) != null && !string.IsNullOrWhiteSpace(jsonPropertyNameAttribute.Name))
+                {
+                    return jsonPropertyNameAttribute.Name;
+                }
+
+                return property.Name;
+            }
+
+            private PropertyInfo GetPropertyInfo(IEdmProperty property)
+            {
+                ClrPropertyInfoAnnotation clrPropertyAnnotation = _model.GetAnnotationValue<ClrPropertyInfoAnnotation>(property);
+                if (clrPropertyAnnotation != null)
+                {
+                    return clrPropertyAnnotation.ClrPropertyInfo;
+                }
+
+                ClrTypeAnnotation clrTypeAnnotation = _model.GetAnnotationValue<ClrTypeAnnotation>(property.DeclaringType);
+                Contract.Assert(clrTypeAnnotation != null);
+
+                PropertyInfo propertyInfo = clrTypeAnnotation.ClrType.GetProperty(property.Name);
+                Contract.Assert(propertyInfo != null);
+
+                return propertyInfo;
+            }
+
+            private static Newtonsoft.Json.JsonPropertyAttribute GetNewtonsoftJsonPropertyAttribute(PropertyInfo property)
+            {
+                return property.GetCustomAttributes(typeof(Newtonsoft.Json.JsonPropertyAttribute), inherit: false)
+                    .OfType<Newtonsoft.Json.JsonPropertyAttribute>().SingleOrDefault();
+            }
+
+            private static JsonPropertyNameAttribute GetSystemTextJsonPropertyNameAttribute(PropertyInfo property)
+            {
+                return property.GetCustomAttributes(typeof(JsonPropertyNameAttribute), inherit: false)
+                    .OfType<JsonPropertyNameAttribute>().SingleOrDefault();
+            }
+        }
+
+        /// <summary>
+        /// Represents a custom <see cref="JsonConverter"/> to serialize <see cref="SelectExpandBinder.SelectSome{TElement}"/> instances to JSON.
+        /// </summary>
+        private class SelectSomeOfTJsonConverter<TEntity>
+            : JsonConverter<SelectExpandBinder.SelectSome<TEntity>>
+        {
+            /// <inheritdoc/>
+            public override SelectExpandBinder.SelectSome<TEntity> Read(
+                ref Utf8JsonReader reader,
+                Type typeToConvert,
+                JsonSerializerOptions options)
+            {
+                throw new NotImplementedException(
+                    Error.Format(
+                        SRResources.JsonConverterDoesNotSupportRead,
+                        typeof(SelectExpandBinder.SelectSome<TEntity>).Name));
+            }
+
+            /// <inheritdoc/>
+            public override void Write(
+                Utf8JsonWriter writer,
+                SelectExpandBinder.SelectSome<TEntity> value,
+                JsonSerializerOptions options)
+            {
+                JsonSerializer.Serialize(
+                    writer,
+                    value.ToDictionary(_mapperProvider), typeof(IDictionary<string, object>),
+                    options);
+            }
+        }
+
+        /// <summary>
+        /// Represents a custom <see cref="JsonConverter"/> to serialize <see cref="SelectExpandBinder.SelectSomeAndInheritance{TElement}"/> instances to JSON.
+        /// </summary>
+        private class SelectSomeAndInheritanceOfTJsonConverter<TEntity>
+            : JsonConverter<SelectExpandBinder.SelectSomeAndInheritance<TEntity>>
+        {
+            /// <inheritdoc/>
+            public override SelectExpandBinder.SelectSomeAndInheritance<TEntity> Read(
+                ref Utf8JsonReader reader,
+                Type typeToConvert,
+                JsonSerializerOptions options)
+            {
+                throw new NotImplementedException(
+                    Error.Format(
+                        SRResources.JsonConverterDoesNotSupportRead,
+                        typeof(SelectExpandBinder.SelectSomeAndInheritance<TEntity>).Name));
+            }
+
+            /// <inheritdoc/>
+            public override void Write(
+                Utf8JsonWriter writer,
+                SelectExpandBinder.SelectSomeAndInheritance<TEntity> value,
+                JsonSerializerOptions options)
+            {
+                JsonSerializer.Serialize(
+                    writer,
+                    value.ToDictionary(_mapperProvider),
+                    typeof(IDictionary<string, object>), options);
+            }
+        }
+
+        /// <summary>
+        /// Represents a custom <see cref="JsonConverter"/> to serialize <see cref="SelectExpandBinder.SelectAll{TElement}"/> instances to JSON.
+        /// </summary>
+        private class SelectAllOfTJsonConverter<TEntity>
+            : JsonConverter<SelectExpandBinder.SelectAll<TEntity>>
+        {
+            /// <inheritdoc/>
+            public override SelectExpandBinder.SelectAll<TEntity> Read(
+                ref Utf8JsonReader reader,
+                Type typeToConvert,
+                JsonSerializerOptions options)
+            {
+                throw new NotImplementedException(
+                    Error.Format(
+                        SRResources.JsonConverterDoesNotSupportRead,
+                        typeof(SelectExpandBinder.SelectAll<TEntity>).Name));
+            }
+
+            /// <inheritdoc/>
+            public override void Write(
+                Utf8JsonWriter writer,
+                SelectExpandBinder.SelectAll<TEntity> value,
+                JsonSerializerOptions options)
+            {
+                JsonSerializer.Serialize(
+                    writer,
+                    value.ToDictionary(_mapperProvider), typeof(IDictionary<string, object>),
+                    options);
+            }
+        }
+
+        /// <summary>
+        /// Represents a custom <see cref="JsonConverter"/> to serialize <see cref="SelectExpandBinder.SelectAllAndExpand{TElement}"/> instances to JSON.
+        /// </summary>
+        private class SelectAllAndExpandOfTJsonConverter<TEntity>
+            : JsonConverter<SelectExpandBinder.SelectAllAndExpand<TEntity>>
+        {
+            /// <inheritdoc/>
+            public override SelectExpandBinder.SelectAllAndExpand<TEntity> Read(
+                ref Utf8JsonReader reader,
+                Type typeToConvert,
+                JsonSerializerOptions options)
+            {
+                throw new NotImplementedException(
+                    Error.Format(
+                        SRResources.JsonConverterDoesNotSupportRead,
+                        typeof(SelectExpandBinder.SelectAllAndExpand<TEntity>).Name));
+            }
+
+            /// <inheritdoc/>
+            public override void Write(
+                Utf8JsonWriter writer,
+                SelectExpandBinder.SelectAllAndExpand<TEntity> value,
+                JsonSerializerOptions options)
+            {
+                JsonSerializer.Serialize(
+                    writer,
+                    value.ToDictionary(_mapperProvider),
+                    typeof(IDictionary<string, object>), options);
+            }
+        }
+
+        /// <summary>
+        /// Represents a custom <see cref="JsonConverter"/> to serialize <see cref="SelectExpandWrapper{TElement}"/> instances to JSON.
+        /// </summary>
+        private class SelectExpandWrapperOfTJsonConverter<TEntity>
+            : JsonConverter<SelectExpandWrapper<TEntity>>
+        {
+            /// <inheritdoc/>
+            public override SelectExpandWrapper<TEntity> Read(
+                ref Utf8JsonReader reader,
+                Type typeToConvert,
+                JsonSerializerOptions options)
+            {
+                throw new NotImplementedException(
+                    Error.Format(
+                        SRResources.JsonConverterDoesNotSupportRead,
+                        typeof(SelectExpandWrapper<TEntity>).Name));
+            }
+
+            /// <inheritdoc/>
+            public override void Write(
+                Utf8JsonWriter writer,
+                SelectExpandWrapper<TEntity> value,
+                JsonSerializerOptions options)
+            {
+                JsonSerializer.Serialize(
+                    writer,
+                    value.ToDictionary(_mapperProvider),
+                    typeof(IDictionary<string, object>), options);
+            }
+        }
+    }
+}
+#endif

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapperOfT.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapperOfT.cs
@@ -15,6 +15,9 @@ namespace Microsoft.AspNet.OData.Query.Expressions
     /// </summary>
     /// <typeparam name="TElement">The element being selected and expanded.</typeparam>
     [JsonConverter(typeof(SelectExpandWrapperConverter))]
+#if NETCOREAPP3_1_OR_GREATER
+    [System.Text.Json.Serialization.JsonConverter(typeof(SelectExpandWrapperJsonConverter))]
+#endif
     internal class SelectExpandWrapper<TElement> : SelectExpandWrapper
     {
         /// <summary>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/NonEdm/NonEdmController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/NonEdm/NonEdmController.cs
@@ -1,0 +1,78 @@
+//-----------------------------------------------------------------------------
+// <copyright file="NonEdmController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Microsoft.Test.E2E.AspNet.OData.NonEdm
+{
+    [ApiController]
+    public class CustomersController : ControllerBase
+    {
+        private static readonly List<Customer> customers = new List<Customer>
+        {
+            new Customer
+            {
+                Id = 1,
+                Name = "Customer 1",
+                RelationshipManager = new Employee
+                {
+                    Id = 1,
+                    Name = "Employee 1"
+                }
+            },
+            new EnterpriseCustomer
+            {
+                Id = 2,
+                Name = "Customer 2",
+                RelationshipManager = new Person
+                {
+                    Id = 3,
+                    Name = "Employee 3"
+                },
+                AccountManager = new Employee
+                {
+                    Id = 2,
+                    Name = "Employee 2"
+                }
+            }
+        };
+
+        [HttpGet]
+        [EnableQuery]
+        [Route("api/Customers")]
+        public ActionResult<IEnumerable<Customer>> Get()
+        {
+            return customers;
+        }
+
+        [HttpGet]
+        [EnableQuery]
+        [Route("api/Customers/Microsoft.Test.E2E.AspNet.OData.NonEdm.EnterpriseCustomer")]
+        public ActionResult<IEnumerable<EnterpriseCustomer>> GetFromEnterpriseCustomer()
+        {
+            return customers.OfType<EnterpriseCustomer>().ToList();
+        }
+
+        [HttpGet]
+        [EnableQuery]
+        [Route("api/Customers/{id}")]
+        public ActionResult<Customer> Get(int id)
+        {
+            var customer = customers.FirstOrDefault(d => d.Id == id);
+
+            if (customer == null)
+            {
+                return NotFound();
+            }
+
+            return customer;
+        }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/NonEdm/NonEdmDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/NonEdm/NonEdmDataModel.cs
@@ -1,0 +1,31 @@
+//-----------------------------------------------------------------------------
+// <copyright file="NonEdmDataModel.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.Test.E2E.AspNet.OData.NonEdm
+{
+    public class Person
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class Employee : Person
+    {
+    }
+
+    public class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public Person RelationshipManager { get; set; }
+    }
+
+    public class EnterpriseCustomer : Customer
+    {
+        public Person AccountManager { get; set; }
+    }
+}

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/NonEdm/NonEdmTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/NonEdm/NonEdmTests.cs
@@ -1,0 +1,159 @@
+//-----------------------------------------------------------------------------
+// <copyright file="NonEdmTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Xunit;
+
+namespace Microsoft.Test.E2E.AspNet.OData.NonEdm
+{
+    public class NonEdmTests : WebHostTestBase
+    {
+        public NonEdmTests(WebHostTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            configuration.AddControllers(typeof(CustomersController));
+            configuration.Select().Filter().OrderBy().Expand().Count().MaxTop(null);
+
+            // Force use of System.Text.Json output formatter
+            configuration.MvcOptionsActions.Add(options =>
+            {
+                options.OutputFormatters.Insert(0, new SystemTextJsonOutputFormatter(new JsonSerializerOptions()));
+            });
+
+            configuration.EnableDependencyInjection();
+        }
+
+        public static IEnumerable<object[]> GetSelectExpandTheoryData()
+        {
+            yield return new object[]
+            {
+                "Customers?$select=Name",
+                "[{\"Name\":\"Customer 1\"},{\"Name\":\"Customer 2\"}]"
+            };
+
+            yield return new object[]
+            {
+                "Customers?$select=*",
+                "[{\"Id\":1,\"Name\":\"Customer 1\"},{\"Id\":2,\"Name\":\"Customer 2\"}]"
+            };
+
+            yield return new object[]
+            {
+                "Customers?$select=Name&$expand=RelationshipManager",
+                "[{\"RelationshipManager\":{\"Id\":1,\"Name\":\"Employee 1\"},\"Name\":\"Customer 1\"},{\"RelationshipManager\":{\"Id\":3,\"Name\":\"Employee 3\"},\"Name\":\"Customer 2\"}]"
+            };
+
+            yield return new object[]
+            {
+                "Customers?$select=Name&$expand=*",
+                "[{\"RelationshipManager\":{\"Id\":1,\"Name\":\"Employee 1\"},\"Name\":\"Customer 1\"},{\"RelationshipManager\":{\"Id\":3,\"Name\":\"Employee 3\"},\"Name\":\"Customer 2\"}]"
+            };
+
+            yield return new object[]
+            {
+                "Customers?$select=Name&$orderby=Name desc",
+                "[{\"Name\":\"Customer 2\"},{\"Name\":\"Customer 1\"}]"
+            };
+
+            yield return new object[]
+            {
+                "Customers?$select=Name&$top=1",
+                "[{\"Name\":\"Customer 1\"}]"
+            };
+
+            yield return new object[]
+            {
+                "Customers?$select=Name&$orderby=Id desc&$skip=1&$top=1",
+                "[{\"Name\":\"Customer 1\"}]"
+            };
+
+            yield return new object[]
+            {
+                "Customers?$filter=Id gt 1&$select=Id,Name",
+                "[{\"Id\":2,\"Name\":\"Customer 2\"}]"
+            };
+
+            yield return new object[]
+            {
+                "Customers/Microsoft.Test.E2E.AspNet.OData.NonEdm.EnterpriseCustomer?$select=Name,Id",
+                "[{\"Name\":\"Customer 2\",\"Id\":2}]"
+            };
+
+            yield return new object[]
+            {
+                "Customers/Microsoft.Test.E2E.AspNet.OData.NonEdm.EnterpriseCustomer?$select=Name&$expand=AccountManager",
+                "[{\"AccountManager\":{\"Id\":2,\"Name\":\"Employee 2\"},\"Name\":\"Customer 2\"}]"
+            };
+
+            yield return new object[]
+            {
+                "Customers/Microsoft.Test.E2E.AspNet.OData.NonEdm.EnterpriseCustomer?$select=Name&$expand=*",
+                "[{\"AccountManager\":{\"Id\":2,\"Name\":\"Employee 2\"},\"RelationshipManager\":{\"Id\":3,\"Name\":\"Employee 3\"},\"Name\":\"Customer 2\"}]"
+            };
+
+            yield return new object[]
+            {
+                "Customers/1?$select=Name",
+                "{\"Name\":\"Customer 1\"}"
+            };
+
+            yield return new object[]
+            {
+                "Customers/1?$select=*&$expand=RelationshipManager",
+                "{\"RelationshipManager\":{\"Id\":1,\"Name\":\"Employee 1\"},\"Id\":1,\"Name\":\"Customer 1\"}"
+            };
+
+            yield return new object[]
+            {
+                "Customers/2?$select=Name&$expand=Microsoft.Test.E2E.AspNet.OData.NonEdm.EnterpriseCustomer/AccountManager",
+                "{\"AccountManager\":{\"Id\":2,\"Name\":\"Employee 2\"},\"Name\":\"Customer 2\"}"
+            };
+
+            yield return new object[]
+            {
+                "Customers/2?$select=Name&$expand=*",
+                "{\"AccountManager\":{\"Id\":2,\"Name\":\"Employee 2\"},\"RelationshipManager\":{\"Id\":3,\"Name\":\"Employee 3\"},\"Name\":\"Customer 2\"}"
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetSelectExpandTheoryData))]
+        public async Task SerializationWorksForQueryOptionsOnQueryStringInNonEdmScenarioUsingSystemTextJson(string odataPath, string expected)
+        {
+            // Arrange
+            var requestUri = string.Format("{0}/api/{1}", BaseAddress, odataPath);
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            var client = new HttpClient();
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(expected, content);
+        }
+    }
+}
+#endif

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
@@ -249,6 +249,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandBinderTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandIncludedPropertyTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandPathExtensionsTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandWrapperJsonConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\SelectExpandWrapperTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\Expressions\UriFunctionBinderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Query\DefaultSkipTokenHandlerTests.cs" />

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandWrapperJsonConverterTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandWrapperJsonConverterTests.cs
@@ -1,0 +1,298 @@
+//-----------------------------------------------------------------------------
+// <copyright file="SelectExpandWrapperJsonConverterTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+#if NETCOREAPP3_1_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Query;
+using Microsoft.AspNet.OData.Query.Expressions;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.AspNet.OData.Test.Query.Expressions
+{
+    public class SelectExpandWrapperJsonConverterTests
+    {
+        [Theory]
+        [InlineData(typeof(SelectExpandBinder.SelectAll<object>), true)]
+        [InlineData(typeof(SelectExpandBinder.SelectAllAndExpand<object>), true)]
+        [InlineData(typeof(SelectExpandBinder.SelectSome<object>), true)]
+        [InlineData(typeof(SelectExpandBinder.SelectSomeAndInheritance<object>), true)]
+        [InlineData(typeof(SelectExpandWrapper<object>), true)]
+        [InlineData(typeof(object), false)]
+        public void CanConvertWorksForSelectExpandWrapper(Type type, bool expected)
+        {
+            // Arrange
+            var converterFactory = new SelectExpandWrapperJsonConverter();
+
+            // Act & Assert
+            Assert.Equal(expected, converterFactory.CanConvert(type));
+        }
+
+        [Fact]
+        public void CanConvertThrowsExceptionForNullSelectExpandWrapper()
+        {
+            // Arrange
+            var converterFactory = new SelectExpandWrapperJsonConverter();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => converterFactory.CanConvert(null));
+        }
+
+        [Theory]
+        [InlineData(typeof(SelectExpandBinder.SelectAll<object>), "SelectAllOfTJsonConverter")]
+        [InlineData(typeof(SelectExpandBinder.SelectAllAndExpand<object>), "SelectAllAndExpandOfTJsonConverter")]
+        [InlineData(typeof(SelectExpandBinder.SelectSome<object>), "SelectSomeOfTJsonConverter")]
+        [InlineData(typeof(SelectExpandBinder.SelectSomeAndInheritance<object>), "SelectSomeAndInheritanceOfTJsonConverter")]
+        [InlineData(typeof(SelectExpandWrapper<object>), "SelectExpandWrapperOfTJsonConverter")]
+        public void CreateConvertWorksForSelectExpandWrapper(Type type, string expected)
+        {
+            // Arrange
+            var jsonSerializerOptions = new JsonSerializerOptions();
+            var converterFactory = new SelectExpandWrapperJsonConverter();
+
+            // Act
+            var result = converterFactory.CreateConverter(type, jsonSerializerOptions);
+
+            // Assert - The created converters are private so we assert on name
+            Assert.Contains(expected, result.GetType().Name);
+        }
+
+        [Theory]
+        [InlineData(typeof(FlatteningWrapper<object>))]
+        [InlineData(typeof(object))]
+        public void CreateConvertReturnsNullForUnexpectedTypeToConvertArgument(Type type)
+        {
+            // Arrange
+            var jsonSerializerOptions = new JsonSerializerOptions();
+            var converterFactory = new SelectExpandWrapperJsonConverter();
+
+            // Act & Assert
+            Assert.Null(converterFactory.CreateConverter(type, jsonSerializerOptions));
+        }
+
+        [Fact]
+        public void SelectExpandWrapperJsonConverterWorksForSelectAllOfT()
+        {
+            // Arrange, Act & Assert
+            SerializeTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandBinder.SelectAll<TrivialEntity>>();
+
+            // Arrange, Act & Assert
+            DeserializeTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandBinder.SelectAll<TrivialEntity>>();
+
+            // Arrange, Act & Assert
+            SerializeNonTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandBinder.SelectAll<NonTrivialEntity>>();
+        }
+
+        [Fact]
+        public void SelectExpandWrapperJsonConverterWorksForSelectAllAndExpandOfT()
+        {
+            // Arrange, Act & Assert
+            SerializeTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandBinder.SelectAllAndExpand<TrivialEntity>>();
+
+            // Arrange, Act & Assert
+            DeserializeTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandBinder.SelectAllAndExpand<TrivialEntity>>();
+
+            // Arrange, Act & Assert
+            SerializeNonTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandBinder.SelectAllAndExpand<NonTrivialEntity>>();
+        }
+
+        [Fact]
+        public void SelectExpandWrapperJsonConverterWorksForSelectSomeOfT()
+        {
+            // Arrange, Act & Assert
+            SerializeTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandBinder.SelectSome<TrivialEntity>>();
+
+            // Arrange, Act & Assert
+            DeserializeTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandBinder.SelectSome<TrivialEntity>>();
+
+            // Arrange, Act & Assert
+            SerializeNonTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandBinder.SelectSome<NonTrivialEntity>>();
+        }
+
+        [Fact]
+        public void SelectExpandWrapperJsonConverterWorksForSelectSomeAndInheritanceOfT()
+        {
+            // Arrange, Act & Assert
+            SerializeTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandBinder.SelectSomeAndInheritance<TrivialEntity>>();
+
+            // Arrange, Act & Assert
+            DeserializeTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandBinder.SelectSomeAndInheritance<TrivialEntity>>();
+
+            // Arrange, Act & Assert
+            SerializeNonTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandBinder.SelectSomeAndInheritance<NonTrivialEntity>>();
+        }
+
+        [Fact]
+        public void SelectExpandWrapperJsonConverterWorksForSelectExpandWrapperOfT()
+        {
+            // Arrange, Act & Assert
+            SerializeTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandWrapper<TrivialEntity>>();
+
+            // Arrange, Act & Assert
+            DeserializeTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandWrapper<TrivialEntity>>();
+
+            // Arrange, Act & Assert
+            SerializeNonTrivialPayloadUsingSelectExpandWriterJsonConverter<SelectExpandWrapper<NonTrivialEntity>>();
+        }
+
+        private static void SerializeTrivialPayloadUsingSelectExpandWriterJsonConverter<T>() where T : SelectExpandWrapper
+        {
+            // Arrange
+            var selectExpandWrapper = (T)Activator.CreateInstance(typeof(T));
+            var mockPropertyContainer = new MockPropertyContainer(new Dictionary<string, object> { { "Property", "foobar" } });
+            var model = GetEdmModel();
+
+            selectExpandWrapper.Container = mockPropertyContainer;
+            selectExpandWrapper.UseInstanceForProperties = true;
+            selectExpandWrapper.ModelID = ModelContainer.GetModelID(model);
+
+            var selectExpandWrapperOfT = selectExpandWrapper as SelectExpandWrapper<TrivialEntity>;
+            Assert.NotNull(selectExpandWrapperOfT);
+
+            selectExpandWrapperOfT.Instance = new TrivialEntity
+            {
+                Property = "foobar"
+            };
+
+            var jsonSerializerOptions = new JsonSerializerOptions();
+            var converterFactory = new SelectExpandWrapperJsonConverter();
+            var converter = converterFactory.CreateConverter(typeof(T), jsonSerializerOptions) as JsonConverter<T>;
+
+            var memoryStream = new MemoryStream();
+            var utf8JsonWriter = new Utf8JsonWriter(memoryStream);
+
+            // Act
+            converter.Write(utf8JsonWriter, selectExpandWrapper, jsonSerializerOptions);
+            memoryStream.Position = 0;
+
+            var result = new StreamReader(memoryStream).ReadToEnd();
+
+            // Assert
+            Assert.Equal("{\"Property\":\"foobar\"}", result);
+        }
+
+        private static void DeserializeTrivialPayloadUsingSelectExpandWriterJsonConverter<T>() where T : SelectExpandWrapper
+        {
+            // Arrange
+            var jsonSerializerOptions = new JsonSerializerOptions();
+            var converterFactory = new SelectExpandWrapperJsonConverter();
+            var converter = converterFactory.CreateConverter(typeof(T), jsonSerializerOptions) as JsonConverter<T>;
+
+            // Act & Assert
+            var exception = Assert.Throws<NotImplementedException>(() =>
+            {
+                var utf8JsonReader = new Utf8JsonReader();
+
+                converter.Read(ref utf8JsonReader, typeof(object), jsonSerializerOptions);
+            });
+
+            Assert.Equal($"'{typeof(T).Name}' is internal and should never be deserialized into.", exception.Message);
+        }
+
+        private void SerializeNonTrivialPayloadUsingSelectExpandWriterJsonConverter<T>() where T : SelectExpandWrapper
+        {
+            // Arrange
+            var selectExpandWrapper = (T)Activator.CreateInstance(typeof(T));
+            var mockPropertyContainer = new MockPropertyContainer(new Dictionary<string, object> {
+                { "Property1", "Prop1Value" },
+                { "Property2", "Prop2Value" },
+                { "Property3", "Prop3Value" },
+                { "Property4", "Prop4Value" }
+            });
+
+            var model = GetEdmModel();
+
+            selectExpandWrapper.Container = mockPropertyContainer;
+            selectExpandWrapper.UseInstanceForProperties = false;
+            selectExpandWrapper.ModelID = ModelContainer.GetModelID(model);
+
+            var selectExpandWrapperOfT = selectExpandWrapper as SelectExpandWrapper<NonTrivialEntity>;
+            Assert.NotNull(selectExpandWrapperOfT);
+
+            var jsonSerializerOptions = new JsonSerializerOptions();
+            var converterFactory = new SelectExpandWrapperJsonConverter();
+            var converter = converterFactory.CreateConverter(typeof(T), jsonSerializerOptions) as JsonConverter<T>;
+
+            var memoryStream = new MemoryStream();
+            var utf8JsonWriter = new Utf8JsonWriter(memoryStream);
+
+            // Act
+            converter.Write(utf8JsonWriter, selectExpandWrapper, jsonSerializerOptions);
+            memoryStream.Position = 0;
+
+            var result = new StreamReader(memoryStream).ReadToEnd();
+
+            // Assert
+            Assert.Equal("{\"Property1\":\"Prop1Value\",\"NsjProperty2\":\"Prop2Value\",\"StjProperty3\":\"Prop3Value\",\"NsjProperty4\":\"Prop4Value\"}", result);
+        }
+
+        private static IEdmModel GetEdmModel()
+        {
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntityType<TrivialEntity>();
+            builder.EntityType<NonTrivialEntity>();
+
+            var model = builder.GetEdmModel();
+
+            // Set an annotation value for MultiEntity.Property1 to support a test case
+            var multiEntity = model.SchemaElements.First(d => d.Name.Equals(typeof(NonTrivialEntity).Name)) as EdmEntityType;
+            var edmProperty1 = multiEntity.Properties().First(d => d.Name.Equals("Property1"));
+            var clrPropertyAnnotion = new ClrPropertyInfoAnnotation(typeof(NonTrivialEntity).GetProperty("Property1"));
+            model.SetAnnotationValue(edmProperty1, clrPropertyAnnotion);
+
+            return model;
+        }
+
+        private class MockPropertyContainer : PropertyContainer
+        {
+            public MockPropertyContainer(Dictionary<string, object> properties)
+            {
+                Properties = properties;
+            }
+
+            public Dictionary<string, object> Properties { get; private set; }
+
+            public override void ToDictionaryCore(
+                Dictionary<string, object> dictionary,
+                IPropertyMapper propertyMapper,
+                bool includeAutoSelected)
+            {
+                foreach (var kvp in Properties)
+                {
+                    dictionary.Add(propertyMapper.MapProperty(kvp.Key), kvp.Value);
+                }
+            }
+        }
+
+        private class TrivialEntity
+        {
+            public string Property { get; set; }
+        }
+
+        private class NonTrivialEntity
+        {
+            public string Property1 { get; set; }
+
+            [Newtonsoft.Json.JsonProperty("NsjProperty2")]
+            public string Property2 { get; set; }
+
+            [JsonPropertyName("StjProperty3")]
+            public string Property3 { get; set; }
+
+            [Newtonsoft.Json.JsonProperty("NsjProperty4")]
+            [JsonPropertyName("StjProperty4")]
+            public string Property4 { get; set; }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #1929, fixes #2174, and fixes #2038.*

### Description

Following the release of .NET Core 3.1, serialization broke when `$select` query option is applied to the URL in non-Edm scenarios. This happened because in ASP.NET Core 3.1, the default serialization library was changed from Newtonsoft.Json to System.Text.Json. There existed custom converters based on Newtonsoft.Json that were used in non-Edm scenarios but they could no longer applied after the default serialization library changed.

This pull request implements custom converters based on System.Text.Json that will be applied in non-Edm scenarios for .NET Core 3.1 or higher.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
