### PR TITLE
Fix for auto-generated swagger missing $filter for EntitySet

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/ODataSwaggerUtilities.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ODataSwaggerUtilities.cs
@@ -40,6 +40,7 @@ namespace Microsoft.AspNet.OData
                         .Description("Returns the EntitySet " + entitySet.Name)
                         .Tags(entitySet.Name)
                         .Parameters(new JArray()
+                            .Parameter("$filter", "query", "Filter by some expression", "string")
                             .Parameter("$expand", "query", "Expand navigation property", "string")
                             .Parameter("$select", "query", "select structural property", "string")
                             .Parameter("$orderby", "query", "order by some property", "string")

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Swagger/SwaggerMetadataTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Swagger/SwaggerMetadataTest.cs
@@ -113,6 +113,12 @@ namespace Microsoft.Test.E2E.AspNet.OData.Swagger
         ],
         ""parameters"": [
           {
+            ""name"": ""$filter"",
+            ""in"": ""query"",
+            ""description"": ""Filter by some expression"",
+            ""type"": ""string""
+          },
+          {
             ""name"": ""$expand"",
             ""in"": ""query"",
             ""description"": ""Expand navigation property"",
@@ -316,6 +322,12 @@ namespace Microsoft.Test.E2E.AspNet.OData.Swagger
         ],
         ""parameters"": [
           {
+            ""name"": ""$filter"",
+            ""in"": ""query"",
+            ""description"": ""Filter by some expression"",
+            ""type"": ""string""
+          },
+          {
             ""name"": ""$expand"",
             ""in"": ""query"",
             ""description"": ""Expand navigation property"",
@@ -518,6 +530,12 @@ namespace Microsoft.Test.E2E.AspNet.OData.Swagger
            ""CompositeKeyItems""
          ],
          ""parameters"": [
+           {
+             ""name"": ""$filter"",
+             ""in"": ""query"",
+             ""description"": ""Filter by some expression"",
+             ""type"": ""string""
+           },
            {
              ""name"": ""$expand"",
              ""in"": ""query"",

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/ODataSwaggerConverterTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/ODataSwaggerConverterTest.cs
@@ -68,6 +68,12 @@ namespace Microsoft.AspNet.OData.Test
         ],
         ""parameters"": [
           {
+            ""name"": ""$filter"",
+            ""in"": ""query"",
+            ""description"": ""Filter by some expression"",
+            ""type"": ""string""
+          },
+          {
             ""name"": ""$expand"",
             ""in"": ""query"",
             ""description"": ""Expand navigation property"",
@@ -270,6 +276,12 @@ namespace Microsoft.AspNet.OData.Test
           ""Orders""
         ],
         ""parameters"": [
+          {
+            ""name"": ""$filter"",
+            ""in"": ""query"",
+            ""description"": ""Filter by some expression"",
+            ""type"": ""string""
+          },
           {
             ""name"": ""$expand"",
             ""in"": ""query"",

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/ODataSwaggerUtilitiesTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/ODataSwaggerUtilitiesTest.cs
@@ -54,6 +54,8 @@ namespace Microsoft.AspNet.OData.Test
             // Assert
             Assert.NotNull(obj);
             Assert.Contains("\"Get EntitySet Customers\"", obj.ToString());
+            Assert.Contains("\"$select\"", obj.ToString());
+            Assert.Contains("\"$filter\"", obj.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #2802

### Description

Adds the $filter parameter to the auto-generated swagger.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

Builds and all tests pass inside VS2019 Community. I couldn't get build.cmd working sorry, it either hung or errored from FxCop.

