### PR TITLE
Fix case-insensitive property matching

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataInputFormatterHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataInputFormatterHelper.cs
@@ -82,6 +82,15 @@ namespace Microsoft.AspNet.OData.Formatter
                 oDataReaderSettings.Version = version;
                 oDataReaderSettings.MaxProtocolVersion = version;
 
+                ODataPath path = internalRequest.Context.Path;
+                ODataDeserializerContext readContext = getODataDeserializerContext();
+                readContext.Path = path;
+                readContext.Model = model;
+                readContext.ResourceType = type;
+                readContext.ResourceEdmType = expectedPayloadType;
+
+                oDataReaderSettings.EnablePropertyNameCaseInsensitive = !readContext.DisableCaseInsensitiveRequestPropertyBinding;
+
                 IODataRequestMessage oDataRequestMessage = getODataRequestMessage();
 
                 string preferHeader = RequestPreferenceHelpers.GetRequestPreferHeader(internalRequest.Headers);
@@ -99,13 +108,6 @@ namespace Microsoft.AspNet.OData.Formatter
 
                 ODataMessageReader oDataMessageReader = new ODataMessageReader(oDataRequestMessage, oDataReaderSettings, model);
                 registerForDisposeAction(oDataMessageReader);
-
-                ODataPath path = internalRequest.Context.Path;
-                ODataDeserializerContext readContext = getODataDeserializerContext();
-                readContext.Path = path;
-                readContext.Model = model;
-                readContext.ResourceType = type;
-                readContext.ResourceEdmType = expectedPayloadType;
 
 #if NETCORE
                 result = await deserializer.ReadAsync(oDataMessageReader, type, readContext);

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataModelBinderConverter.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataModelBinderConverter.cs
@@ -232,6 +232,7 @@ namespace Microsoft.AspNet.OData.Formatter
 
             IWebApiRequestMessage request = readContext.InternalRequest;
             ODataMessageReaderSettings oDataReaderSettings = request.ReaderSettings;
+            oDataReaderSettings.EnablePropertyNameCaseInsensitive = !readContext.DisableCaseInsensitiveRequestPropertyBinding;
 
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(valueString)))
             {

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/OpenType/TypedTest.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/OpenType/TypedTest.cs
@@ -590,6 +590,35 @@ namespace Microsoft.Test.E2E.AspNet.OData.OpenType
         #region Insert
 
         [Fact]
+        public async Task InsertEntityWithOpenCaseInsensitiveProperty()
+        {
+            foreach (string routing in Routings)
+            {
+                await ResetDatasource();
+
+                var postUri = string.Format(this.BaseAddress + "/{0}/Accounts", routing);
+
+                var postContent = JObject.Parse(
+@"{
+    'Id':4,
+    'naMe':null
+}");
+                using (HttpResponseMessage response = await this.Client.PostAsJsonAsync(postUri, postContent))
+                {
+                    Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+                    var json = await response.Content.ReadAsObject<JObject>();
+
+                    var id = (int)json["Id"];
+                    Assert.Equal(4, id);
+
+                    var name = (string)json["Name"];
+                    Assert.Null(name);
+                }
+            }
+        }
+
+        [Fact]
         public async Task InsertEntityWithOpenComplexTypeProperty()
         {
             foreach (string routing in Routings)

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingTest.cs
@@ -420,7 +420,7 @@ namespace Microsoft.AspNet.OData.Test.Routing
         [Theory]
         [InlineData("CollectionOfPrimitiveTypeFunction(intValues=@p)?@p=[1,2,4,7,8")] // missing "]"
         [InlineData("CanMoveToAddress(address=@p)?@p={\"@odata.")] // not valid complex payload
-        [InlineData("EntityTypeFunction(product=@p)?@p={\"@odata.type\":\"Microsoft.AspNet.OData.Test.Routing.Product\",\"id\":9,\"Name\":\"Phone\"}")] // should be "ID"
+        [InlineData("EntityTypeFunction(product=@p)?@p={\"@odata.type\":\"Microsoft.AspNet.OData.Test.Routing.Product\",\"id1\":9,\"Name\":\"Phone\"}")] // should be "ID"
         public async Task RoutesIncorrectly_ForBadFunctionParameters(string uri)
         {
             // Arrange & Act


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2635 .*

### Description

If we have an entitytype `Book`
```csharp
public class Book
{
    public int Id { get; set; }
    public string? Title { get; set; }
    public IDictionary<string, object> DynamicProperties { get; set; }
}
```
And we send a POST request to update the value of `Title` on an open-type using `title` as the name and have a null value
```json
{
  "title": null
}
```
An exception is thrown.

By default, we set the WebAPI requests to be `case-insensitive`, however we usually don't set `EnablePropertyNameCaseInsensitive=true` in the `ODataReaderSettings` that we use to intialize the `ODataMessageReader`. This causes the `title` property to be deserialized as an `ODataUntypedValue` with RawValue as string "null". That's why we treat the value as a primitive value and this fails in the `ConvertPrimitiveValue` method.

If we set `EnablePropertyNameCaseInsensitive` as `true` in the `ODataReaderSettings`, the `title` property is deserialized as an `ODataNullValue`.

This PR ensures that set the correct `EnablePropertyNameCaseInsensitive` in the `ODataReaderSettings`

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
