### PR TITLE
Declared properties read as untyped when lower camel case is enabled

### DIFF
--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/LowerCamelCase/LowerCamelCaseController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/LowerCamelCase/LowerCamelCaseController.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.LowerCamelCase
             return Ok(_employees.Single(e => e.ID == key).Manager);
         }
 
-        public ITestActionResult Post(Employee employee)
+        public ITestActionResult Post([FromBody] Employee employee)
         {
             employee.ID = _employees.Count + 1;
             _employees.Add(employee);

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/LowerCamelCase/LowerCamelCaseDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/LowerCamelCase/LowerCamelCaseDataModel.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.LowerCamelCase
 
         [DataMember]
         public Manager Manager { get; set; }
+
+        public Dictionary<string, object> ExtendedProperties { get; set; }
     }
 
     [DataContract]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes https://github.com/OData/odata.net/issues/2049.*

### Description

Prior to [this fix](https://github.com/OData/WebApi/pull/2804) implemented by @KenitoInc, if someone enabled lower camel case by invoking `EnableLowerCamelCase` method against the Edm model builder, an exception would be thrown from [`ApplyIdToPath` method](https://github.com/OData/WebApi/blob/9ec53763e3b927a87ceed5a58b5766bd87bd7ae6/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializerHelpers.cs#L390) if the key property in the request body was not in lower camel case.

For example,

In service start up code:
```csharp
var modelBuilder = new ODataConventionModelBuilder();
// ...
modelBuilder.EnableLowerCamelCase();
```
Request payload:
```json
{
    "Id": 1,
    "Name": "Sue"
}
```
The reason the exception is thrown is because `Id` and `Name` are not in lower camel case and since property binding was case-sensitive previously, the two properties are read as untyped values. Subsequently when the `KeySegment` object is being initialized, it's initialized with the value as an `ODataUntypedValue` object instead of primitive. Attempt to append that key segment leads to an exception since a Uri cannot contain an object - **"The type 'Microsoft.OData.ODataUntypedValue' is not supported when converting to a URI literal."**.

This issue was inadvertently fixed by a different PR https://github.com/OData/WebApi/pull/2804. In this PR, tests are added for the scenario described above.

In relation to the reported issue of escaped characters in properties that are read as untyped (e.g., dynamic properties) being double-escaped, that issue no longer exists in the latest 7.x version of the Web API library.

For example,

For dynamic property `NickName` in a request payload:
```json
{"NickName": "J\\D"}
```
Deserialized:
![image](https://github.com/OData/WebApi/assets/28291332/a688e7d4-8800-4db8-862c-055522b7ae2a)

This scenario is also tested for in this PR.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
