### PR TITLE
Fix issue with property names which differ from Clr property names

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/ODataAPIHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/ODataAPIHandler.cs
@@ -178,7 +178,7 @@ namespace Microsoft.AspNet.OData
                 navigationProperties = edmEntityType.NavigationProperties();
             }
 
-            IDictionary<string, object> keys = GetKeys(entityKey, resource, type); // Refactored ApplyHandler. Consider removing this.
+            IDictionary<string, object> keys = GetKeys(model, entityKey, resource, type); // Refactored ApplyHandler. Consider removing this.
 
             IODataAPIHandler odataIdContainerHandler = null;
 
@@ -203,7 +203,8 @@ namespace Microsoft.AspNet.OData
             {
                 foreach (IEdmNavigationProperty navProp in navigationProperties)
                 {
-                    navPropNames.Add(navProp.Name);
+                    string clrPropertyName = EdmLibHelpers.GetClrPropertyName(navProp, model);
+                    navPropNames.Add(clrPropertyName);
                 }
             }
 
@@ -422,7 +423,7 @@ namespace Microsoft.AspNet.OData
             }
         }
 
-        private static IDictionary<string, object> GetKeys(IEnumerable<IEdmStructuralProperty> properties, object resource, Type type)
+        private static IDictionary<string, object> GetKeys(IEdmModel model, IEnumerable<IEdmStructuralProperty> properties, object resource, Type type)
         {
             IDictionary<string, object> keys = new Dictionary<string, object>();
 
@@ -433,7 +434,8 @@ namespace Microsoft.AspNet.OData
 
             foreach (IEdmStructuralProperty property in properties)
             {
-                PropertyInfo prop = type.GetProperty(property.Name);
+                string clrPropertyName = EdmLibHelpers.GetClrPropertyName(property, model);
+                PropertyInfo prop = type.GetProperty(clrPropertyName);
                 object value = prop.GetValue(resource, null);
 
                 keys.Add(new KeyValuePair<string, object>(property.Name, value));

--- a/src/Microsoft.AspNet.OData.Shared/Query/ExpandQueryBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/ExpandQueryBuilder.cs
@@ -70,7 +70,8 @@ namespace Microsoft.AspNet.OData.Query
             foreach (IEdmNavigationProperty navProp in navigationProperties)
             {
                 count++;
-                PropertyInfo prop = type.GetProperty(navProp.Name);
+                string clrPropertyName = EdmLibHelpers.GetClrPropertyName(navProp, model);
+                PropertyInfo prop = type.GetProperty(clrPropertyName);
 
                 if (isCollection)
                 {
@@ -86,7 +87,7 @@ namespace Microsoft.AspNet.OData.Query
                         if (!navPropNames.Contains(navProp.Name))
                         {
                             expandString += !isNestedExpand ? "" : "(";
-                            expandString += count > 1 ? "," + prop.Name : string.Concat("$expand=", prop.Name);
+                            expandString += count > 1 ? "," + navProp.Name : string.Concat("$expand=", navProp.Name);
                             navPropNames.Add(navProp.Name);
                             expandString += GenerateExpandQueryStringInternal(navPropValue, model, true);
                         }
@@ -108,7 +109,7 @@ namespace Microsoft.AspNet.OData.Query
                         if (!navPropNames.Contains(navProp.Name))
                         {
                             expandString += !isNestedExpand ? "" : "(";
-                            expandString += count > 1 ? "," + prop.Name : string.Concat("$expand=", prop.Name);
+                            expandString += count > 1 ? "," + navProp.Name : string.Concat("$expand=", navProp.Name);
                             navPropNames.Add(navProp.Name);
                             expandString += GenerateExpandQueryStringInternal(navPropValue, model, true);
                         }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationController.cs
@@ -488,4 +488,36 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
             var cntrl = new EmployeesController();
         }
     }
+
+    public class StudentController : TestODataController
+    {
+        public static IList<Student> Students = null;
+        public static IList<Course> Courses = null;
+
+        public StudentController()
+        {
+            if (null == Students)
+            {
+                InitStudents();
+            }
+        }
+
+        private void InitStudents()
+        {
+            Students = new List<Student>();
+            Courses = new List<Course>();
+        }
+
+        [ODataRoute("Students")]
+        [HttpPost]
+        [EnableQuery]
+        public ITestActionResult Post([FromBody] Student student)
+        {
+            var handler = new StudentAPIHandler();
+
+            handler.DeepInsert(student, Request.GetModel(), new APIHandlerFactory(Request.GetModel()));
+
+            return Created(student);
+        }
+    }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationDataModel.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
 using Microsoft.AspNet.OData;
 using Microsoft.AspNet.OData.Builder;
 
@@ -160,6 +161,32 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
         public int Id { get; set; }
         public string Street { get; set; }
     }
+
+    [DataContract]
+    public class Student
+    {
+        [Key]
+        [DataMember(Name="StudentId")]
+        public int Id { get; set; }
+
+        [DataMember(Name = "StudentName")]
+        public string Name { get; set; }
+
+        [DataMember(Name = "StudentCourses")]
+        public List<Course> Courses { get; set; }
+    }
+
+    [DataContract]
+    public class Course
+    {
+        [Key]
+        [DataMember(Name = "CourseId")]
+        public int Id { get; set; }
+
+        [DataMember(Name = "CourseName")]
+        public string Name { get; set; }
+    }
+
 
     public class FriendColl<T> : ICollection<T>
     {

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationEdmModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationEdmModel.cs
@@ -73,6 +73,8 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
             EntitySetConfiguration<NewOrder> overdueorders = builder.EntitySet<NewOrder>("OverdueOrders");
             EntitySetConfiguration<MyNewOrder> myoverdueorders = builder.EntitySet<MyNewOrder>("MyOverdueOrders");
             EntitySetConfiguration<NewOrder> myNewOrders = builder.EntitySet<NewOrder>("MyNewOrders");
+            EntitySetConfiguration<Student> students = builder.EntitySet<Student>("Students");
+            EntitySetConfiguration<Course> courses = builder.EntitySet<Course>("Courses");
 
             // maybe following lines are not required once bug #1587 is fixed.
             // 1587: It's better to support automatically adding actions and functions in ODataConventionModelBuilder.

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationPatchHandlers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/BulkOperation/BulkOperationPatchHandlers.cs
@@ -1926,4 +1926,230 @@ namespace Microsoft.Test.E2E.AspNet.OData.BulkOperation
             return ODataAPIResponseStatus.Success;
         }
     }
+
+    internal class StudentAPIHandler : ODataAPIHandler<Student>
+    {
+        public override ODataAPIResponseStatus TryCreate(IDictionary<string, object> keyValues, out Student createdObject, out string errorMessage)
+        {
+            createdObject = null;
+            errorMessage = string.Empty;
+
+            try
+            {
+                createdObject = new Student();
+                StudentController.Students.Add(createdObject);
+
+                return ODataAPIResponseStatus.Success;
+            }
+            catch (Exception ex)
+            {
+                errorMessage = ex.Message;
+
+                return ODataAPIResponseStatus.Failure;
+            }
+        }
+
+        public override ODataAPIResponseStatus TryDelete(IDictionary<string, object> keyValues, out string errorMessage)
+        {
+            errorMessage = string.Empty;
+
+            try
+            {
+                var id = keyValues.First().Value.ToString();
+                var student = StudentController.Students.First(x => x.Id == Int32.Parse(id));
+
+                StudentController.Students.Remove(student);
+
+                return ODataAPIResponseStatus.Success;
+            }
+            catch (Exception ex)
+            {
+                errorMessage = ex.Message;
+
+                return ODataAPIResponseStatus.Failure;
+            }
+        }
+
+        public override ODataAPIResponseStatus TryGet(IDictionary<string, object> keyValues, out Student originalObject, out string errorMessage)
+        {
+            ODataAPIResponseStatus status = ODataAPIResponseStatus.Success;
+            errorMessage = string.Empty;
+            originalObject = null;
+
+            try
+            {
+                var id = keyValues["Id"].ToString();
+                originalObject = StudentController.Students.FirstOrDefault(x => x.Id == Int32.Parse(id));
+
+                if (originalObject == null)
+                {
+                    status = ODataAPIResponseStatus.NotFound;
+                }
+            }
+            catch (Exception ex)
+            {
+                status = ODataAPIResponseStatus.Failure;
+                errorMessage = ex.Message;
+            }
+
+            return status;
+        }
+
+        public override IODataAPIHandler GetNestedHandler(Student parent, string navigationPropertyName)
+        {
+            switch (navigationPropertyName)
+            {
+                case "Courses":
+                    return new CourseAPIHandler(parent);
+                default:
+                    return null;
+            }
+        }
+
+        public override ODataAPIResponseStatus TryAddRelatedObject(Student resource, out string errorMessage)
+        {
+            errorMessage = string.Empty;
+
+            return ODataAPIResponseStatus.Success;
+        }
+
+        public override Task<ODataAPIResponseStatus> TryCreateAsync(IDictionary<string, object> keyValues, out Student createdObject, out string errorMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<ODataAPIResponseStatus> TryGetAsync(IDictionary<string, object> keyValues, out Student originalObject, out string errorMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<ODataAPIResponseStatus> TryDeleteAsync(IDictionary<string, object> keyValues, out string errorMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<ODataAPIResponseStatus> TryAddRelatedObjectAsync(Student resource, out string errorMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IODataAPIHandler GetNestedHandlerAsync(Student parent, string navigationPropertyName)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    internal class CourseAPIHandler : ODataAPIHandler<Course>
+    {
+        Student student;
+        public CourseAPIHandler(Student student)
+        {
+            this.student = student;
+        }
+
+        public override ODataAPIResponseStatus TryCreate(IDictionary<string, object> keyValues, out Course createdObject, out string errorMessage)
+        {
+            createdObject = null;
+            errorMessage = string.Empty;
+
+            try
+            {
+                createdObject = new Course();
+                StudentController.Courses.Add(createdObject);
+
+                return ODataAPIResponseStatus.Success;
+            }
+            catch (Exception ex)
+            {
+                errorMessage = ex.Message;
+
+                return ODataAPIResponseStatus.Failure;
+            }
+        }
+
+        public override ODataAPIResponseStatus TryDelete(IDictionary<string, object> keyValues, out string errorMessage)
+        {
+            errorMessage = string.Empty;
+
+            try
+            {
+                var id = keyValues.First().Value.ToString();
+                var course = StudentController.Courses.First(x => x.Id == Int32.Parse(id));
+
+                StudentController.Courses.Remove(course);
+
+                return ODataAPIResponseStatus.Success;
+            }
+            catch (Exception ex)
+            {
+                errorMessage = ex.Message;
+
+                return ODataAPIResponseStatus.Failure;
+            }
+        }
+
+        public override ODataAPIResponseStatus TryGet(IDictionary<string, object> keyValues, out Course originalObject, out string errorMessage)
+        {
+            ODataAPIResponseStatus status = ODataAPIResponseStatus.Success;
+            errorMessage = string.Empty;
+            originalObject = null;
+
+            try
+            {
+                var id = keyValues["Id"].ToString();
+                originalObject = StudentController.Courses.FirstOrDefault(x => x.Id == Int32.Parse(id));
+
+                if (originalObject == null)
+                {
+                    status = ODataAPIResponseStatus.NotFound;
+                }
+            }
+            catch (Exception ex)
+            {
+                status = ODataAPIResponseStatus.Failure;
+                errorMessage = ex.Message;
+            }
+
+            return status;
+        }
+
+        public override IODataAPIHandler GetNestedHandler(Course parent, string navigationPropertyName)
+        {
+            return null;
+        }
+
+        public override ODataAPIResponseStatus TryAddRelatedObject(Course resource, out string errorMessage)
+        {
+            errorMessage = string.Empty;
+
+            this.student.Courses.Add(resource);
+
+            return ODataAPIResponseStatus.Success;
+        }
+
+        public override Task<ODataAPIResponseStatus> TryCreateAsync(IDictionary<string, object> keyValues, out Course createdObject, out string errorMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<ODataAPIResponseStatus> TryGetAsync(IDictionary<string, object> keyValues, out Course originalObject, out string errorMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<ODataAPIResponseStatus> TryDeleteAsync(IDictionary<string, object> keyValues, out string errorMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<ODataAPIResponseStatus> TryAddRelatedObjectAsync(Course resource, out string errorMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IODataAPIHandler GetNestedHandlerAsync(Course parent, string navigationPropertyName)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2805 .*

### Description

When we have `DataContract / DataMember` attributes in the model, the `IEdmModel` entity property names differ from the Clr type property names.
When we run this method
```c#
PropertyInfo propertyInfo = type.GetProperty(edmProperty.Name);
```
the `propertyInfo` is `null`.

The change we introduced is to call `GetClrPropertyName(...)` before calling `GetProperty(...)`

```c#
string clrPropertyName = EdmLibHelpers.GetClrPropertyName(edmProperty.Name, edmModel);
PropertyInfo prop = type.GetProperty(clrPropertyName);
```
This ensure we are able to get the propertyinfo using the clr property name.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
