### PR TITLE
Upgrade Microsoft.NetCore.App to 2.0.3

### DIFF
--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -24,9 +24,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">
     <!-- Define the Items for .NET Standard 2.0 -->
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.3" />
     <!-- PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="1.1.0" /> -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
@@ -79,6 +79,12 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>SRResources.resx</DependentUpon>
     </Compile>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.Netcore.app">
+      <Version>2.0.3</Version>
+    </PackageReference>
   </ItemGroup>
   <Target Name="SetNuspecProperties" BeforeTargets="GenerateNuspec">
     <PropertyGroup>

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -24,9 +24,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">
     <!-- Define the Items for .NET Standard 2.0 -->
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" />
     <!-- PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="1.1.0" /> -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
@@ -81,11 +81,6 @@
     </Compile>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Netcore.app">
-      <Version>2.0.3</Version>
-    </PackageReference>
-  </ItemGroup>
   <Target Name="SetNuspecProperties" BeforeTargets="GenerateNuspec">
     <PropertyGroup>
       <NuspecProperties>ProductRoot=$(ProductBinPath);VersionNuGetSemantic=$(VersionNuGetSemantic)</NuspecProperties>

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataMediaTypeFormattersTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataMediaTypeFormattersTests.cs
@@ -18,9 +18,10 @@ using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 #if NETCOREAPP3_1
 #else
-    using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.WebUtilities;

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Routing/ODataRoutingTest.cs
@@ -666,6 +666,7 @@ namespace Microsoft.AspNet.OData.Test.Routing
         }
 
         [AcceptVerbs("GET", "POST", "PUT", "PATCH", "DELETE", "CUSTOM")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "MVC1004:Rename model bound parameter.", Justification = "<Pending>")]
         public string HandleUnmappedRequest(ODataPath path)
         {
             return path.PathTemplate;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/Endpoint/EndpointRouteBuilderFactory.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/Endpoint/EndpointRouteBuilderFactory.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 using System;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Extensions;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/Endpoint/MockEndpointRouteBuilder.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/Endpoint/MockEndpointRouteBuilder.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ODataActionSelectorTestHelper.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ODataActionSelectorTestHelper.cs
@@ -17,7 +17,7 @@ using System.IO;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System.Linq;
 using System.Text;
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.OData;
@@ -87,7 +87,7 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
                 as IReadOnlyList<ControllerActionDescriptor>;
             actionDescriptors = actionDescriptors.Where(a => a.ActionName == actionName).ToList();
             var serviceProvider = routeBuilder.ServiceProvider;
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
             var actionsProvider = serviceProvider.GetRequiredService<IActionDescriptorCollectionProvider>();
             var actionConstraintsProvider = serviceProvider.GetRequiredService<ActionConstraintCache>();
             var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/RoutingConfigurationFactory.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/RoutingConfigurationFactory.cs
@@ -17,7 +17,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
 using Microsoft.AspNetCore.Builder.Internal;
 using Microsoft.AspNetCore.Mvc.Internal;
 #endif
@@ -81,7 +81,7 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
             // Create a route build with a default path handler.
             IRouteBuilder routeBuilder = new RouteBuilder(appBuilder);
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
             routeBuilder.DefaultHandler = new MvcRouteHandler(
                 mockInvokerFactory.Object,
                 mockActionSelector.Object,

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ServerFactory.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ServerFactory.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
             IWebHostBuilder builder = WebHost.CreateDefaultBuilder();
             builder.ConfigureServices(services =>
             {
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
                 services.AddMvc();
 #else
                 services.AddMvc(options => options.EnableEndpointRouting = false)

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointLinkGeneratorTests.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointLinkGeneratorTests.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 using System;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Test.Common;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointPatternTests.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointPatternTests.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 using System;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Test.Common;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointRouteValueTransformerTests.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointRouteValueTransformerTests.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointSelectorPolicyTests.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointSelectorPolicyTests.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\..\..\tools\WebStack.settings.targets" />
   <PropertyGroup>
@@ -25,13 +25,13 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' ">
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.34" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.17.0" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.17.0" />

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
@@ -26,12 +26,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.17.0" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.17.0" />

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
@@ -26,11 +26,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.34" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.17.0" />

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Routing/ODataActionSelectorTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Routing/ODataActionSelectorTest.cs
@@ -270,8 +270,10 @@ namespace Microsoft.AspNet.OData.Test.Routing
 
     public class PathAndQueryController : TestODataController
     {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "MVC1004:Rename model bound parameter.", Justification = "<Pending>")]
         public void Get(ODataPath path, ODataQueryOptions queryOptions) { }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "MVC1004:Rename model bound parameter.", Justification = "<Pending>")]
         public void Get(ODataPath path) { }
     }
 
@@ -297,12 +299,14 @@ namespace Microsoft.AspNet.OData.Test.Routing
 
     public class KeyAndRelatedKeyAndPathController : TestODataController
     {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "MVC1004:Rename model bound parameter.", Justification = "<Pending>")]
         public void Get(int key, int relatedKey, ODataPath path) { }
 
         public void Get(int key, int relatedKey) { }
 
         public void Get(int key, int relatedKey, int navigationProperty) { }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "MVC1004:Rename model bound parameter.", Justification = "<Pending>")]
         public void Get(int key, ODataPath path) { }
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description
PR builds in the WebAPI repo are failing
```
The nuget command failed with exit code(1) and error(NU1903: Warning As Error: Package 'Microsoft.NETCore.App' 2.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7mfr-774f-w5r9
Errors in D:\a\1\s\test\UnitTest\Microsoft.AspNetCore.OData.Test\Microsoft.AspNetCore.OData.Test.csproj
    NU1903: Warning As Error: Package 'Microsoft.NETCore.App' 2.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7mfr-774f-w5r9)
```

The vulnerability was fixed in v2.03 see https://github.com/advisories/GHSA-7mfr-774f-w5r9

I have upgraded to v2.0.3 and not a higher version to ensure all our code compiles as expected and tests pass.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
