### PR TITLE
Fix failing build

### DIFF
--- a/pipelines/common.yml
+++ b/pipelines/common.yml
@@ -13,9 +13,9 @@ steps:
     version: 3.x
 
 - task: UseDotNet@2
-  displayName: Use .NET Core sdk 2.0.x
+  displayName: Use .NET Core sdk 2.1.x
   inputs:
-    version: 2.0.x
+    version: 2.1.x
 
 - task: UseDotNet@2
   displayName: Use .NET Core sdk 5.x

--- a/samples/AspNetCoreODataSample.Web/AspNetCoreODataSample.Web.csproj
+++ b/samples/AspNetCoreODataSample.Web/AspNetCoreODataSample.Web.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.30" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataFormatterTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataFormatterTests.cs
@@ -522,7 +522,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             }
         }
 
-#if !NETCOREAPP2_0 && NETCORE
+#if !NETCOREAPP2_1 && NETCORE
         [Fact]
         public async Task ConflictResponseFromODataControllerIsSerializedAsODataError()
         {
@@ -930,7 +930,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter
             {
                 return Unauthorized("Not authorized to access this resource.");
             }
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
             public IActionResult Patch([FromODataUri] int key, [FromBody] Customer customer)
             {
                 return Conflict("Conflict during update.");

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataMediaTypeFormattersTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/ODataMediaTypeFormattersTests.cs
@@ -18,9 +18,11 @@ using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
 #if NETCOREAPP3_1
 #else
-    using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.WebUtilities;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/Endpoint/EndpointRouteBuilderFactory.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/Endpoint/EndpointRouteBuilderFactory.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 using System;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Extensions;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/Endpoint/MockEndpointRouteBuilder.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/Endpoint/MockEndpointRouteBuilder.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/FormatterTestHelper.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/FormatterTestHelper.cs
@@ -16,7 +16,7 @@ using Microsoft.AspNet.OData.Test.Formatter;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
     using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ODataActionSelectorTestHelper.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ODataActionSelectorTestHelper.cs
@@ -17,7 +17,7 @@ using System.IO;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System.Linq;
 using System.Text;
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.OData;
@@ -87,7 +87,7 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
                 as IReadOnlyList<ControllerActionDescriptor>;
             actionDescriptors = actionDescriptors.Where(a => a.ActionName == actionName).ToList();
             var serviceProvider = routeBuilder.ServiceProvider;
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
             var actionsProvider = serviceProvider.GetRequiredService<IActionDescriptorCollectionProvider>();
             var actionConstraintsProvider = serviceProvider.GetRequiredService<ActionConstraintCache>();
             var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/RoutingConfigurationFactory.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/RoutingConfigurationFactory.cs
@@ -17,7 +17,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
 using Microsoft.AspNetCore.Builder.Internal;
 using Microsoft.AspNetCore.Mvc.Internal;
 #endif
@@ -81,7 +81,7 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
             // Create a route build with a default path handler.
             IRouteBuilder routeBuilder = new RouteBuilder(appBuilder);
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
             routeBuilder.DefaultHandler = new MvcRouteHandler(
                 mockInvokerFactory.Object,
                 mockActionSelector.Object,
@@ -207,7 +207,7 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
             // Create a route build with a default path handler.
             IRouteBuilder routeBuilder = new RouteBuilder(appBuilder);
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
             routeBuilder.DefaultHandler = new MvcRouteHandler(
                 mockInvokerFactory.Object,
                 mockActionSelector.Object,

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ServerFactory.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Abstraction/ServerFactory.cs
@@ -15,7 +15,7 @@ using Microsoft.AspNet.OData.Test.Common;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
     using Microsoft.AspNetCore.Http.Features;
 #endif
 using Microsoft.AspNetCore.Mvc;
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
             IWebHostBuilder builder = WebHost.CreateDefaultBuilder();
             builder.ConfigureServices(services =>
             {
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
                 services.AddMvc();
 #else
                 services.AddMvc(options => options.EnableEndpointRouting = false)
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.OData.Test.Abstraction
 
             builder.Configure(app =>
             {
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
                 app.Use(next => context =>
                 {
                     var body = context.Features.Get<IHttpBodyControlFeature>();

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/ActionDescriptorExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/ActionDescriptorExtensionsTest.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
     using Microsoft.AspNetCore.Mvc.Internal;
     using Microsoft.AspNetCore.Http.Internal;
 #endif
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.OData.Test.Extensions
             var services = new Mock<IServiceProvider>();
             services.Setup(s => s.GetService(typeof(ApplicationPartManager))).Returns(new ApplicationPartManager());
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
             var request = new DefaultHttpRequest(new DefaultHttpContext { RequestServices = services.Object });
 #else
             var request = new DefaultHttpContext { RequestServices = services.Object }.Request;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointLinkGeneratorTests.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointLinkGeneratorTests.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 using System;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Test.Common;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointPatternTests.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointPatternTests.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 using System;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Test.Common;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointRouteValueTransformerTests.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointRouteValueTransformerTests.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointSelectorPolicyTests.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Extensions/Endpoint/ODataEndpointSelectorPolicyTests.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\..\..\tools\WebStack.settings.targets" />
   <PropertyGroup>
@@ -25,14 +25,13 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' ">
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.1" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.17.0" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.17.0" />
     <PackageReference Include="Microsoft.Spatial" Version="7.17.0" />

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/PublicApiTest.cs
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/PublicApiTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.OData.Test.PublicApi
     {
         private const string AssemblyName = "Microsoft.AspNetCore.OData.dll";
         private const string OutputFileName = "Microsoft.AspNetCore.OData.PublicApi.out";
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
         private const string BaseLineFileName = "Microsoft.AspNetCore.OData.PublicApi.bsl";
 #else
         private const string BaseLineFileName = "Microsoft.AspNetCore3x.OData.PublicApi.bsl";


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

The OData/WebApi build is failing on the pipeline due to severe vulnerability detected in some of the referenced AspNetCore packages. This pull request fixes that by updating the dependencies.

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*