### PR TITLE
fixes #2816: Set the response version to delta response and delta patch response

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/ODataOutputFormatterHelper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/ODataOutputFormatterHelper.cs
@@ -158,7 +158,8 @@ namespace Microsoft.AspNet.OData.Formatter
             ODataMessageWriterSettings writerSettings = internalRequest.WriterSettings;
             writerSettings.BaseUri = baseAddress;
 
-            if (serializer.ODataPayloadKind == ODataPayloadKind.Delta)
+            // Set the response version to v4.01 when the request is a delta patch, but not any time we write a delta response payload.
+            if (serializer.ODataPayloadKind == ODataPayloadKind.Delta && internalRequest.Method == ODataRequestMethod.Patch)
             {
                 writerSettings.Version = ODataVersion.V401;
             }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DeltaQueryTests/DeltaQueryTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DeltaQueryTests/DeltaQueryTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Test.E2E.AspNet.OData
         }
 
         [Fact]
-        public async Task DeltaVerifyReslt()
+        public async Task DeltaVerifyResult()
         {
             HttpRequestMessage get = new HttpRequestMessage(HttpMethod.Get, BaseAddress + "/odata/TestCustomers?$deltaToken=abc");
             get.Headers.Add("Accept", "application/json;odata.metadata=minimal");
@@ -128,7 +128,7 @@ namespace Microsoft.Test.E2E.AspNet.OData
         }
 
         [Fact]
-        public async Task DeltaVerifyReslt_ContainsDynamicComplexProperties()
+        public async Task DeltaVerifyResult_ContainsDynamicComplexProperties()
         {
             HttpRequestMessage get = new HttpRequestMessage(HttpMethod.Get, BaseAddress + "/odata/TestOrders?$deltaToken=abc");
             get.Headers.Add("Accept", "application/json;odata.metadata=minimal");
@@ -149,6 +149,37 @@ namespace Microsoft.Test.E2E.AspNet.OData
                   "\"OpenProperty\":10," +
                   "\"key-samplelist\":{" +
                     "\"@type\":\"#Microsoft.Test.E2E.AspNet.OData.TestAddress\"," +
+                    "\"State\":\"sample state\"," +
+                    "\"ZipCode\":9," +
+                    "\"title\":\"sample title\"" +
+                  "}" +
+                "}" +
+              "}" +
+            "]" +
+          "}",
+                result);
+        }
+
+        [Fact]
+        public async Task DeltaVerifyResult_ContainsDynamicComplexProperties_UsingDefaultVersion()
+        {
+            HttpRequestMessage get = new HttpRequestMessage(HttpMethod.Get, BaseAddress + "/odata/TestOrders?$deltaToken=abc");
+            HttpResponseMessage response = await Client.SendAsync(get);
+            Assert.True(response.IsSuccessStatusCode);
+
+            string result = await response.Content.ReadAsStringAsync();
+            Assert.Contains("odata/$metadata#TestOrders/$delta\"," +
+            "\"value\":[" +
+              "{" +
+                "\"Id\":1," +
+                "\"Amount\":42," +
+                "\"Location\":" +
+                "{" +
+                  "\"State\":\"State\"," +
+                  "\"ZipCode\":null," +
+                  "\"OpenProperty\":10," +
+                  "\"key-samplelist\":{" +
+                    "\"@odata.type\":\"#Microsoft.Test.E2E.AspNet.OData.TestAddress\"," +
                     "\"State\":\"sample state\"," +
                     "\"ZipCode\":9," +
                     "\"title\":\"sample title\"" +

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/Untyped/UntypedDeltaSerializationTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/Untyped/UntypedDeltaSerializationTests.cs
@@ -21,18 +21,14 @@ using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
 using Microsoft.Test.E2E.AspNet.OData.Common.Extensions;
 using Newtonsoft.Json.Linq;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.Test.E2E.AspNet.OData.Formatter.Untyped
 {
     public class UntypedDeltaSerializationTests : WebHostTestBase
     {
-        private readonly ITestOutputHelper output;
-
-        public UntypedDeltaSerializationTests(WebHostTestFixture fixture, ITestOutputHelper output)
+        public UntypedDeltaSerializationTests(WebHostTestFixture fixture)
             : base(fixture)
         {
-            this.output = output;
         }
 
         protected override void UpdateConfiguration(WebRouteConfiguration configuration)
@@ -59,7 +55,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter.Untyped
             string url = "/untyped/UntypedDeltaCustomers?$deltatoken=abc";
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, BaseAddress + url);
 
-            // by default, the odata version is 4.0. It will throw:
+            // By default, the odata version is 4.0. It will throw:
             // "Cannot transition from state 'DeletedResource' to state 'NestedResourceInfo' when writing an OData 4.0 payload.
             // To write content to a deleted resource, please specify ODataVersion 4.01 or greater in MessageWriterSettings."
             request.Headers.Add("OData-Version", "4.01");

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/Untyped/UntypedDeltaSerializationTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/Untyped/UntypedDeltaSerializationTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter.Untyped
 
             for (int i = 10; i < 15; i++)
             {
-                Assert.True(i.ToString().Equals(((dynamic)returnedObject).value[i]["@id"].Value));
+                Assert.True(i.ToString().Equals(((dynamic)returnedObject).value[i]["@odata.id"].Value));
             }
         }
     }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/Untyped/UntypedDeltaSerializationTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/Untyped/UntypedDeltaSerializationTests.cs
@@ -21,14 +21,18 @@ using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
 using Microsoft.Test.E2E.AspNet.OData.Common.Extensions;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Test.E2E.AspNet.OData.Formatter.Untyped
 {
     public class UntypedDeltaSerializationTests : WebHostTestBase
     {
-        public UntypedDeltaSerializationTests(WebHostTestFixture fixture)
+        private readonly ITestOutputHelper output;
+
+        public UntypedDeltaSerializationTests(WebHostTestFixture fixture, ITestOutputHelper output)
             : base(fixture)
         {
+            this.output = output;
         }
 
         protected override void UpdateConfiguration(WebRouteConfiguration configuration)
@@ -54,6 +58,11 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter.Untyped
         {
             string url = "/untyped/UntypedDeltaCustomers?$deltatoken=abc";
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, BaseAddress + url);
+
+            // by default, the odata version is 4.0. It will throw:
+            // "Cannot transition from state 'DeletedResource' to state 'NestedResourceInfo' when writing an OData 4.0 payload.
+            // To write content to a deleted resource, please specify ODataVersion 4.01 or greater in MessageWriterSettings."
+            request.Headers.Add("OData-Version", "4.01");
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(acceptHeader));
             HttpResponseMessage response = await Client.SendAsync(request);
             Assert.True(response.IsSuccessStatusCode);
@@ -70,7 +79,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter.Untyped
 
             for (int i = 10; i < 15; i++)
             {
-                Assert.True(i.ToString().Equals(((dynamic)returnedObject).value[i]["@odata.id"].Value));
+                Assert.True(i.ToString().Equals(((dynamic)returnedObject).value[i]["@id"].Value));
             }
         }
     }


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2816.*

### Description

Currently, ODataVersion.4.01 is hard coded for all delta response. So, customer can't switch between 4.0 and 4.01.

However, it may be true for delta patch since it's only included in OData version 4.01, but not in OData version 4.0. For other delta responses, it should be valid in both versions.

This PR is to change to 4.01 only for delta patch response but use the version setting for other delta response. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
