### PR TITLE
Make sure 'top' doesn't apply on a null collection

### DIFF
--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
@@ -290,6 +290,38 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Fact]
+        public void ProjectAsWrapper_Collection_TopOnNullExpand()
+        {
+            // Arrange
+            _settings.HandleNullPropagation = HandleNullPropagationOption.True;
+
+            IEdmEntityType vipCustomer = _model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "QueryVipCustomer");
+            IEdmNavigationProperty specialOrdersNav = vipCustomer.DeclaredNavigationProperties().Single(c => c.Name == "SpecialOrders");
+            ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(
+                new ODataExpandPath(new NavigationPropertySegment(specialOrdersNav, navigationSource: _orders)),
+                _orders,
+                selectAndExpand: null,
+                filterOption: null,
+                orderByOption: null,
+                topOption: 10,
+                skipOption: null,
+                countOption: null,
+                searchOption: null,
+                levelsOption: null);
+            SelectExpandClause selectExpand = new SelectExpandClause(new SelectItem[] { expandItem }, allSelected: true);
+
+            QueryVipCustomer customer = new QueryVipCustomer();
+            Expression source = Expression.Constant(customer);
+
+            // Act
+            Expression projection = _binder.ProjectAsWrapper(source, selectExpand, vipCustomer, _customers);
+
+            // Assert
+            IEnumerable<SelectExpandWrapper<QueryOrder>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<QueryOrder>>;
+            Assert.Null(projectedOrders);
+        }
+
+        [Fact]
         public void ProjectAsWrapper_Collection_ProjectedValueNullAndHandleNullPropagationTrue()
         {
             // Arrange

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandBinderTest.cs
@@ -295,8 +295,8 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             // Arrange
             _settings.HandleNullPropagation = HandleNullPropagationOption.True;
 
-            IEdmEntityType vipCustomer = _model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "QueryVipCustomer");
-            IEdmNavigationProperty specialOrdersNav = vipCustomer.DeclaredNavigationProperties().Single(c => c.Name == "SpecialOrders");
+            IEdmEntityType vipCustomer = _model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == nameof(QueryVipCustomer));
+            IEdmNavigationProperty specialOrdersNav = vipCustomer.DeclaredNavigationProperties().Single(c => c.Name == nameof(QueryVipCustomer.SpecialOrders));
             ExpandedNavigationSelectItem expandItem = new ExpandedNavigationSelectItem(
                 new ODataExpandPath(new NavigationPropertySegment(specialOrdersNav, navigationSource: _orders)),
                 _orders,
@@ -317,8 +317,12 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             Expression projection = _binder.ProjectAsWrapper(source, selectExpand, vipCustomer, _customers);
 
             // Assert
-            IEnumerable<SelectExpandWrapper<QueryOrder>> projectedOrders = Expression.Lambda(projection).Compile().DynamicInvoke() as IEnumerable<SelectExpandWrapper<QueryOrder>>;
-            Assert.Null(projectedOrders);
+            object rawProjectionResult = Expression.Lambda(projection).Compile().DynamicInvoke();
+            Assert.NotNull(rawProjectionResult);
+            SelectExpandWrapper<QueryVipCustomer> projectedCustomer = rawProjectionResult as SelectExpandWrapper<QueryVipCustomer>;
+            Assert.NotNull(projectedCustomer);
+            Assert.True(projectedCustomer.TryGetPropertyValue(nameof(QueryVipCustomer.SpecialOrders), out object rawSpecialOrders));
+            Assert.Null(rawSpecialOrders);
         }
 
         [Fact]


### PR DESCRIPTION
### Issues
`$top` is attempted on null collections, resulting in failures like this:
```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. --> 
System.ArgumentNullException: Value cannot be null. 
Parameter name: source
	at System.Linq.OrderedEnumerable`2..ctor(Enumerable`1 source, Func` keySelector, IComparer`1comparer, Boolean decending)
	at lambda_method(Closure_Site) 
	--End of inner exception stack trace--
	at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor) 
	at System.Reflection.RuntimeMethodInfo. UnsafeInvokeInternal(Object obj, Object [] parameters, Object arguments) 
	at System.Delegatre.DynamicInvokeImpl
	at Microsot.AspNet.OData.Query.Expressions.SelectExpandBinder.Bind
	at Microsot.AspNet.OData.Query.ODataQueryOptions.ApplySelectExpand
```

### Description
`ProjectCollection` does have logic for handling null propagation, but it's currently using the modified source (e.g. the one that wraps the original in `OrderBy`, `Take`, `Skip`). As a result, when the `source` is null the check doesn't apply prior to the execution of those operations, which all require a non-null collection.

The fix is to simply perform the null check on the original `source`.

NOTE: The same issue exists in https://github.com/OData/AspNetCoreOData but I'll leave it to maintainers to port the fix.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*