### PR TITLE
Fixes #2844: Enable property with instance annotation without propert…

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/DeserializationHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/DeserializationHelpers.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             }
         }
 
-        internal static void ApplyInstanceAnnotations(object resource, IEdmStructuredTypeReference structuredType, ODataResourceBase oDataResource,
+        internal static void ApplyInstanceAnnotations(object resource, IEdmStructuredTypeReference structuredType, ODataResourceWrapper resourceWrapper,
             ODataDeserializerProvider deserializerProvider, ODataDeserializerContext readContext)
         {
             //Apply instance annotations for both entityobject/changedobject/delta and normal resources
@@ -120,7 +120,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                 return;
             }
 
-            SetInstanceAnnotations(oDataResource, persistentInstanceAnnotationContainer, transientInstanceAnnotationContainer, deserializerProvider, readContext);
+            SetInstanceAnnotations(resourceWrapper, persistentInstanceAnnotationContainer, transientInstanceAnnotationContainer, deserializerProvider, readContext);
         }
 
         internal static void SetDynamicProperty(object resource, IEdmStructuredTypeReference resourceType,
@@ -302,13 +302,13 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         }
 
         internal static void SetInstanceAnnotations(
-            ODataResourceBase oDataResource,
+            ODataResourceWrapper resourceWrapper,
             IODataInstanceAnnotationContainer instanceAnnotationContainer,
             IODataInstanceAnnotationContainer transientAnnotationContainer,
             ODataDeserializerProvider deserializerProvider,
             ODataDeserializerContext readContext)
         {
-            foreach (ODataInstanceAnnotation annotation in oDataResource.InstanceAnnotations)
+            foreach (ODataInstanceAnnotation annotation in resourceWrapper.ResourceBase.InstanceAnnotations)
             {
                 if (!TransientAnnotations.TransientAnnotationTerms.Contains(annotation.Name))
                 {
@@ -320,11 +320,20 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                 }
             }
 
-            foreach (ODataProperty property in oDataResource.Properties)
+            foreach (ODataProperty property in resourceWrapper.ResourceBase.Properties)
             {
                 foreach (ODataInstanceAnnotation annotation in property.InstanceAnnotations)
                 {
                     AddInstanceAnnotationToContainer(instanceAnnotationContainer, deserializerProvider, readContext, annotation, property.Name);
+                }
+            }
+
+            // Add the instance annotations of property without value
+            foreach (ODataPropertyInfo propertyInfo in resourceWrapper.NestedPropertyInfos)
+            {
+                foreach (ODataInstanceAnnotation annotation in propertyInfo.InstanceAnnotations)
+                {
+                    AddInstanceAnnotationToContainer(instanceAnnotationContainer, deserializerProvider, readContext, annotation, propertyInfo.Name);
                 }
             }
         }

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataReaderExtensions.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataReaderExtensions.cs
@@ -189,6 +189,12 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                     itemsStack.Push(deltaResourceSetWrapper);
                     break;
 
+                case ODataReaderState.NestedProperty:
+                    Contract.Assert(itemsStack.Count > 0, "The nested property info should be a non-null primitive value within resource wrapper.");
+                    ODataResourceWrapper resourceParentWrapper = (ODataResourceWrapper)itemsStack.Peek();
+                    resourceParentWrapper.NestedPropertyInfos.Add((ODataPropertyInfo)reader.Item);
+                    break;
+
                 case ODataReaderState.DeltaLink:
                 case ODataReaderState.DeltaDeletedLink:
 

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceDeserializer.cs
@@ -483,7 +483,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
                 throw Error.ArgumentNull("resourceWrapper");
             }
 
-            DeserializationHelpers.ApplyInstanceAnnotations(resource, structuredType, resourceWrapper.ResourceBase, DeserializerProvider, readContext);
+            DeserializationHelpers.ApplyInstanceAnnotations(resource, structuredType, resourceWrapper, DeserializerProvider, readContext);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceWrapper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Formatter/Deserialization/ODataResourceWrapper.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
             : base(item)
         {
             NestedResourceInfos = new List<ODataNestedResourceInfoWrapper>();
+            NestedPropertyInfos = new List<ODataPropertyInfo>();
             ResourceBase = item;
         }
 
@@ -49,5 +50,11 @@ namespace Microsoft.AspNet.OData.Formatter.Deserialization
         /// Gets the inner nested resource infos.
         /// </summary>
         public IList<ODataNestedResourceInfoWrapper> NestedResourceInfos { get; private set; }
+
+        /// <summary>
+        /// Gets the nested property infos.
+        /// The nested property info is a property without value but could have instance annotations.
+        /// </summary>
+        public IList<ODataPropertyInfo> NestedPropertyInfos { get; private set; }
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/DeserializationHelpersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/DeserializationHelpersTest.cs
@@ -370,7 +370,7 @@ namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
             var deletedEntity = new DeltaDeletedEntityObject<SimpleOpenCustomer>();
 
             // Act
-            DeserializationHelpers.ApplyInstanceAnnotations(deletedEntity, customerTypeReference, odataResource, _deserializerProvider, readContext);
+            DeserializationHelpers.ApplyInstanceAnnotations(deletedEntity, customerTypeReference, topLevelResourceWrapper, _deserializerProvider, readContext);
 
             // Assert
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/ODataReaderExtensionsTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Formatter/Deserialization/ODataReaderExtensionsTests.cs
@@ -1,0 +1,333 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ODataDeserializerTest.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData.Formatter;
+using Microsoft.AspNet.OData.Formatter.Deserialization;
+using Microsoft.AspNet.OData.Test.Common;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.OData.Test.Formatter.Deserialization
+{
+    public partial class ODataReaderExtensionsTests
+    {
+        private static readonly EdmModel Model;
+
+        static ODataReaderExtensionsTests()
+        {
+            Model = new EdmModel();
+
+            // Address
+            EdmComplexType address = new EdmComplexType("NS", "Address");
+            address.AddStructuralProperty("Street", EdmCoreModel.Instance.GetString(false));
+            Model.AddElement(address);
+
+            // Customer
+            EdmEntityType customer = new EdmEntityType("NS", "Customer");
+            Model.AddElement(customer);
+            customer.AddKeys(customer.AddStructuralProperty("CustomerID", EdmCoreModel.Instance.GetInt32(false)));
+            customer.AddStructuralProperty("Name", EdmCoreModel.Instance.GetString(true));
+            customer.AddStructuralProperty("Location", new EdmComplexTypeReference(address, false));
+
+            // Order
+            EdmEntityType order = new EdmEntityType("NS", "Order");
+            Model.AddElement(order);
+            order.AddKeys(order.AddStructuralProperty("OrderId", EdmCoreModel.Instance.GetInt32(false)));
+            order.AddStructuralProperty("Price", EdmCoreModel.Instance.GetInt32(false));
+
+            // VipOrder
+            EdmEntityType vipOrder = new EdmEntityType("NS", "VipOrder", order);
+            Model.AddElement(vipOrder);
+            vipOrder.AddKeys(vipOrder.AddStructuralProperty("Email", EdmCoreModel.Instance.GetString(false)));
+
+            var orderNav = customer.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo
+                {
+                    Name = "Order",
+                    Target = order,
+                    TargetMultiplicity = EdmMultiplicity.ZeroOrOne
+                });
+
+            var ordresNav = customer.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo
+                {
+                    Name = "Orders",
+                    Target = order,
+                    TargetMultiplicity = EdmMultiplicity.Many
+                });
+
+            EdmEntityContainer defaultContainer = new EdmEntityContainer("NS", "Container");
+            Model.AddElement(defaultContainer);
+            EdmEntitySet customers = defaultContainer.AddEntitySet("Customers", customer);
+            EdmEntitySet orders = defaultContainer.AddEntitySet("Orders", order);
+            customers.AddNavigationTarget(orderNav, orders);
+            customers.AddNavigationTarget(ordresNav, orders);
+        }
+
+        [Fact]
+        public void ReadResourceOrResourceSet_ThrowsArgumentNull_EdmType()
+        {
+            // Arrange & Act & Assert
+            ODataReader reader = null;
+            ExceptionAssert.ThrowsArgumentNull(() => reader.ReadResourceOrResourceSet(), "reader");
+        }
+
+        [Fact]
+        public async Task ReadResourceOrResourceSetAsync_ThrowsArgumentNull_EdmType()
+        {
+            // Arrange & Act & Assert
+            ODataReader reader = null;
+            await ExceptionAssert.ThrowsArgumentNullAsync(() => reader.ReadResourceOrResourceSetAsync(), "reader");
+        }
+
+        [Fact]
+        public async Task ReadResourceWorksAsExpected()
+        {
+            // Arrange
+            const string payload =
+            "{" +
+                "\"@odata.context\":\"http://localhost/$metadata#Customers/$entity\"," +
+                "\"CustomerID\": 7," +
+                "\"Location\": { \"Street\":\"154TH AVE\"}," +
+                "\"Order\": {\"OrderId\": 8, \"Price\": 82 }," +
+                "\"Orders\": []" +
+            "}";
+
+            IEdmEntitySet customers = Model.EntityContainer.FindEntitySet("Customers");
+            Assert.NotNull(customers); // Guard
+
+            // Act
+            Func<ODataMessageReader, Task<ODataReader>> func = mr => mr.CreateODataResourceReaderAsync(customers, customers.EntityType());
+            ODataItemBase item = await ReadPayloadAsync(payload, Model, func);
+
+            // Assert
+            Assert.NotNull(item);
+            ODataResourceWrapper resource = Assert.IsType<ODataResourceWrapper>(item);
+            Assert.Equal(3, resource.NestedResourceInfos.Count);
+            Assert.Equal(new[] { "Location", "Order", "Orders" }, resource.NestedResourceInfos.Select(n => n.NestedResourceInfo.Name));
+        }
+
+        [Fact]
+        public async Task ReadResourceWithPropertyWithoutValueButWithInstanceAnnotationsWorksAsExpected()
+        {
+            // Arrange
+            // Property 'Name' without value but with instance annotations
+            const string payload =
+            "{" +
+                "\"@odata.context\":\"http://localhost/$metadata#Customers/$entity\"," +
+                "\"CustomerID\": 17," +
+                "\"Name@Custom.PrimitiveAnnotation\":123," +
+                "\"Name@Custom.BooleanAnnotation\":true," +
+                "\"Location\": { \"Street\":\"154TH AVE\"}" +
+            "}";
+
+            IEdmEntitySet customers = Model.EntityContainer.FindEntitySet("Customers");
+            Assert.NotNull(customers); // Guard
+
+            // Act
+            Func<ODataMessageReader, Task<ODataReader>> func = mr => mr.CreateODataResourceReaderAsync(customers, customers.EntityType());
+            ODataItemBase item = await ReadPayloadAsync(payload, Model, func, ODataVersion.V4, false, "*");
+
+            // Assert
+            Assert.NotNull(item);
+            ODataResourceWrapper resource = Assert.IsType<ODataResourceWrapper>(item);
+            Assert.NotNull(resource.ResourceBase);
+            ODataProperty customerIdProp = Assert.Single(resource.ResourceBase.Properties);
+            Assert.Equal("CustomerID", customerIdProp.Name);
+            Assert.Equal(17, customerIdProp.Value);
+
+            ODataPropertyInfo nameProp = Assert.Single(resource.NestedPropertyInfos);
+            Assert.Equal("Name", nameProp.Name);
+            Assert.Equal(2, nameProp.InstanceAnnotations.Count);
+
+            ODataInstanceAnnotation primitiveAnnotation = nameProp.InstanceAnnotations.First(i => i.Name == "Custom.PrimitiveAnnotation");
+            ODataPrimitiveValue primitiveValue = Assert.IsType<ODataPrimitiveValue>(primitiveAnnotation.Value);
+            Assert.Equal(123, primitiveValue.Value);
+
+            ODataInstanceAnnotation booleanAnnotation = nameProp.InstanceAnnotations.First(i => i.Name == "Custom.BooleanAnnotation");
+            ODataPrimitiveValue booleanValue = Assert.IsType<ODataPrimitiveValue>(booleanAnnotation.Value);
+            Assert.True((bool)booleanValue.Value);
+
+            ODataNestedResourceInfoWrapper nestedInfoWrapper = Assert.Single(resource.NestedResourceInfos);
+            Assert.Equal("Location", nestedInfoWrapper.NestedResourceInfo.Name);
+        }
+
+        [Fact]
+        public async Task ReadResourceSetWorksAsExpected()
+        {
+            // Arrange
+            const string payload =
+            "{" +
+                "\"@odata.context\":\"http://localhost/$metadata#Customers\"," +
+                "\"value\": [" +
+                 "{" +
+                    "\"CustomerID\": 7," +
+                    "\"Location\": { \"Street\":\"154TH AVE\"}," +
+                    "\"Order\": {\"OrderId\": 8, \"Price\": 82 }," +
+                    "\"Orders\": []" +
+                   "}" +
+                "]" +
+            "}";
+
+            IEdmEntitySet customers = Model.EntityContainer.FindEntitySet("Customers");
+            Assert.NotNull(customers); // Guard
+
+            // Act
+            Func<ODataMessageReader, Task<ODataReader>> func = mr => mr.CreateODataResourceSetReaderAsync(customers, customers.EntityType());
+            ODataItemBase item = await ReadPayloadAsync(payload, Model, func);
+
+            // Assert
+            Assert.NotNull(item);
+            ODataResourceSetWrapper resourceSet = Assert.IsType<ODataResourceSetWrapper>(item);
+            ODataResourceWrapper resource = Assert.Single(resourceSet.Resources);
+            Assert.Equal(new[] { "Location", "Order", "Orders" }, resource.NestedResourceInfos.Select(n => n.NestedResourceInfo.Name));
+        }
+
+        [Fact]
+        public async Task ReadResourceSetWithNestedResourceSetWorksAsExpected()
+        {
+            // Arrange
+            const string payload =
+            "{" +
+                "\"@odata.context\":\"http://localhost/$metadata#Customers\"," +
+                "\"value\": [" +
+                 "{" +
+                    "\"CustomerID\": 7," +
+                    "\"Location\": { \"Street\":\"154TH AVE\"}," +
+                    "\"Order\": {\"OrderId\": 8, \"Price\": 82 }," +
+                    "\"Orders\": [" +
+                        "{\"OrderId\": 8, \"Price\": 82 }," +
+                        "{\"@odata.type\": \"#NS.VipOrder\",\"OrderId\": 9, \"Price\": 42, \"Email\": \"abc@efg.com\" }" +
+                      "]" +
+                   "}" +
+                "]" +
+            "}";
+
+            IEdmEntitySet customers = Model.EntityContainer.FindEntitySet("Customers");
+            Assert.NotNull(customers); // Guard
+
+            // Act
+            Func<ODataMessageReader, Task<ODataReader>> func = mr => mr.CreateODataResourceSetReaderAsync(customers, customers.EntityType());
+            ODataItemBase item = await ReadPayloadAsync(payload, Model, func);
+
+            // Assert
+            Assert.NotNull(item);
+            ODataResourceSetWrapper resourceSet = Assert.IsType<ODataResourceSetWrapper>(item);
+            ODataResourceWrapper resource = Assert.Single(resourceSet.Resources);
+            Assert.Equal(new[] { "Location", "Order", "Orders" }, resource.NestedResourceInfos.Select(n => n.NestedResourceInfo.Name));
+
+            ODataNestedResourceInfoWrapper orders = resource.NestedResourceInfos.First(n => n.NestedResourceInfo.Name == "Orders");
+            ODataItemBase nestedItem = Assert.Single(orders.NestedItems);
+
+            ODataResourceSetWrapper ordersSet = Assert.IsType<ODataResourceSetWrapper>(nestedItem);
+            Assert.Equal(2, ordersSet.Resources.Count);
+            Assert.Collection(ordersSet.Resources,
+                r =>
+                {
+                    Assert.Equal("NS.Order", r.ResourceBase.TypeName);
+                    Assert.Equal(82, r.ResourceBase.Properties.First(p => p.Name == "Price").Value);
+                },
+                r =>
+                {
+                    Assert.Equal("NS.VipOrder", r.ResourceBase.TypeName);
+                    Assert.Equal("abc@efg.com", r.ResourceBase.Properties.First(p => p.Name == "Email").Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadEntityReferenceLinksSetWorksAsExpected_V401()
+        {
+            // Arrange
+            string payload = "{" + // -> ResourceStart
+                "\"@odata.context\":\"http://localhost/$metadata#Customers/$entity\"," +
+                "\"CustomerID\": 7," +
+                "\"Orders\":[" +  // -> NestedResourceInfoStart
+                    "{ \"@id\": \"http://svc/Orders(2)\" }," +
+                    "{ \"@id\": \"http://svc/Orders(3)\" }," +
+                    "{ \"@id\": \"http://svc/Orders(4)\" }" +
+                "]" +
+            "}";
+
+            IEdmEntitySet customers = Model.EntityContainer.FindEntitySet("Customers");
+            Assert.NotNull(customers); // Guard
+
+            // Act
+            Func<ODataMessageReader, Task<ODataReader>> func = mr => mr.CreateODataResourceReaderAsync(customers, customers.EntityType());
+            ODataItemBase item = await ReadPayloadAsync(payload, Model, func, ODataVersion.V401);
+
+            // Assert
+            Assert.NotNull(item);
+
+            // --- Resource
+            //     |--- NestedResourceInfo
+            //        |--- NestedResourceSet
+            //              |--- Resource (2)
+            //              |--- Resource (3)
+            //              |--- Resource (4)
+            ODataResourceWrapper resource = Assert.IsType<ODataResourceWrapper>(item);
+
+            ODataNestedResourceInfoWrapper nestedResourceInfo = Assert.Single(resource.NestedResourceInfos);
+            Assert.Equal("Orders", nestedResourceInfo.NestedResourceInfo.Name);
+            Assert.True(nestedResourceInfo.NestedResourceInfo.IsCollection);
+
+            ODataResourceSetWrapper ordersResourceSet = Assert.IsType<ODataResourceSetWrapper>(Assert.Single(nestedResourceInfo.NestedItems));
+            Assert.Equal(3, ordersResourceSet.Resources.Count);
+            Assert.Collection(ordersResourceSet.Resources,
+                r =>
+                {
+                    Assert.Equal("http://svc/Orders(2)", r.ResourceBase.Id.OriginalString);
+                },
+                r =>
+                {
+                    Assert.Equal("http://svc/Orders(3)", r.ResourceBase.Id.OriginalString);
+                },
+                r =>
+                {
+                    Assert.Equal("http://svc/Orders(4)", r.ResourceBase.Id.OriginalString);
+                });
+        }
+
+        private async Task<ODataItemBase> ReadPayloadAsync(string payload,
+            IEdmModel edmModel, Func<ODataMessageReader, Task<ODataReader>> createReader, ODataVersion version = ODataVersion.V4,
+            bool readUntypedAsString = false,
+            string annotationFilter = null)
+        {
+            //var message = new InMemoryMessage()
+            //{
+            //    Stream = new MemoryStream(Encoding.UTF8.GetBytes(payload))
+            //};
+            ODataMessageWrapper message = new ODataMessageWrapper(new MemoryStream(Encoding.UTF8.GetBytes(payload)));
+            message.SetHeader("Content-Type", "application/json;odata.metadata=minimal");
+
+            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings()
+            {
+                BaseUri = new Uri("http://localhost/$metadata"),
+                EnableMessageStreamDisposal = true,
+                ReadUntypedAsString = readUntypedAsString,
+                Version = version,
+            };
+
+            if (annotationFilter != null)
+            {
+                readerSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter(annotationFilter);
+            }
+
+            using (var msgReader = new ODataMessageReader((IODataRequestMessageAsync)message, readerSettings, edmModel))
+            {
+                ODataReader reader = await createReader(msgReader);
+                return await reader.ReadResourceOrResourceSetAsync();
+            }
+        }
+    }
+}

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
@@ -155,6 +155,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\IHeaderDictionaryExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\RoutingConfigurationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter\Deserialization\HttpRequestODataMessage.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Formatter\Deserialization\ODataReaderExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter\Deserialization\ODataEnumDeserializerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter\Deserialization\ODataDeserializerContextTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter\Deserialization\ODataSingletonDeserializerTest.cs" />

--- a/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test/PublicApi/Microsoft.AspNet.OData.PublicApi.bsl
@@ -3534,6 +3534,7 @@ public sealed class Microsoft.AspNet.OData.Formatter.Deserialization.ODataResour
 public sealed class Microsoft.AspNet.OData.Formatter.Deserialization.ODataResourceWrapper : ODataItemBase {
 	public ODataResourceWrapper (Microsoft.OData.ODataResourceBase item)
 
+	System.Collections.Generic.IList`1[[Microsoft.OData.ODataPropertyInfo]] NestedPropertyInfos  { public get; }
 	System.Collections.Generic.IList`1[[Microsoft.AspNet.OData.Formatter.Deserialization.ODataNestedResourceInfoWrapper]] NestedResourceInfos  { public get; }
 	[
 	ObsoleteAttribute(),

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -3737,6 +3737,7 @@ public sealed class Microsoft.AspNet.OData.Formatter.Deserialization.ODataResour
 public sealed class Microsoft.AspNet.OData.Formatter.Deserialization.ODataResourceWrapper : ODataItemBase {
 	public ODataResourceWrapper (Microsoft.OData.ODataResourceBase item)
 
+	System.Collections.Generic.IList`1[[Microsoft.OData.ODataPropertyInfo]] NestedPropertyInfos  { public get; }
 	System.Collections.Generic.IList`1[[Microsoft.AspNet.OData.Formatter.Deserialization.ODataNestedResourceInfoWrapper]] NestedResourceInfos  { public get; }
 	[
 	ObsoleteAttribute(),

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -3936,6 +3936,7 @@ public sealed class Microsoft.AspNet.OData.Formatter.Deserialization.ODataResour
 public sealed class Microsoft.AspNet.OData.Formatter.Deserialization.ODataResourceWrapper : ODataItemBase {
 	public ODataResourceWrapper (Microsoft.OData.ODataResourceBase item)
 
+	System.Collections.Generic.IList`1[[Microsoft.OData.ODataPropertyInfo]] NestedPropertyInfos  { public get; }
 	System.Collections.Generic.IList`1[[Microsoft.AspNet.OData.Formatter.Deserialization.ODataNestedResourceInfoWrapper]] NestedResourceInfos  { public get; }
 	[
 	ObsoleteAttribute(),


### PR DESCRIPTION
…y value

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2844 .*

### Description

* Enable property with instance annotations without property value

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
