### PR TITLE
Update pipeline agent image

### DIFF
--- a/pipelines/azure_pipelines.yml
+++ b/pipelines/azure_pipelines.yml
@@ -27,7 +27,7 @@ extends:
   parameters:
     pool:
       name: MSSecurity-1ES-Build-Agents-Pool
-      image: MSSecurity-1ES-Windows-2019
+      image: MSSecurity-1ES-Windows-2022
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -56,6 +56,7 @@ extends:
         - task: NuGetCommand@2
           displayName: NuGet restore **\*.sln
           inputs:
+            command: 'restore'
             solution: sln/WebApiOData.AspNet.sln;sln/WebApiOData.AspNetCore.sln;sln/WebApiOData.E2E.AspNet.sln;sln/WebApiOData.E2E.AspNetCore.sln
         - task: VSBuild@1
           displayName: Build solution sln\WebApiOData.AspNet.sln

--- a/pipelines/azure_pipelines_nightly.yml
+++ b/pipelines/azure_pipelines_nightly.yml
@@ -29,7 +29,7 @@ extends:
   parameters:
     pool:
       name: MSSecurity-1ES-Build-Agents-Pool
-      image: MSSecurity-1ES-Windows-2019
+      image: MSSecurity-1ES-Windows-2022
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -73,6 +73,7 @@ extends:
         - task: NuGetCommand@2
           displayName: NuGet restore *\*.sln
           inputs:
+            command: 'restore'
             solution: sln/WebApiOData.AspNet.sln;sln/WebApiOData.AspNetCore.sln;sln/WebApiOData.E2E.AspNet.sln;sln/WebApiOData.E2E.AspNetCore.sln
         - task: VSBuild@1
           displayName: Build solution sln\WebApiOData.AspNet.sln

--- a/samples/AspNetODataSample.Web/AspNetODataSample.Web.csproj
+++ b/samples/AspNetODataSample.Web/AspNetODataSample.Web.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AspNetODataSample.Web</RootNamespace>
     <AssemblyName>AspNetODataSample.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
+++ b/src/Microsoft.AspNet.OData/Microsoft.AspNet.OData.csproj
@@ -15,7 +15,7 @@
     <RunCodeAnalysis Condition=" '$(CodeAnalysis)' == '' and '$(Configuration)' != 'Release' ">true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Strict.ruleset</CodeAnalysisRuleSet>
     <StyleCopEnabled Condition=" '$(StyleCopEnabled)' == '' ">true</StyleCopEnabled>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <DefineConstants>$(DefineConstants);ASPNETODATA;ASPNETWEBAPI;NETFX;NETFX45</DefineConstants>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Test.E2E.AspNet.OData</RootNamespace>
     <AssemblyName>Microsoft.Test.E2E.AspNetCore.OData</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <OutputPath>$(WebStackRootPath)bin\$(Configuration)\E2ETest\AspNetCore\</OutputPath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(WebStackRootPath)sln\</SolutionDir>
     <DefineConstants>$(DefineConstants);ASPNETODATA;ASPNETWEBAPI;NETCORE;NETCORE2x;NETCOREAPP2_1;PORTABLELIB</DefineConstants>

--- a/test/PerfTest/WebApiPerformance.Service/WebApiPerformance.Service.csproj
+++ b/test/PerfTest/WebApiPerformance.Service/WebApiPerformance.Service.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WebApiPerformance.Service</RootNamespace>
     <AssemblyName>WebApiPerformance.Service</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <OutputPath>..\..\..\bin\$(Configuration)\PerfTest\bin\</OutputPath>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

`Windows 2019` image is deprecated. This change is to update the image to `Windows 2022`

The PR updates the .NET framework from `v4.5` to `v4.5.2` and `v4.6.1` to `v4.6.2` as documented in [Windows 2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#visual-studio-enterprise-2022)

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
