### PR TITLE
Update version for AspNetPackageDependency to resolve issue #2884

### DIFF
--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="EntityFramework" Version="6.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />

--- a/tools/WebStack.versions.settings.targets
+++ b/tools/WebStack.versions.settings.targets
@@ -11,7 +11,7 @@
 
   <!-- For NuGet Package Dependencies -->
   <PropertyGroup>
-    <AspNetPackageDependency>5.2.2</AspNetPackageDependency>
+    <AspNetPackageDependency>6.0.0</AspNetPackageDependency>
     <AspNetCorePackageDependency>[2.0.1, 3.0.0)</AspNetCorePackageDependency>
     <DependencyInjection1PackageDependency>1.0.0</DependencyInjection1PackageDependency>
     <DependencyInjection2PackageDependency>2.0.0</DependencyInjection2PackageDependency>


### PR DESCRIPTION
Updates dependency AspNetPackageDependency to resolve issue #2884

### Description

https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Client/5.2.2 Pins a Newtonsoft.Json version that is vulnerable. Although we require a newer package >= 13.0.0 some users can download the Vulnerable version.

The dependencies of these two versions should be compatible with our code
```
## New Package (6.0.0)
.NETFramework 4.5
Newtonsoft.Json (>= 13.0.1)
Newtonsoft.Json.Bson (>= 1.0.2)
System.Memory (>= 4.5.5)
System.Threading.Tasks.Extensions (>= 4.5.4)
.NETStandard 1.3
Microsoft.Net.Http (>= 2.2.22)
Newtonsoft.Json (>= 13.0.1)
Newtonsoft.Json.Bson (>= 1.0.2)
System.Collections.Specialized (>= 4.3.0)
System.ComponentModel.EventBasedAsync (>= 4.3.0)
System.Data.Common (>= 4.3.0)
System.Diagnostics.Contracts (>= 4.3.0)
System.Memory (>= 4.5.5)
System.Runtime.Serialization.Json (>= 4.3.0)
System.Runtime.Serialization.Xml (>= 4.3.0)
System.Threading.Tasks.Extensions (>= 4.5.4)
.NETStandard 2.0
Newtonsoft.Json (>= 13.0.1)
Newtonsoft.Json.Bson (>= 1.0.2)
System.Memory (>= 4.5.5)
System.Threading.Tasks.Extensions (>= 4.5.4)


## Old Package(5.2.2)

.NETFramework 4.5
Newtonsoft.Json (>= 6.0.4)
Portable Class Library (.NETFramework 4.5, .NETCore 4.5, WindowsPhone 8.0, WindowsPhone 8.1, WindowsPhoneApp 8.1)
Microsoft.Net.Http (>= 2.2.22)
Newtonsoft.Json (>= 6.0.4)
```

### Checklist (Uncheck if it is not completed)

