### PR TITLE
Bump Microsoft.AspNetCore.Server.Kestrel.Core for netcoreapp3.1 to resolve CVE-2025-55315

### DIFF
--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/Microsoft.AspNetCore.OData.Test.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
     <!-- Resolve CVE-2024-38095 - Upgrade System.Formats.Asn1 -->
     <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
   </ItemGroup>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Bump `Microsoft.AspNetCore.Server.Kestrel.Core` for netcoreapp3.1 to resolve CVE-2025-55315

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
