### PR TITLE
Port: Enforce EDM model boundary for open-type property binding in `$apply groupby`

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -569,6 +569,15 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         {
             IEdmStructuredType edmStructuredType;
             IEdmTypeReference edmTypeReference = openNode.Source.TypeReference;
+            if (edmTypeReference == null)
+            {
+                // The source segment is itself an open/dynamic property, so it has no known EDM type
+                // from which to resolve a dynamic-property container (e.g. a nested open path such as
+                // A/B/C where A is dynamic). Surface a clean query error instead of dereferencing a
+                // null type reference, which would otherwise bubble up as a raw ArgumentNullException.
+                throw new ODataException(Error.Format(SRResources.QueryNodeBindingNotSupported, openNode.Kind, typeof(FilterBinder).Name));
+            }
+
             if (edmTypeReference.IsEntity())
             {
                 edmStructuredType = edmTypeReference.AsEntity().EntityDefinition();

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/TransformationBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/TransformationBinderBase.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.AspNet.OData.Common;
+using Microsoft.AspNet.OData.Formatter;
 using Microsoft.AspNet.OData.Interfaces;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
@@ -136,15 +137,58 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             }
         }
 
+        /// <summary>
+        /// Gets the CLR <see cref="PropertyInfo"/> that a property segment binds to, mapping the
+        /// segment's EDM name to the CLR property name. Returns null for a dynamic (open) property, which
+        /// the caller then reads from the dynamic property container.
+        /// </summary>
+        /// <param name="instanceType">The runtime CLR type of the value being accessed.</param>
+        /// <param name="propertyName">The property name from the URI segment (the EDM name).</param>
+        /// <param name="model">The Edm model.</param>
+        /// <returns>
+        /// The <see cref="PropertyInfo"/> to bind for a property declared in the model (resolved by its
+        /// CLR name), or null when the segment is an undeclared member of a type that is in the model
+        /// (whether open or not), so the caller resolves it from the dynamic container or treats it as
+        /// absent rather than binding a CLR member that is not part of the model.
+        /// </returns>
+        private static PropertyInfo GetDeclaredClrProperty(Type instanceType, string propertyName, IEdmModel model)
+        {
+            if (model != null && model.GetEdmType(instanceType) is IEdmStructuredType structuredType)
+            {
+                IEdmProperty edmProperty = structuredType.FindProperty(propertyName);
+                if (edmProperty != null)
+                {
+                    // Declared in the model: bind by the CLR name, which can differ from the EDM name
+                    // (e.g. a [DataMember(Name=...)] or builder .Name rename). Fall through to the dynamic
+                    // container (null) rather than throwing if the CLR name cannot be resolved.
+                    string clrPropertyName = EdmLibHelpers.GetClrPropertyName(edmProperty, model);
+                    return clrPropertyName != null ? instanceType.GetProperty(clrPropertyName) : null;
+                }
+
+                // The name is not declared on this modeled type. Whether the type is open (a dynamic
+                // member) or not (a CLR member deliberately excluded from the model, e.g. via [NotMapped]
+                // or Ignore()), it must not bind to the CLR member. Return null so the caller resolves it
+                // from the dynamic container (open type) or treats it as absent, consistent with how a
+                // genuinely dynamic name on the same type is handled.
+                return null;
+            }
+
+            // A type that is not in the model (e.g. an intermediate transformation result such as a
+            // grouping or flattening wrapper): bind the CLR property directly by the segment name.
+            return instanceType.GetProperty(propertyName);
+        }
+
         private Expression CreateOpenPropertyAccessExpression(SingleValueOpenPropertyAccessNode openNode)
         {
             Expression sourceAccessor = BindAccessor(openNode.Source);
 
-            // First check that property exists in source
-            // It's the case when we are apply transformation based on earlier transformation
-            if (sourceAccessor.Type.GetProperty(openNode.Name) != null)
+            // If the segment names a property declared in the model, bind to it directly (e.g. it exists
+            // on the source type after an earlier $apply transformation), mapping the EDM name to the CLR
+            // name. Otherwise fall through to the dynamic property container below.
+            PropertyInfo declaredClrProperty = GetDeclaredClrProperty(sourceAccessor.Type, openNode.Name, Model);
+            if (declaredClrProperty != null)
             {
-                return Expression.Property(sourceAccessor, openNode.Name);
+                return Expression.Property(sourceAccessor, declaredClrProperty);
             }
 
             // Property doesn't exists go for dynamic properties dictionary

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Aggregation/AggregationController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Aggregation/AggregationController.cs
@@ -241,4 +241,20 @@ namespace Microsoft.Test.E2E.AspNet.OData.Aggregation
             return employees.AsQueryable();
         }
     }
+
+    public class OpenAggregationProductsController : TestODataController
+    {
+        private static readonly List<OpenAggregationProduct> products = new List<OpenAggregationProduct>
+        {
+            new OpenAggregationProduct { Id = 1, Name = "P1", SupplierRegion = "Region-A", DynamicProperties = new Dictionary<string, object>() },
+            new OpenAggregationProduct { Id = 2, Name = "P2", SupplierRegion = "Region-B", DynamicProperties = new Dictionary<string, object>() },
+            new OpenAggregationProduct { Id = 3, Name = "P3", SupplierRegion = "Region-C", DynamicProperties = new Dictionary<string, object>() },
+        };
+
+        [EnableQuery]
+        public ITestActionResult Get()
+        {
+            return Ok(products);
+        }
+    }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Aggregation/AggregationDataModel.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Aggregation/AggregationDataModel.cs
@@ -105,4 +105,19 @@ namespace Microsoft.Test.E2E.AspNet.OData.Aggregation
     {
         public string City { get; set; }
     }
+
+    public class OpenAggregationProduct
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        // A CLR property excluded from the EDM model. Because the type is open, a client can name it in
+        // $apply=groupby((...)); the binder resolves it from the dynamic container, not from this CLR
+        // member. See TransformationBinderBase.CreateOpenPropertyAccessExpression.
+        [NotMapped]
+        public string SupplierRegion { get; set; }
+
+        public System.Collections.Generic.IDictionary<string, object> DynamicProperties { get; set; }
+    }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Aggregation/AggregationTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Aggregation/AggregationTests.cs
@@ -13,6 +13,7 @@ using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNet.OData.Extensions;
+using Microsoft.OData.Edm;
 using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
 using Microsoft.Test.E2E.AspNet.OData.Common.Extensions;
 using Newtonsoft.Json;
@@ -851,6 +852,64 @@ namespace Microsoft.Test.E2E.AspNet.OData.Aggregation
             Assert.Equal(2, results.Count);
             Assert.Equal("Redmond", ((results[0]["NextOfKin"] as JObject)["PhysicalAddress"] as JObject)["City"].ToString());
             Assert.Equal("Nairobi", ((results[1]["NextOfKin"] as JObject)["PhysicalAddress"] as JObject)["City"].ToString());
+        }
+    }
+
+    public class OpenTypeAggregationTests : WebHostTestBase
+    {
+        public OpenTypeAggregationTests(WebHostTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            configuration.AddControllers(typeof(OpenAggregationProductsController));
+            configuration.Count().Filter().OrderBy().Expand().MaxTop(null);
+            configuration.MapODataServiceRoute("openaggregation", "openaggregation", GetEdmModel(configuration));
+        }
+
+        protected static IEdmModel GetEdmModel(WebRouteConfiguration configuration)
+        {
+            var builder = configuration.CreateConventionModelBuilder();
+            builder.EntitySet<OpenAggregationProduct>("OpenAggregationProducts");
+            return builder.GetEdmModel();
+        }
+
+        // On an open type, $apply=groupby over a property that is not declared in the EDM model resolves
+        // the name from the dynamic property container, not from a same-named CLR property that was
+        // excluded from the model.
+        [Fact]
+        public async Task GroupByOpenType_UndeclaredClrProperty_ResolvesFromDynamicContainer()
+        {
+            // Arrange
+            string requestUri = this.BaseAddress +
+                "/openaggregation/OpenAggregationProducts?$apply=groupby((SupplierRegion), aggregate($count as Count))";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            HttpResponseMessage response = await this.Client.SendAsync(request);
+            string body = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.True(HttpStatusCode.OK == response.StatusCode, $"Status={response.StatusCode}, Body={body}");
+
+            JToken parsed = JToken.Parse(body);
+            JArray groups = (parsed as JArray) ?? (parsed["value"] as JArray);
+            Assert.True(groups != null, $"Could not find groups array. Body={body}");
+
+            // SupplierRegion is not present as a dynamic (open) property on any row, so grouping resolves
+            // it from the (empty) container -> a single null-keyed group covering all three rows.
+            Assert.True(groups.Count == 1, $"Expected a single group, got {groups.Count}. Body={body}");
+            Assert.Equal(3, (groups[0] as JObject)["Count"].ToObject<int>());
+
+            JToken regionToken = (groups[0] as JObject)["SupplierRegion"];
+            Assert.True(regionToken == null || regionToken.Type == JTokenType.Null, $"Unexpected SupplierRegion value: {regionToken}. Body={body}");
+
+            // The excluded CLR member values are not part of the model, so they do not appear in the result.
+            Assert.DoesNotContain("Region-A", body);
+            Assert.DoesNotContain("Region-B", body);
+            Assert.DoesNotContain("Region-C", body);
         }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/JsonLight/Metadata/Controllers/EntityWithSimplePropertiesController.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/JsonLight/Metadata/Controllers/EntityWithSimplePropertiesController.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter.JsonLight.Metadata.Controlle
         public EntityWithSimplePropertiesController()
             : base("Id")
         {
-            EntityWithSimpleProperties[] entities = MetadataTestHelpers.CreateInstances<EntityWithSimpleProperties[]>();
+            EntityWithSimpleProperties[] entities = MetadataTestHelpers.GetEntityWithSimplePropertiesInstances();
             foreach (var entity in entities)
             {
                 LocalTable.AddOrUpdate(entity.Id, entity, (key, oldEntity) => oldEntity);

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/JsonLight/Metadata/MetadataTestHelpers.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/JsonLight/Metadata/MetadataTestHelpers.cs
@@ -9,6 +9,7 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using Microsoft.Test.E2E.AspNet.OData.Common.Instancing;
+using Microsoft.Test.E2E.AspNet.OData.Formatter.JsonLight.Metadata.Model;
 
 namespace Microsoft.Test.E2E.AspNet.OData.Formatter.JsonLight.Metadata
 {
@@ -25,6 +26,46 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter.JsonLight.Metadata
             var results = InstanceCreator.CreateInstanceOf<T>(new Random(RandomSeedGenerator.GetRandomSeed()), new CreatorSettings { NullValueProbability = 0, AllowEmptyCollection = false });
 
             return results;
+        }
+
+        /// <summary>
+        /// Returns a fixed, deterministic set of <see cref="EntityWithSimpleProperties"/> instances.
+        /// Both the controller (server-side data) and the tests (client-side expectations) call this so the
+        /// two always agree, regardless of when each one runs.
+        /// Using the random <see cref="CreateInstances{T}"/> here made the tests flaky: the array length
+        /// depends on <see cref="RandomSeedGenerator.GetRandomSeed"/>, which changes every hour, and the
+        /// controller's process-wide static in-memory table accumulates entities across those hourly seeds.
+        /// When the client and server calls landed in different hours the expected and actual feed lengths
+        /// diverged (e.g. Expected 5 / Actual 6). This mirrors the deterministic data already used by
+        /// <see cref="Controllers.BaseEntityController"/>.
+        /// </summary>
+        public static EntityWithSimpleProperties[] GetEntityWithSimplePropertiesInstances()
+        {
+            var entities = new EntityWithSimpleProperties[5];
+            for (int i = 1; i <= entities.Length; i++)
+            {
+                entities[i - 1] = new EntityWithSimpleProperties
+                {
+                    Id = i,
+                    NullableIntProperty = i * 10,
+                    BinaryProperty = new byte[] { (byte)i, (byte)(i + 1), (byte)(i + 2) },
+                    BooleanProperty = (i % 2) == 0,
+                    DurationProperty = TimeSpan.FromMinutes(i),
+                    DecimalProperty = i + 0.5m,
+                    DoubleProperty = i + 0.25,
+                    SingleProperty = i + 0.75f,
+                    GuidProperty = Guid.Parse("00000000-0000-0000-0000-00000000000" + i),
+                    Int16Property = (short)i,
+                    Int32Property = i,
+                    Int64Property = i,
+                    SbyteProperty = (sbyte)i,
+                    DateTimeOffsetProperty = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero).AddDays(i),
+                    StringProperty = "Entity" + i,
+                    EnumerationProperty = SimpleEnumeration.FirstValue
+                };
+            }
+
+            return entities;
         }
     }
 }

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/JsonLight/Metadata/PrimitiveTypesMetadataTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Formatter/JsonLight/Metadata/PrimitiveTypesMetadataTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter.JsonLight.Metadata
             string acceptHeader)
         {
             // Arrange
-            EntityWithSimpleProperties[] entities = MetadataTestHelpers.CreateInstances<EntityWithSimpleProperties[]>();
+            EntityWithSimpleProperties[] entities = MetadataTestHelpers.GetEntityWithSimplePropertiesInstances();
             string requestUrl = BaseAddress.ToLowerInvariant() + "/EntityWithSimpleProperties/";
             string expectedContextUrl = BaseAddress.ToLowerInvariant() + "/$metadata#EntityWithSimpleProperties";
             HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Get, requestUrl);
@@ -142,7 +142,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter.JsonLight.Metadata
             string edmType)
         {
             // Arrange
-            EntityWithSimpleProperties entity = MetadataTestHelpers.CreateInstances<EntityWithSimpleProperties[]>()
+            EntityWithSimpleProperties entity = MetadataTestHelpers.GetEntityWithSimplePropertiesInstances()
                                                                    .FirstOrDefault();
             Assert.NotNull(entity);
 
@@ -180,7 +180,7 @@ namespace Microsoft.Test.E2E.AspNet.OData.Formatter.JsonLight.Metadata
         public async Task MetadataIsCorrectForAnEntryWithJustPrimitiveTypeProperties(string acceptHeader)
         {
             // Arrange
-            EntityWithSimpleProperties entity = MetadataTestHelpers.CreateInstances<EntityWithSimpleProperties[]>()
+            EntityWithSimpleProperties entity = MetadataTestHelpers.GetEntityWithSimplePropertiesInstances()
                                                                    .FirstOrDefault();
             Assert.NotNull(entity);
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/AggregationBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/AggregationBinderTests.cs
@@ -90,6 +90,33 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
                 + ".Select($it => new AggregationWrapper() {GroupByContainer = $it.Key.GroupByContainer, })");
         }
 
+        [Fact]
+        public void GroupByOpenType_UnmodeledClrProperty_ResolvesFromDynamicContainer_NotClrMember()
+        {
+            // ExcludedClrProperty is a public CLR member excluded from the EDM model via [NotMapped].
+            // On an open type, a groupby over that name must bind from the dynamic property container
+            // (open-type semantics) rather than reflecting the excluded CLR member directly.
+            IEdmModel model = GetModel<DynamicProductWithExcludedProperty>();
+            ApplyClause clause = CreateApplyNode("groupby((ExcludedClrProperty))", model, typeof(DynamicProductWithExcludedProperty));
+
+            var binder = new AggregationBinder(
+                new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False },
+                WebApiAssembliesResolverFactory.Create(),
+                typeof(DynamicProductWithExcludedProperty),
+                model,
+                clause.Transformations.First());
+
+            var query = Enumerable.Empty<DynamicProductWithExcludedProperty>().AsQueryable();
+            var applyExpr = binder.Bind(query).Expression;
+            var result = ExpressionStringBuilder.ToString(applyExpr);
+
+            // Resolved from the dynamic container ...
+            Assert.Contains("ProductProperties.ContainsKey(ExcludedClrProperty)", result);
+            // ... and NOT bound to the excluded CLR member ($it.ExcludedClrProperty).
+            Assert.DoesNotContain("$it.ExcludedClrProperty", result);
+        }
+
+
 
         [Fact]
         public void SingleSum()

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/DataModel.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/DataModel.cs
@@ -159,4 +159,13 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
     {
         public Dictionary<string, object> ProductProperties { get; set; }
     }
+
+    public class DynamicProductWithExcludedProperty : DynamicProduct
+    {
+        // A public CLR property that is deliberately excluded from the EDM model via [NotMapped].
+        // On an open type, a query segment naming this member must resolve from the dynamic property
+        // container - not bind the excluded CLR member.
+        [System.ComponentModel.DataAnnotations.Schema.NotMapped]
+        public string ExcludedClrProperty { get; set; }
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

**Ported from:** [OData/AspNetCoreOData@`5e3adee4`](https://github.com/OData/AspNetCoreOData/commit/5e3adee4db5e419b835a0af14cf98536fab09fa5)

When an `$apply groupby` path crosses an open/dynamic segment, the transformation binder resolved the trailing open-property segment with raw reflection (`Type.GetProperty(name)`) using the EDM/URI name, binding to any matching public CLR property **without consulting the model**. A CLR property excluded from the model (`[NotMapped]` / `Ignore()` / simply unmodeled) was still resolvable, so its value **leaked** into groupby results. 

**Fix (`TransformationBinderBase.CreateOpenPropertyAccessExpression`).** Resolve the open property from the runtime type's dynamic-property container when the name is not an EDM-declared structural property, instead of falling back to CLR reflection. Declared properties bind as before. The dynamic-container access is null-guarded only when `QuerySettings.HandleNullPropagation` is enabled (the in-memory LINQ-to-Objects path uses `HandleNullPropagation.Default → True`, so it is guarded).

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
