### PR TITLE
Port: Enforce `UpdatableProperties` allow-list for nested resources in `Delta<T>`

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
+++ b/src/Microsoft.AspNet.OData.Shared/DeltaOfTStructuralType.cs
@@ -403,7 +403,10 @@ namespace Microsoft.AspNet.OData
         /// </summary>
         public override IEnumerable<string> GetChangedPropertyNames()
         {
-            return _changedProperties.Intersect(_updatableProperties).Concat(_deltaNestedResources.Keys);
+            // Filter the changed structural properties and the changed nested resources by the updatable
+            // properties in a single pass, so a name removed from UpdatableProperties is excluded whether
+            // it is a structural property or a nested resource.
+            return _changedProperties.Concat(_deltaNestedResources.Keys).Intersect(_updatableProperties);
         }
 
         /// <summary>
@@ -874,6 +877,13 @@ namespace Microsoft.AspNet.OData
             // For nested resources.
             foreach (string nestedResourceName in _deltaNestedResources.Keys)
             {
+                // Skip nested resources that are not in the updatable properties list,
+                // consistent with how the structural properties above are handled.
+                if (!_updatableProperties.Contains(nestedResourceName))
+                {
+                    continue;
+                }
+
                 // Patch for each nested resource changed under this TStructuralType.
                 dynamic deltaNestedResource = _deltaNestedResources[nestedResourceName];
                 dynamic originalNestedResource = null;

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNet/Microsoft.Test.E2E.AspNet.OData.csproj
@@ -1708,6 +1708,9 @@
     <Compile Include="..\ServerSidePaging\ServerSidePagingDataSource.cs">
       <Link>ServerSidePaging\ServerSidePagingDataSource.cs</Link>
     </Compile>
+    <Compile Include="..\DeltaNestedUpdatableProperties\DeltaNestedUpdatablePropertiesTests.cs">
+      <Link>DeltaNestedUpdatableProperties\DeltaNestedUpdatablePropertiesTests.cs</Link>
+    </Compile>
     <Compile Include="..\ServerSidePaging\ServerSidePagingTests.cs">
       <Link>ServerSidePaging\ServerSidePagingTests.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore/Microsoft.Test.E2E.AspNetCore.OData.csproj
@@ -1585,6 +1585,9 @@
     <Compile Include="..\ServerSidePaging\ServerSidePagingDataSource.cs">
       <Link>ServerSidePaging\ServerSidePagingDataSource.cs</Link>
     </Compile>
+    <Compile Include="..\DeltaNestedUpdatableProperties\DeltaNestedUpdatablePropertiesTests.cs">
+      <Link>DeltaNestedUpdatableProperties\DeltaNestedUpdatablePropertiesTests.cs</Link>
+    </Compile>
     <Compile Include="..\ServerSidePaging\ServerSidePagingTests.cs">
       <Link>ServerSidePaging\ServerSidePagingTests.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/Build.AspNetCore3x/Microsoft.Test.E2E.AspNetCore3x.OData.csproj
@@ -1593,6 +1593,9 @@
     <Compile Include="..\ServerSidePaging\ServerSidePagingDataSource.cs">
       <Link>ServerSidePaging\ServerSidePagingDataSource.cs</Link>
     </Compile>
+    <Compile Include="..\DeltaNestedUpdatableProperties\DeltaNestedUpdatablePropertiesTests.cs">
+      <Link>DeltaNestedUpdatableProperties\DeltaNestedUpdatablePropertiesTests.cs</Link>
+    </Compile>
     <Compile Include="..\ServerSidePaging\ServerSidePagingTests.cs">
       <Link>ServerSidePaging\ServerSidePagingTests.cs</Link>
     </Compile>

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DeltaNestedUpdatableProperties/DeltaNestedUpdatablePropertiesTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/DeltaNestedUpdatableProperties/DeltaNestedUpdatablePropertiesTests.cs
@@ -1,0 +1,152 @@
+//-----------------------------------------------------------------------------
+// <copyright file="DeltaNestedUpdatablePropertiesTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Dynamic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Routing;
+using Microsoft.AspNet.OData.Routing.Conventions;
+using Microsoft.OData.Edm;
+using Microsoft.Test.E2E.AspNet.OData.Common.Controllers;
+using Microsoft.Test.E2E.AspNet.OData.Common.Execution;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Test.E2E.AspNet.OData.DeltaNestedUpdatableProperties
+{
+    public class DeltaNestedCustomer
+    {
+        public int Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public DeltaNestedAddress Address { get; set; }
+    }
+
+    public class DeltaNestedAddress
+    {
+        public string City { get; set; }
+        public string State { get; set; }
+        public string StreetAddress { get; set; }
+        public int ZipCode { get; set; }
+    }
+
+    public class DeltaNestedCustomersController : TestODataController
+    {
+        // The customer whose nested Address is treated as server-protected: the controller removes
+        // "Address" from the delta's UpdatableProperties so a PATCH cannot change the nested resource.
+        private const int ProtectedNestedCustomerKey = 1;
+
+        public ITestActionResult Patch([FromODataUri] int key, Delta<DeltaNestedCustomer> delta)
+        {
+            var original = CreateCustomer(key);
+
+            if (key == ProtectedNestedCustomerKey)
+            {
+                delta.UpdatableProperties.Remove("Address");
+            }
+
+            delta.Patch(original);
+            return Ok(original);
+        }
+
+        private static DeltaNestedCustomer CreateCustomer(int key)
+        {
+            return new DeltaNestedCustomer
+            {
+                Id = key,
+                FirstName = "Bob",
+                LastName = "Smith",
+                Address = new DeltaNestedAddress
+                {
+                    City = "Redmond",
+                    State = "WA",
+                    StreetAddress = "21110 NE 44th St",
+                    ZipCode = 98074
+                }
+            };
+        }
+    }
+
+    public class DeltaNestedUpdatablePropertiesTests : WebHostTestBase
+    {
+        public DeltaNestedUpdatablePropertiesTests(WebHostTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UpdateConfiguration(WebRouteConfiguration configuration)
+        {
+            configuration.MapODataServiceRoute(
+                routeName: "odata",
+                routePrefix: "odata",
+                model: GetEdmModel(configuration),
+                pathHandler: new DefaultODataPathHandler(),
+                routingConventions: ODataRoutingConventions.CreateDefault());
+        }
+
+        protected static IEdmModel GetEdmModel(WebRouteConfiguration configuration)
+        {
+            var builder = configuration.CreateConventionModelBuilder();
+            builder.EntitySet<DeltaNestedCustomer>("DeltaNestedCustomers");
+            return builder.GetEdmModel();
+        }
+
+        [Fact]
+        public async Task Patch_DoesNotApplyNestedResource_WhenNestedPropertyRemovedFromUpdatableProperties()
+        {
+            // Arrange - customer 1's nested Address is removed from UpdatableProperties by the controller.
+            var request = new HttpRequestMessage(new HttpMethod("PATCH"), this.BaseAddress + "/odata/DeltaNestedCustomers(1)");
+            dynamic body = new ExpandoObject();
+            body.FirstName = "Alice";
+            body.Address = new { City = "Sammamish", StreetAddress = "23213 NE 15th Ct" };
+            request.Content = new StringContent(JsonConvert.SerializeObject(body));
+            request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode, content);
+            var result = JObject.Parse(content);
+            // The structural property still flows through.
+            Assert.Equal("Alice", (string)result["FirstName"]);
+            // The nested resource is left exactly as it was; the delta's Address is not copied.
+            Assert.Equal("Redmond", (string)result["Address"]["City"]);
+            Assert.Equal("21110 NE 44th St", (string)result["Address"]["StreetAddress"]);
+        }
+
+        [Fact]
+        public async Task Patch_AppliesNestedResource_WhenUpdatablePropertiesUntrimmed()
+        {
+            // Arrange - customer 2 is not protected; the default (untrimmed) behavior applies the nested Address.
+            var request = new HttpRequestMessage(new HttpMethod("PATCH"), this.BaseAddress + "/odata/DeltaNestedCustomers(2)");
+            dynamic body = new ExpandoObject();
+            body.FirstName = "Alice";
+            body.Address = new { City = "Sammamish" };
+            request.Content = new StringContent(JsonConvert.SerializeObject(body));
+            request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+
+            // Act
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode, content);
+            var result = JObject.Parse(content);
+            Assert.Equal("Alice", (string)result["FirstName"]);
+            // The changed nested value is copied and the unchanged nested values are retained.
+            Assert.Equal("Sammamish", (string)result["Address"]["City"]);
+            Assert.Equal("WA", (string)result["Address"]["State"]);
+        }
+    }
+}

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/DeltaTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/DeltaTest.cs
@@ -575,6 +575,191 @@ namespace Microsoft.AspNet.OData.Test
         }
 
         [Fact]
+        public void GetChangedPropertyNames_ExcludesNestedResource_WhenRemovedFromUpdatableProperties()
+        {
+            // Arrange
+            dynamic deltaCustomer = new Delta<CustomerEntity>();
+            IDelta ideltaCustomer = deltaCustomer as IDelta;
+            deltaCustomer.FirstName = "Alice";
+
+            dynamic deltaAddress = new Delta<AddressEntity>();
+            deltaAddress.City = "Sammamish";
+            deltaCustomer.Address = deltaAddress;
+
+            // both the scalar and the nested resource are initially reported as changed
+            Assert.Contains("FirstName", ideltaCustomer.GetChangedPropertyNames());
+            Assert.Contains("Address", ideltaCustomer.GetChangedPropertyNames());
+
+            // Act - remove the nested property from the updatable allow-list
+            deltaCustomer.UpdatableProperties.Remove("Address");
+
+            // Assert - the nested resource name is now excluded (previously it was concatenated
+            // unconditionally, bypassing the allow-list)
+            Assert.Contains("FirstName", ideltaCustomer.GetChangedPropertyNames());
+            Assert.DoesNotContain("Address", ideltaCustomer.GetChangedPropertyNames());
+        }
+
+        [Fact]
+        public void Patch_DoesNotCopyNestedResource_WhenNestedPropertyRemovedFromUpdatableProperties()
+        {
+            // Arrange
+            var originalAddress = new AddressEntity { ID = 1, City = "Redmond", State = "WA", StreetAddress = "21110 NE 44th St", ZipCode = 98074 };
+            var originalCustomer = new CustomerEntity { ID = 7, FirstName = "Bob", LastName = "Smith", Address = originalAddress };
+
+            dynamic deltaCustomer = new Delta<CustomerEntity>();
+            deltaCustomer.FirstName = "Alice";
+
+            dynamic deltaAddress = new Delta<AddressEntity>();
+            deltaAddress.City = "Sammamish";
+            deltaAddress.StreetAddress = "23213 NE 15th Ct";
+            deltaCustomer.Address = deltaAddress;
+
+            deltaCustomer.UpdatableProperties.Remove("Address");
+
+            // Act
+            deltaCustomer.Patch(originalCustomer);
+
+            // Assert - the nested resource is left exactly as it was
+            Assert.Same(originalAddress, originalCustomer.Address);
+            Assert.Equal(1, originalCustomer.Address.ID);
+            Assert.Equal("Redmond", originalCustomer.Address.City);
+            Assert.Equal("WA", originalCustomer.Address.State);
+            Assert.Equal("21110 NE 44th St", originalCustomer.Address.StreetAddress);
+            Assert.Equal(98074, originalCustomer.Address.ZipCode);
+
+            // Assert - properties still in the list are applied
+            Assert.Equal("Alice", originalCustomer.FirstName);
+            Assert.Equal("Smith", originalCustomer.LastName);
+        }
+
+        [Fact]
+        public void Patch_DoesNotSetNestedResource_WhenNestedPropertyRemovedFromUpdatableProperties_AndOriginalIsNull()
+        {
+            // Arrange
+            var originalCustomer = new CustomerEntity { ID = 7, FirstName = "Bob", LastName = "Smith", Address = null };
+
+            dynamic deltaCustomer = new Delta<CustomerEntity>();
+
+            dynamic deltaAddress = new Delta<AddressEntity>();
+            deltaAddress.City = "Sammamish";
+            deltaAddress.StreetAddress = "23213 NE 15th Ct";
+            deltaCustomer.Address = deltaAddress;
+
+            deltaCustomer.UpdatableProperties.Remove("Address");
+
+            // Act
+            deltaCustomer.Patch(originalCustomer);
+
+            // Assert - the nested resource is not created
+            Assert.Null(originalCustomer.Address);
+        }
+
+        [Fact]
+        public void Patch_DoesNotCopyNestedResource_WhenUpdatablePropertiesCleared()
+        {
+            // Arrange
+            var originalAddress = new AddressEntity { ID = 1, City = "Redmond", State = "WA", StreetAddress = "21110 NE 44th St", ZipCode = 98074 };
+            var originalCustomer = new CustomerEntity { ID = 7, FirstName = "Bob", LastName = "Smith", Address = originalAddress };
+
+            dynamic deltaCustomer = new Delta<CustomerEntity>();
+            deltaCustomer.FirstName = "Alice";
+            deltaCustomer.LastName = "Johnson";
+
+            dynamic deltaAddress = new Delta<AddressEntity>();
+            deltaAddress.City = "Sammamish";
+            deltaCustomer.Address = deltaAddress;
+
+            deltaCustomer.UpdatableProperties.Clear();
+
+            // Act
+            deltaCustomer.Patch(originalCustomer);
+
+            // Assert - nothing is copied
+            Assert.Same(originalAddress, originalCustomer.Address);
+            Assert.Equal("Redmond", originalCustomer.Address.City);
+            Assert.Equal("Bob", originalCustomer.FirstName);
+            Assert.Equal("Smith", originalCustomer.LastName);
+        }
+
+        [Fact]
+        public void Patch_CopiesNestedResource_WhenNestedPropertyReAddedToUpdatableProperties()
+        {
+            // Arrange
+            var originalAddress = new AddressEntity { ID = 1, City = "Redmond", State = "WA", StreetAddress = "21110 NE 44th St", ZipCode = 98074 };
+            var originalCustomer = new CustomerEntity { ID = 7, FirstName = "Bob", LastName = "Smith", Address = originalAddress };
+
+            dynamic deltaCustomer = new Delta<CustomerEntity>();
+
+            dynamic deltaAddress = new Delta<AddressEntity>();
+            deltaAddress.City = "Sammamish";
+            deltaAddress.StreetAddress = "23213 NE 15th Ct";
+            deltaCustomer.Address = deltaAddress;
+
+            deltaCustomer.UpdatableProperties.Remove("Address");
+            deltaCustomer.UpdatableProperties.Add("Address");
+
+            // Act
+            deltaCustomer.Patch(originalCustomer);
+
+            // Assert - changed nested values are copied (no over-restriction)
+            Assert.Equal("Sammamish", originalCustomer.Address.City);
+            Assert.Equal("23213 NE 15th Ct", originalCustomer.Address.StreetAddress);
+            // unchanged nested values stay
+            Assert.Equal("WA", originalCustomer.Address.State);
+            Assert.Equal(98074, originalCustomer.Address.ZipCode);
+        }
+
+        [Fact]
+        public void Patch_CopiesOnlyNestedResource_WhenUpdatablePropertiesLimitedToNestedProperty()
+        {
+            // Arrange
+            var originalAddress = new AddressEntity { ID = 1, City = "Redmond", State = "WA", StreetAddress = "21110 NE 44th St", ZipCode = 98074 };
+            var originalCustomer = new CustomerEntity { ID = 7, FirstName = "Bob", LastName = "Smith", Address = originalAddress };
+
+            dynamic deltaCustomer = new Delta<CustomerEntity>();
+            deltaCustomer.FirstName = "Alice";
+
+            dynamic deltaAddress = new Delta<AddressEntity>();
+            deltaAddress.City = "Sammamish";
+            deltaCustomer.Address = deltaAddress;
+
+            deltaCustomer.UpdatableProperties.Clear();
+            deltaCustomer.UpdatableProperties.Add("Address");
+
+            // Act
+            deltaCustomer.Patch(originalCustomer);
+
+            // Assert - the nested resource is copied
+            Assert.Equal("Sammamish", originalCustomer.Address.City);
+            // Assert - the scalar property left out of the list is not copied
+            Assert.Equal("Bob", originalCustomer.FirstName);
+        }
+
+        [Fact]
+        public void Put_DoesNotCopyNestedResource_WhenNestedPropertyRemovedFromUpdatableProperties()
+        {
+            // Arrange
+            var originalAddress = new AddressEntity { ID = 1, City = "Redmond", State = "WA", StreetAddress = "21110 NE 44th St", ZipCode = 98074 };
+            var originalCustomer = new CustomerEntity { ID = 7, FirstName = "Bob", LastName = "Smith", Address = originalAddress };
+
+            dynamic deltaCustomer = new Delta<CustomerEntity>();
+            deltaCustomer.FirstName = "Alice";
+
+            dynamic deltaAddress = new Delta<AddressEntity>();
+            deltaAddress.City = "Sammamish";
+            deltaCustomer.Address = deltaAddress;
+
+            deltaCustomer.UpdatableProperties.Remove("Address");
+
+            // Act
+            deltaCustomer.Put(originalCustomer);
+
+            // Assert - the nested resource is left unchanged
+            Assert.Same(originalAddress, originalCustomer.Address);
+            Assert.Equal("Redmond", originalCustomer.Address.City);
+        }
+
+        [Fact]
         public void TestDelta_IgnoresUnmapped()
         {
             //Arrange


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

**Ported from:** [OData/AspNetCoreOData@`4a192c41`](https://github.com/OData/AspNetCoreOData/commit/4a192c4192076b50e4666af3f245f5712f3286a6)

`Delta<T>.UpdatableProperties` controls which properties are applied when a delta is materialized onto an instance. The allow-list was respected for scalar (structural) properties but **not** for nested resources (complex types and single-valued navigation properties): removing a nested property name from `UpdatableProperties` after deserialization had no effect - `Patch()`/`Put()` still copied the nested resource. 

**Fix.** `GetChangedPropertyNames()` now filters both changed scalar properties and changed nested-resource names through `UpdatableProperties` in one pass; `CopyChangedValues()` skips nested resources whose names are not in `UpdatableProperties`, mirroring the scalar path. Both changes are **no-ops** when `UpdatableProperties` is left untrimmed (default), so existing behavior is fully preserved.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
