### PR TITLE
Port: Fix server-driven paging bypass via `Prefer: maxpagesize=0`

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/RequestPreferenceHelpers.cs
+++ b/src/Microsoft.AspNet.OData.Shared/RequestPreferenceHelpers.cs
@@ -47,16 +47,16 @@ namespace Microsoft.AspNet.OData
             if (headers.TryGetValues(PreferHeaderName, out preferences))
             {
                 pageSize = GetMaxPageSize(preferences, MaxPageSize);
-                if (pageSize >= 0)
+                if (pageSize < 0)
                 {
-                    return true;
+                    // maxpagesize supersedes odata.maxpagesize, so only fall back to odata.maxpagesize
+                    // when no maxpagesize preference was supplied.
+                    pageSize = GetMaxPageSize(preferences, ODataMaxPageSize);
                 }
-                //maxpagesize supersedes odata.maxpagesize
-                pageSize = GetMaxPageSize(preferences, ODataMaxPageSize);
-                if (pageSize >= 0)
-                {
-                    return true;
-                }
+
+                // Preferred max page size is only honored when it is a positive integer.
+                // A value of 0 (or any non-positive value) is not a meaningful page size; ignore it
+                return pageSize > 0;
             }
 
             return false;
@@ -74,7 +74,8 @@ namespace Microsoft.AspNet.OData
             {
                 int index = maxPageSize.IndexOf(preferenceHeaderName, StringComparison.OrdinalIgnoreCase) + preferenceHeaderName.Length;
                 String value = String.Empty;
-                if (maxPageSize[index++] == '=')
+                // A bare token (e.g. "Prefer: maxpagesize" with no "=value"), should not throw
+                if (index < maxPageSize.Length && maxPageSize[index++] == '=')
                 {
                     while (index < maxPageSize.Length && Char.IsDigit(maxPageSize[index]))
                     {

--- a/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingTests.cs
+++ b/test/E2ETest/Microsoft.Test.E2E.AspNet.OData/ServerSidePaging/ServerSidePagingTests.cs
@@ -91,6 +91,64 @@ namespace Microsoft.Test.E2E.AspNet.OData.ServerSidePaging
         }
 
         [Fact]
+        public async Task PreferMaxPageSizeZero_DoesNotDisableServerDrivenPaging()
+        {
+            // ServerSidePagingCustomers returns 7 items and the controller sets [EnableQuery(PageSize = 5)].
+            // A client-supplied "Prefer: maxpagesize=0" must not turn off server-driven paging; the
+            // configured server page size (5) stays in effect and the whole collection is not returned.
+            var requestUri = this.BaseAddress + "/prefix/ServerSidePagingCustomers";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.TryAddWithoutValidation("Prefer", "maxpagesize=0");
+
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var value = (JArray)JObject.Parse(content)["value"];
+            Assert.Equal(5, value.Count);
+            Assert.Contains("@odata.nextLink", content);
+            Assert.Contains("/prefix/ServerSidePagingCustomers?$skip=5", content);
+        }
+
+        [Fact]
+        public async Task PreferBareMaxPageSizeToken_DoesNotFaultAndServerDrivenPagingApplies()
+        {
+            // A bare "Prefer: maxpagesize" token (no "=value") must not surface as a 500, and the
+            // configured server page size must still apply.
+            var requestUri = this.BaseAddress + "/prefix/ServerSidePagingCustomers";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.TryAddWithoutValidation("Prefer", "maxpagesize");
+
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var value = (JArray)JObject.Parse(content)["value"];
+            Assert.Equal(5, value.Count);
+            Assert.Contains("@odata.nextLink", content);
+            Assert.Contains("/prefix/ServerSidePagingCustomers?$skip=5", content);
+        }
+
+        [Fact]
+        public async Task PreferPositiveMaxPageSize_IsStillHonored()
+        {
+            // A positive "Prefer: maxpagesize" below the server page size (5) is still honored,
+            // producing that requested page size (regression guard for valid preferences).
+            var requestUri = this.BaseAddress + "/prefix/ServerSidePagingCustomers";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.TryAddWithoutValidation("Prefer", "maxpagesize=2");
+
+            var response = await this.Client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var value = (JArray)JObject.Parse(content)["value"];
+            Assert.Equal(2, value.Count);
+            Assert.Contains("@odata.nextLink", content);
+            Assert.Contains("/prefix/ServerSidePagingCustomers?$skip=2", content);
+        }
+
+        [Fact]
         public async Task VerifyParametersInNextPageLinkInEdmFunctionResponseBodyAreInSameCaseAsInRequestUrl()
         {
             // Arrange

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
@@ -421,6 +421,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)PerRequestContentNegotiatorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PerRequestParameterBindingTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QueryableLimitationTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RequestPreferenceHelpersTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ResourceContextTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Resources.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SelectExpandNestedDollarCountTest.cs" />

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/RequestPreferenceHelpersTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/RequestPreferenceHelpersTest.cs
@@ -1,0 +1,157 @@
+//-----------------------------------------------------------------------------
+// <copyright file="RequestPreferenceHelpersTest.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNet.OData.Interfaces;
+using Xunit;
+
+namespace Microsoft.AspNet.OData.Test
+{
+    public class RequestPreferenceHelpersTest
+    {
+        [Fact]
+        public void RequestPrefersMaxPageSize_ReturnsFalse_WhenMaxPageSizeIsZero()
+        {
+            // Arrange
+            var headers = new FakeWebApiHeaders("maxpagesize=0");
+
+            // Act
+            var result = RequestPreferenceHelpers.RequestPrefersMaxPageSize(headers, out int pageSize);
+
+            // Assert - a client-supplied maxpagesize=0 must not disable server-driven paging
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void RequestPrefersMaxPageSize_ReturnsFalse_WhenMaxPageSizeIsNegative()
+        {
+            // Arrange
+            var headers = new FakeWebApiHeaders("maxpagesize=-5");
+
+            // Act
+            var result = RequestPreferenceHelpers.RequestPrefersMaxPageSize(headers, out int pageSize);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void RequestPrefersMaxPageSize_ReturnsTrue_WithPageSize_WhenMaxPageSizeIsPositive()
+        {
+            // Arrange
+            var headers = new FakeWebApiHeaders("maxpagesize=10");
+
+            // Act
+            var result = RequestPreferenceHelpers.RequestPrefersMaxPageSize(headers, out int pageSize);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(10, pageSize);
+        }
+
+        [Fact]
+        public void RequestPrefersMaxPageSize_IsCaseInsensitive()
+        {
+            // Arrange
+            var headers = new FakeWebApiHeaders("MaxPageSize=15");
+
+            // Act
+            var result = RequestPreferenceHelpers.RequestPrefersMaxPageSize(headers, out int pageSize);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(15, pageSize);
+        }
+
+        [Fact]
+        public void RequestPrefersMaxPageSize_ReturnsTrue_WithPageSize_ForODataMaxPageSize()
+        {
+            // Arrange
+            var headers = new FakeWebApiHeaders("odata.maxpagesize=20");
+
+            // Act
+            var result = RequestPreferenceHelpers.RequestPrefersMaxPageSize(headers, out int pageSize);
+
+            // Assert - back-compat: odata.maxpagesize is still honored when positive
+            Assert.True(result);
+            Assert.Equal(20, pageSize);
+        }
+
+        [Fact]
+        public void RequestPrefersMaxPageSize_ReturnsFalse_ForBareMaxPageSizeToken_WithoutThrowing()
+        {
+            // Arrange - a bare "maxpagesize" token with no "=value" must not throw IndexOutOfRange
+            var headers = new FakeWebApiHeaders("maxpagesize");
+
+            // Act
+            var result = RequestPreferenceHelpers.RequestPrefersMaxPageSize(headers, out int pageSize);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void RequestPrefersMaxPageSize_ReturnsFalse_WhenNoPreferHeaderPresent()
+        {
+            // Arrange
+            var headers = new FakeWebApiHeaders();
+
+            // Act
+            var result = RequestPreferenceHelpers.RequestPrefersMaxPageSize(headers, out int pageSize);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void RequestPrefersMaxPageSize_MaxPageSizeZeroSupersedesODataMaxPageSize_ReturnsFalse()
+        {
+            // Arrange - maxpagesize supersedes odata.maxpagesize; the 0 must win and disable paging
+            var headers = new FakeWebApiHeaders("maxpagesize=0, odata.maxpagesize=20");
+
+            // Act
+            var result = RequestPreferenceHelpers.RequestPrefersMaxPageSize(headers, out int pageSize);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void RequestPrefersMaxPageSize_MaxPageSizeSupersedesODataMaxPageSize_ReturnsMaxPageSizeValue()
+        {
+            // Arrange - when both are present and positive, maxpagesize wins
+            var headers = new FakeWebApiHeaders("maxpagesize=5, odata.maxpagesize=20");
+
+            // Act
+            var result = RequestPreferenceHelpers.RequestPrefersMaxPageSize(headers, out int pageSize);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(5, pageSize);
+        }
+
+        private sealed class FakeWebApiHeaders : IWebApiHeaders
+        {
+            private readonly IDictionary<string, IEnumerable<string>> _headers =
+                new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
+
+            public FakeWebApiHeaders(string preferHeaderValue = null)
+            {
+                if (preferHeaderValue != null)
+                {
+                    _headers[RequestPreferenceHelpers.PreferHeaderName] = new[] { preferHeaderValue };
+                }
+            }
+
+            public bool TryGetValues(string key, out IEnumerable<string> values)
+            {
+                return _headers.TryGetValue(key, out values);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

**Ported from:** [OData/AspNetCoreOData@`4018c717`](https://github.com/OData/AspNetCoreOData/commit/4018c7175aa6696f671113f34f669c847ab87a40)

A client could defeat `[EnableQuery(PageSize = N)]` / model-bound `PageSize` and pull an entire collection in one response by sending a single header: 
``` 
Prefer: maxpagesize=0        (or Prefer: odata.maxpagesize=0) 
``` 

**Root cause.** `RequestPreferenceHelpers.RequestPrefersMaxPageSize` treated `0` as a valid preference (guard `>= 0`). `ApplyPaging` then computed `Math.Min(serverPageSize, 0) = 0`, the activation guard `if (pageSize > 0)` was false, and `LimitResults` was never called - the full `IQueryable` was returned with **no `@odata.nextLink`** (paging silently disabled). A bare `Prefer: maxpagesize` token (no `=value`) also read past the end of the header string -> `IndexOutOfRangeException` -> unhandled **500**. 

**Fix (parser, single source of truth).** Honor a client max page size only when it is a **positive integer** (`> 0`); a non-positive value is ignored so the operator-configured page size stays in effect and cannot be disabled via the header. Bounds-check before dereferencing the char after the header name so a bare token no longer throws. `RequestPrefersMaxPageSize`/`GetMaxPageSize` are `internal` -> **no public API change**.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
