### PR TITLE
Improve OData query and batch request handling

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchRequestHeaders.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Batch/ODataBatchRequestHeaders.cs
@@ -1,0 +1,39 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ODataBatchRequestHeaders.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.OData.Batch
+{
+    internal static class ODataBatchRequestHeaders
+    {
+        private static readonly HashSet<string> blockedHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Authorization",
+            "Proxy-Authorization",
+            "Host",
+            "Forwarded",
+            "X-Forwarded-For",
+            "X-Forwarded-Host",
+            "X-Forwarded-Proto",
+            "X-Forwarded-Scheme",
+            "X-Original-Host",
+            "X-Real-IP",
+            "X-ARR-ClientCert",
+            "X-ARR-LOG-ID",
+            "X-MS-Client-Principal-Id",
+            "X-MS-Client-Principal-Name",
+            "X-MS-Client-Principal-IdP",
+        };
+
+        internal static bool IsBlocked(string headerName)
+        {
+            return blockedHeaders.Contains(headerName);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.Designer.cs
@@ -246,6 +246,28 @@ namespace Microsoft.AspNet.OData.Common
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The batch sub-request URI &apos;{0}&apos; has a different authority (scheme, host, or port) than the outer batch request &apos;{1}&apos;. Batch sub-requests must target the same service as the outer batch request..
+        /// </summary>
+        internal static string BatchRequestUriAuthorityMismatch
+        {
+            get
+            {
+                return ResourceManager.GetString("BatchRequestUriAuthorityMismatch", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The batch sub-request URI &apos;{0}&apos; targets a path that is not within the OData service root &apos;{1}&apos;. Batch sub-requests must address resources within the OData service..
+        /// </summary>
+        internal static string BatchSubRequestPathNotUnderServiceRoot
+        {
+            get
+            {
+                return ResourceManager.GetString("BatchSubRequestPathNotUnderServiceRoot", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The batch request must have a &quot;Content-Type&quot; header..
         /// </summary>
         internal static string BatchRequestMissingContentType

--- a/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
+++ b/src/Microsoft.AspNet.OData.Shared/Common/SRResources.resx
@@ -571,6 +571,12 @@
   <data name="BatchRequestMissingContent" xml:space="preserve">
     <value>The 'Content' property on the batch request cannot be null.</value>
   </data>
+  <data name="BatchRequestUriAuthorityMismatch" xml:space="preserve">
+    <value>The batch sub-request URI '{0}' has a different authority (scheme, host, or port) than the outer batch request '{1}'. Batch sub-requests must target the same service as the outer batch request.</value>
+  </data>
+  <data name="BatchSubRequestPathNotUnderServiceRoot" xml:space="preserve">
+    <value>The batch sub-request URI '{0}' targets a path that is not within the OData service root '{1}'. Batch sub-requests must address resources within the OData service.</value>
+  </data>
   <data name="InvalidExpansionDepthValue" xml:space="preserve">
     <value>'{0}' should be less than or equal to '{1}'.</value>
   </data>

--- a/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
+++ b/src/Microsoft.AspNet.OData.Shared/Microsoft.AspNet.OData.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchContent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Batch\ODataBatchRequestHeaders.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\Conventions\Attributes\DerivedTypeConstraintAttributeEdmPropertyConvention.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\Conventions\Attributes\MaxLengthAttributeEdmPropertyConvention.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Builder\Conventions\Attributes\DefaultValueAttributeEdmPropertyConvention.cs" />

--- a/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
@@ -142,7 +142,31 @@ namespace Microsoft.AspNet.OData.Query
                 }
                 else if (edmProperty.Type.IsEnum())
                 {
-                    ODataEnumValue enumValue = new ODataEnumValue(value.ToString(), value.GetType().FullName);
+                    IEdmEnumType enumDefinition = edmProperty.Type.AsEnum().EnumDefinition();
+
+                    // Use the EDM type name (e.g. "MyNamespace.Color") rather than the CLR
+                    // FullName (e.g. "MyNamespace+OuterClass+Color"). The CLR nested-type
+                    // separator ('+') is not valid OData syntax and causes
+                    // ODataUriUtils.ConvertFromUriLiteral to fail when parsing the skiptoken
+                    // value back on the next page request, silently breaking enum-ordered paging.
+                    string edmTypeName = enumDefinition.FullName();
+
+                    // Prefer the EDM member name (which reflects any [EnumMember(Value="...")]
+                    // alias) over the CLR member name returned by value.ToString(). Without this,
+                    // an aliased enum member would generate a token containing the CLR name, which
+                    // does not match the EDM-aliased name and fails to parse back.
+                    string memberName = value.ToString();
+                    ClrEnumMemberAnnotation clrEnumMemberAnnotation = model.GetClrEnumMemberAnnotation(enumDefinition);
+                    if (clrEnumMemberAnnotation != null && value is Enum enumValueForAnnotation)
+                    {
+                        IEdmEnumMember edmMember = clrEnumMemberAnnotation.GetEdmEnumMember(enumValueForAnnotation);
+                        if (edmMember != null)
+                        {
+                            memberName = edmMember.Name;
+                        }
+                    }
+
+                    ODataEnumValue enumValue = new ODataEnumValue(memberName, edmTypeName);
                     uriLiteral = ODataUriUtils.ConvertToUriLiteral(enumValue, ODataVersion.V401, model);
                 }
                 else if(edmProperty.Type.IsDateTimeOffset() && value is DateTime)

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/ExpressionBinderBase.cs
@@ -127,10 +127,48 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         {
             ExpressionType binaryExpressionType;
 
+            // When one operand is object-typed (open/dynamic property access) and the other is
+            // strongly typed, insert Expression.Convert to coerce the runtime-boxed CLR value to
+            // the nullable form of the declared type. Using the nullable form ensures that rows
+            // where the dynamic property is absent (null) do not cause a NullReferenceException
+            // at query execution time. Null constants are excluded: they are the sentinel value
+            // used for OData "null" literals and are handled correctly by the existing baseline
+            // logic without conversion.
+            if (left.Type == typeof(object) && right.Type != typeof(object)
+                && !(left is ConstantExpression leftConstant && leftConstant.Value == null))
+            {
+                left = Expression.Convert(left, ToNullable(right.Type));
+            }
+            else if (right.Type == typeof(object) && left.Type != typeof(object)
+                && !(right is ConstantExpression rightConstant && rightConstant.Value == null))
+            {
+                right = Expression.Convert(right, ToNullable(left.Type));
+            }
+
             // When comparing an enum to a string, parse the string, convert both to the enum underlying type, and compare the values
             // When comparing an enum to an enum with the same type, convert both to the underlying type, and compare the values
             Type leftUnderlyingType = Nullable.GetUnderlyingType(left.Type) ?? left.Type;
             Type rightUnderlyingType = Nullable.GetUnderlyingType(right.Type) ?? right.Type;
+
+            // bool/bool? has no ordering operators in .NET expression trees.
+            // For gt, ge, lt, le: convert to int (false -> 0, true -> 1) so standard integer
+            // comparison applies and preserves the expected false < true ordering.
+            if (leftUnderlyingType == typeof(bool) && rightUnderlyingType == typeof(bool) &&
+                (binaryOperator == BinaryOperatorKind.GreaterThan ||
+                 binaryOperator == BinaryOperatorKind.GreaterThanOrEqual ||
+                 binaryOperator == BinaryOperatorKind.LessThan ||
+                 binaryOperator == BinaryOperatorKind.LessThanOrEqual))
+            {
+                // Only widen to int? when at least one side is nullable; Expression.MakeBinary
+                // rejects mismatched int/int? operands, and forcing int? unconditionally would
+                // make a lifted comparison (bool?) out of two non-nullable bool operands, which
+                // is not a valid predicate for LINQ's Where.
+                bool isNullable = IsNullable(left.Type) || IsNullable(right.Type);
+                left = BoolToIntExpression(left, isNullable);
+                right = BoolToIntExpression(right, isNullable);
+                leftUnderlyingType = typeof(int);
+                rightUnderlyingType = typeof(int);
+            }
 
             // Convert to integers unless Enum type is required
             if ((TypeHelper.IsEnum(leftUnderlyingType) || TypeHelper.IsEnum(rightUnderlyingType)) && binaryOperator != BinaryOperatorKind.Has)
@@ -1059,6 +1097,40 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             }
 
             return expression;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="bool"/> or <see cref="Nullable{Boolean}"/> expression to an integer
+        /// expression using the mapping <c>false -> 0</c>, <c>true -> 1</c> (and <c>null -> null</c> for
+        /// the nullable form). This is needed because .NET expression trees do not define ordering
+        /// operators for <see cref="bool"/>, yet OData allows <c>$orderby</c> on boolean properties with
+        /// the conventional ordering <c>false &lt; true</c>.
+        /// </summary>
+        /// <param name="boolExpr">The bool or bool? expression to convert.</param>
+        /// <param name="forceNullable">
+        /// When <c>true</c>, always returns <see cref="Nullable{Int32}"/> even for a non-nullable
+        /// <paramref name="boolExpr"/>, so that it can be paired with a nullable counterpart -
+        /// Expression.MakeBinary rejects mismatched int/int? operands. When <c>false</c> and
+        /// <paramref name="boolExpr"/> is non-nullable, returns a plain <see cref="Int32"/> so the
+        /// resulting comparison is not lifted to <c>bool?</c>, which would not be a valid predicate
+        /// for LINQ's Where.
+        /// </param>
+        private static Expression BoolToIntExpression(Expression boolExpr, bool forceNullable)
+        {
+            if (Nullable.GetUnderlyingType(boolExpr.Type) == null)
+            {
+                // false -> 0, true -> 1
+                Expression intExpr = Expression.Condition(boolExpr, Expression.Constant(1), Expression.Constant(0));
+                return forceNullable ? Expression.Convert(intExpr, typeof(int?)) : intExpr;
+            }
+
+            // null -> null (int?), false -> 0 (int?), true -> 1 (int?)
+            Expression hasValue = Expression.Property(boolExpr, "HasValue");
+            Expression value = Expression.Property(boolExpr, "Value");
+            Expression intValue = Expression.Convert(
+                Expression.Condition(value, Expression.Constant(1), Expression.Constant(0)),
+                typeof(int?));
+            return Expression.Condition(hasValue, intValue, Expression.Constant(null, typeof(int?)));
         }
 
         internal static bool IsIQueryable(Type type)

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandWrapper.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Reflection;
 using Microsoft.AspNet.OData.Common;
 using Microsoft.AspNet.OData.Formatter;
 using Microsoft.AspNet.OData.Formatter.Serialization;
@@ -86,15 +87,43 @@ namespace Microsoft.AspNet.OData.Query.Expressions
             // fall back to the instance.
             if (UseInstanceForProperties && UntypedInstance != null)
             {
-                if (GetEdmType() is IEdmComplexTypeReference)
+                IEdmTypeReference edmTypeReference = GetEdmType();
+                IEdmModel model = GetModel();
+
+                // Restrict the CLR fallback to properties that are declared as *structural* properties
+                // in the EDM model or are the open-type dynamic-property container
+                // (IDictionary<string,object> bag). Property names not found in the container that are
+                // neither an EDM-declared structural property nor the dynamic container have no basis
+                // for CLR resolution and are returned as not found. Navigation properties are excluded
+                // so that a declared navigation property that is absent from the container cannot reach
+                // the CLR fallback.
+                if (edmTypeReference is IEdmStructuredTypeReference structuredTypeRef && model != null)
+                {
+                    IEdmStructuralProperty structuralProperty =
+                        structuredTypeRef.FindProperty(propertyName) as IEdmStructuralProperty;
+
+                    if (structuralProperty == null)
+                    {
+                        PropertyInfo dynamicContainerProp =
+                            EdmLibHelpers.GetDynamicPropertyDictionary(structuredTypeRef.StructuredDefinition(), model);
+                        if (dynamicContainerProp == null || dynamicContainerProp.Name != propertyName)
+                        {
+                            value = null;
+                            return false;
+                        }
+                    }
+                }
+
+                IEdmComplexTypeReference complexTypeReference = edmTypeReference as IEdmComplexTypeReference;
+                if (complexTypeReference != null)
                 {
                     _typedEdmStructuredObject = _typedEdmStructuredObject ??
-                    new TypedEdmComplexObject(UntypedInstance, GetEdmType() as IEdmComplexTypeReference, GetModel());
+                    new TypedEdmComplexObject(UntypedInstance, complexTypeReference, model);
                 }
                 else
                 {
                     _typedEdmStructuredObject = _typedEdmStructuredObject ??
-                    new TypedEdmEntityObject(UntypedInstance, GetEdmType() as IEdmEntityTypeReference, GetModel());
+                    new TypedEdmEntityObject(UntypedInstance, edmTypeReference as IEdmEntityTypeReference, model);
                 }
 
                 return _typedEdmStructuredObject.TryGetPropertyValue(propertyName, out value);

--- a/src/Microsoft.AspNet.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs
+++ b/src/Microsoft.AspNet.OData/Batch/ODataBatchHttpRequestMessageExtensions.cs
@@ -38,6 +38,7 @@ namespace Microsoft.AspNet.OData.Batch
         private const string ChangeSetIdKey = "ChangesetId";
         private const string ContentIdKey = "ContentId";
         private const string ContentIdMappingKey = "ContentIdMapping";
+        private const string BatchServiceRootKey = "BatchServiceRoot";
         private const string BatchMediaTypeMime = "multipart/mixed";
         private const string BatchMediaTypeJson = "application/json";
         private const string Boundary = "boundary";
@@ -186,6 +187,17 @@ namespace Microsoft.AspNet.OData.Batch
             }
 
             request.Properties[ContentIdMappingKey] = contentIdMapping;
+        }
+
+        internal static Uri GetODataBatchServiceRoot(this HttpRequestMessage request)
+        {
+            object serviceRoot;
+            return request.Properties.TryGetValue(BatchServiceRootKey, out serviceRoot) ? serviceRoot as Uri : null;
+        }
+
+        internal static void SetODataBatchServiceRoot(this HttpRequestMessage request, Uri serviceRoot)
+        {
+            request.Properties[BatchServiceRootKey] = serviceRoot;
         }
 
         [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "Relies on many ODataLib classes.")]

--- a/src/Microsoft.AspNet.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNet.OData/Batch/ODataBatchReaderExtensions.cs
@@ -25,6 +25,8 @@ namespace Microsoft.AspNet.OData.Batch
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class ODataBatchReaderExtensions
     {
+        private static readonly UriComponents RequestAuthority = UriComponents.SchemeAndServer;
+
         /// <summary>
         /// Reads a ChangeSet request.
         /// </summary>
@@ -157,11 +159,17 @@ namespace Microsoft.AspNet.OData.Batch
             HttpRequestMessage request = new HttpRequestMessage();
             request.Method = new HttpMethod(batchRequest.Method);
             Uri requestUri = batchRequest.Url;
+            Uri serviceRoot = batchRequest.Container.GetRequiredService<ODataMessageReaderSettings>().BaseUri;
 
             if (!requestUri.IsAbsoluteUri)
             {
-                Uri baseUri = batchRequest.Container.GetRequiredService<ODataMessageReaderSettings>().BaseUri;
-                requestUri = new Uri(baseUri, requestUri);
+                requestUri = new Uri(serviceRoot, requestUri);
+            }
+
+            if (serviceRoot != null)
+            {
+                ValidateRequestUri(requestUri, serviceRoot);
+                request.SetODataBatchServiceRoot(serviceRoot);
             }
 
             request.RequestUri = requestUri;
@@ -186,6 +194,11 @@ namespace Microsoft.AspNet.OData.Batch
             {
                 string headerName = header.Key;
                 string headerValue = header.Value;
+                if (ODataBatchRequestHeaders.IsBlocked(headerName))
+                {
+                    continue;
+                }
+
                 if (!request.Headers.TryAddWithoutValidation(headerName, headerValue))
                 {
                     request.Content.Headers.TryAddWithoutValidation(headerName, headerValue);
@@ -201,6 +214,34 @@ namespace Microsoft.AspNet.OData.Batch
             }
 
             return request;
+        }
+
+        internal static void ValidateRequestUri(Uri requestUri, Uri serviceRoot)
+        {
+            if (Uri.Compare(requestUri, serviceRoot, RequestAuthority, UriFormat.SafeUnescaped, StringComparison.OrdinalIgnoreCase) != 0)
+            {
+                throw Error.InvalidOperation(
+                    SRResources.BatchRequestUriAuthorityMismatch,
+                    requestUri.AbsoluteUri,
+                    serviceRoot.GetLeftPart(UriPartial.Authority));
+            }
+
+            string serviceRootPath = serviceRoot.AbsolutePath.TrimEnd('/');
+            if (serviceRootPath.Length == 0)
+            {
+                serviceRootPath = "/";
+            }
+
+            string requestPath = requestUri.AbsolutePath;
+            if (serviceRootPath != "/"
+                && !string.Equals(requestPath, serviceRootPath, StringComparison.OrdinalIgnoreCase)
+                && !requestPath.StartsWith(serviceRootPath + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                throw Error.InvalidOperation(
+                    SRResources.BatchSubRequestPathNotUnderServiceRoot,
+                    requestUri.AbsoluteUri,
+                    serviceRoot.AbsoluteUri);
+            }
         }
     }
 }

--- a/src/Microsoft.AspNet.OData/Batch/ODataBatchRequestItem.cs
+++ b/src/Microsoft.AspNet.OData/Batch/ODataBatchRequestItem.cs
@@ -43,7 +43,14 @@ namespace Microsoft.AspNet.OData.Batch
             if (contentIdToLocationMapping != null)
             {
                 string resolvedRequestUrl = ContentIdHelpers.ResolveContentId(request.RequestUri.OriginalString, contentIdToLocationMapping);
-                request.RequestUri = new Uri(resolvedRequestUrl);
+                Uri resolvedRequestUri = new Uri(resolvedRequestUrl);
+                Uri serviceRoot = request.GetODataBatchServiceRoot();
+                if (serviceRoot != null)
+                {
+                    ODataBatchReaderExtensions.ValidateRequestUri(resolvedRequestUri, serviceRoot);
+                }
+
+                request.RequestUri = resolvedRequestUri;
 
                 request.SetODataContentIdMapping(contentIdToLocationMapping);
             }

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchReaderExtensions.cs
@@ -145,6 +145,35 @@ namespace Microsoft.AspNet.OData.Batch
             }
 
             request.Method = batchRequest.Method;
+
+            // Each sub-request URL must target the same service as the outer batch request.
+            // Sub-request URIs that specify a different scheme, host, or port are rejected.
+            string outerScheme = originalContext.Request.Scheme;
+            HostString outerHost = originalContext.Request.Host;
+            Uri outerBaseUri = new Uri($"{outerScheme}://{outerHost}/");
+            if (Uri.Compare(requestUri, outerBaseUri, UriComponents.SchemeAndServer, UriFormat.SafeUnescaped, StringComparison.OrdinalIgnoreCase) != 0)
+            {
+                throw Error.InvalidOperation(
+                    SRResources.BatchRequestUriAuthorityMismatch,
+                    requestUri.AbsoluteUri,
+                    $"{outerScheme}://{outerHost}");
+            }
+
+            // Each sub-request path must fall within the OData service root.  Absolute URLs targeting
+            // other paths and Content-ID references that resolve outside the service root via
+            // dot-segment traversal (e.g. $1/../../../other) are both rejected here.  The service
+            // root is derived from the outer batch request's own path (mapped as
+            // "{routePrefix}/$batch") rather than IODataFeature.RoutePrefix, which is not
+            // populated in the conventional (non-endpoint) routing pipeline this code runs in.
+            if (!IsPathWithinServiceRoot(requestUri.AbsolutePath, originalContext.Request.Path, originalContext.Request.PathBase))
+            {
+                string serviceRoot = BuildServiceRootPath(originalContext.Request.Path, originalContext.Request.PathBase);
+                throw Error.InvalidOperation(
+                    SRResources.BatchSubRequestPathNotUnderServiceRoot,
+                    requestUri.AbsoluteUri,
+                    $"{outerScheme}://{outerHost}{serviceRoot}");
+            }
+
             request.CopyAbsoluteUrl(requestUri);
 
             // Not using bufferContentStream. Unlike AspNet, AspNetCore cannot guarantee the disposal
@@ -163,6 +192,15 @@ namespace Microsoft.AspNet.OData.Batch
             {
                 string headerName = header.Key;
                 string headerValue = header.Value;
+
+                // The OData batch spec requires sub-requests to omit authentication and authorization
+                // headers.  In addition, proxy/gateway headers that carry caller identity or origin
+                // signals are excluded so that the synthetic sub-request reflects the outer request's
+                // context rather than values supplied in the batch body.
+                if (ODataBatchRequestHeaders.IsBlocked(headerName))
+                {
+                    continue;
+                }
 
                 if (headerName.Trim().ToLowerInvariant() == "prefer")
                 {
@@ -402,6 +440,48 @@ namespace Microsoft.AspNet.OData.Batch
             {
                 yield return preferences.Substring(preferenceStartIndex).Trim();
             }
+        }
+
+        // Returns true when the sub-request's absolute path falls within the OData service root.
+        // Batch sub-requests are intended to address resources within the same OData service;
+        // this check prevents requests that pass the authority check from reaching unrelated
+        // in-process routes via a same-authority absolute URL or via dot-segment traversal in a
+        // Content-ID reference ($1/../../../other), which the .NET Uri constructor normalises.
+        private static bool IsPathWithinServiceRoot(string requestPath, PathString batchRequestPath, PathString pathBase)
+        {
+            string serviceRoot = BuildServiceRootPath(batchRequestPath, pathBase);
+
+            // A "/" service root means the service is mounted at the host root (no route prefix
+            // and no PathBase), so every path is by definition within scope.
+            if (serviceRoot == "/")
+            {
+                return true;
+            }
+
+            // The request path must equal the service root exactly OR begin with the service root
+            // followed by '/' (a child resource).  The trailing-slash requirement prevents a prefix
+            // like '/odata' from accidentally matching '/odata-admin'.
+            return string.Equals(requestPath, serviceRoot, StringComparison.OrdinalIgnoreCase)
+                || requestPath.StartsWith(serviceRoot + "/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Builds the expected path prefix for the OData service root, combining the ASP.NET Core
+        // path base (for apps mounted under a sub-path) with the OData route prefix.  The route
+        // prefix is derived from the outer batch request's own path, which is always mapped as
+        // "{routePrefix}/$batch" (see ODataRouteBuilderExtensions.MapODataServiceRoute), rather
+        // than IODataFeature.RoutePrefix, which is not populated by the conventional (non-endpoint)
+        // routing pipeline this code runs in.
+        private static string BuildServiceRootPath(PathString batchRequestPath, PathString pathBase)
+        {
+            string basePart = pathBase.HasValue ? pathBase.Value.TrimEnd('/') : string.Empty;
+
+            string batchPath = batchRequestPath.HasValue ? batchRequestPath.Value : string.Empty;
+            string trimmedBatchPath = batchPath.TrimEnd('/');
+            int lastSlash = trimmedBatchPath.LastIndexOf('/');
+            string routePrefixPart = lastSlash > 0 ? trimmedBatchPath.Substring(0, lastSlash) : string.Empty;
+
+            string combined = basePart + routePrefixPart;
+            return string.IsNullOrEmpty(combined) ? "/" : combined;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs
+++ b/src/Microsoft.AspNetCore.OData/Batch/ODataBatchRequestItem.cs
@@ -44,7 +44,8 @@ namespace Microsoft.AspNet.OData.Batch
                 string resolvedRequestUrl = ContentIdHelpers.ResolveContentId(encodedUrl, contentIdToLocationMapping);
                 Uri resolvedUri;
                 if (!string.IsNullOrEmpty(resolvedRequestUrl)
-                    && Uri.TryCreate(resolvedRequestUrl, UriKind.Absolute, out resolvedUri))
+                    && Uri.TryCreate(resolvedRequestUrl, UriKind.Absolute, out resolvedUri)
+                    && IsSameAuthority(resolvedUri, context.Request))
                 { 
                     context.Request.CopyAbsoluteUrl(resolvedUri);
                 }
@@ -94,6 +95,17 @@ namespace Microsoft.AspNet.OData.Batch
             {
                 contentIdToLocationMapping.Add(contentId, headers.Location.AbsoluteUri);
             }
+        }
+
+        // Returns true when the resolved Content-ID URI shares the same scheme, host, and port as
+        // the current sub-request context.  Content-ID references are resolved by string-
+        // concatenating a Location header value with the remainder of the relative reference; the
+        // Location header may point to a different origin (redirect, multi-tenant alias, etc.) so
+        // the authority must be re-validated after resolution before the URL is applied.
+        private static bool IsSameAuthority(Uri resolvedUri, HttpRequest request)
+        {
+            Uri requestBaseUri = new Uri($"{request.Scheme}://{request.Host}/");
+            return Uri.Compare(resolvedUri, requestBaseUri, UriComponents.SchemeAndServer, UriFormat.SafeUnescaped, StringComparison.OrdinalIgnoreCase) == 0;
         }
 
         /// <summary>

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/DefaultODataBatchHandlerTest.cs
@@ -790,6 +790,349 @@ Prefer: return=representation
 
             // TODO: assert somehow?
         }
+
+        // ─── Security tests ──────────────────────────────────────────────────────
+        // Sub-request URLs and headers in the batch body are untrusted input. These tests
+        // verify that the batch middleware validates sub-request authority and path scope,
+        // and strips trust/forwarding headers, before dispatching each synthetic request.
+
+        [Fact]
+        public async Task SendAsync_Throws_WhenSubRequestUriHasDifferentHost()
+        {
+            var batchRef = $"batch_{Guid.NewGuid()}";
+            var endpoint = "http://localhost";
+
+            Type[] controllers = new[] { typeof(BatchTestCustomersController) };
+            var server = TestServerFactory.Create(controllers, (config) =>
+            {
+                var builder = ODataConventionModelBuilderFactory.Create(config);
+                builder.EntitySet<BatchTestCustomer>("BatchTestCustomers");
+
+                config.MapODataServiceRoute("odata", null, builder.GetEdmModel(), new DefaultODataBatchHandler());
+            });
+
+            var client = TestServerFactory.CreateClient(server);
+
+            var batchRequest = new HttpRequestMessage(HttpMethod.Post, $"{endpoint}/$batch");
+            var batchContent = $@"
+--{batchRef}
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET https://other.example.com/admin/diagnostics HTTP/1.1
+Host: other.example.com
+
+
+--{batchRef}--
+";
+            var httpContent = new StringContent(batchContent);
+            httpContent.Headers.ContentType = MediaTypeHeaderValue.Parse($"multipart/mixed;boundary={batchRef}");
+            batchRequest.Content = httpContent;
+
+            InvalidOperationException exception = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(
+                () => client.SendAsync(batchRequest));
+            Assert.Contains("has a different authority", exception.Message);
+        }
+
+        [Fact]
+        public async Task SendAsync_Throws_WhenSubRequestUriHasDifferentScheme()
+        {
+            var batchRef = $"batch_{Guid.NewGuid()}";
+            var endpoint = "http://localhost";
+
+            Type[] controllers = new[] { typeof(BatchTestCustomersController) };
+            var server = TestServerFactory.Create(controllers, (config) =>
+            {
+                var builder = ODataConventionModelBuilderFactory.Create(config);
+                builder.EntitySet<BatchTestCustomer>("BatchTestCustomers");
+
+                config.MapODataServiceRoute("odata", null, builder.GetEdmModel(), new DefaultODataBatchHandler());
+            });
+
+            var client = TestServerFactory.CreateClient(server);
+
+            var batchRequest = new HttpRequestMessage(HttpMethod.Post, $"{endpoint}/$batch");
+            var batchContent = $@"
+--{batchRef}
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET https://localhost/BatchTestCustomers HTTP/1.1
+Host: localhost
+
+
+--{batchRef}--
+";
+            var httpContent = new StringContent(batchContent);
+            httpContent.Headers.ContentType = MediaTypeHeaderValue.Parse($"multipart/mixed;boundary={batchRef}");
+            batchRequest.Content = httpContent;
+
+            InvalidOperationException exception = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(
+                () => client.SendAsync(batchRequest));
+            Assert.Contains("has a different authority", exception.Message);
+        }
+
+        [Fact]
+        public async Task SendAsync_Throws_WhenSubRequestUriHasDifferentPort()
+        {
+            var batchRef = $"batch_{Guid.NewGuid()}";
+            var endpoint = "http://localhost";
+
+            Type[] controllers = new[] { typeof(BatchTestCustomersController) };
+            var server = TestServerFactory.Create(controllers, (config) =>
+            {
+                var builder = ODataConventionModelBuilderFactory.Create(config);
+                builder.EntitySet<BatchTestCustomer>("BatchTestCustomers");
+
+                config.MapODataServiceRoute("odata", null, builder.GetEdmModel(), new DefaultODataBatchHandler());
+            });
+
+            var client = TestServerFactory.CreateClient(server);
+
+            var batchRequest = new HttpRequestMessage(HttpMethod.Post, $"{endpoint}/$batch");
+            var batchContent = $@"
+--{batchRef}
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET http://localhost:9090/BatchTestCustomers HTTP/1.1
+Host: localhost:9090
+
+
+--{batchRef}--
+";
+            var httpContent = new StringContent(batchContent);
+            httpContent.Headers.ContentType = MediaTypeHeaderValue.Parse($"multipart/mixed;boundary={batchRef}");
+            batchRequest.Content = httpContent;
+
+            InvalidOperationException exception = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(
+                () => client.SendAsync(batchRequest));
+            Assert.Contains("has a different authority", exception.Message);
+        }
+
+        [Fact]
+        public async Task SendAsync_Succeeds_WhenSubRequestUriHasSameAuthority()
+        {
+            var batchRef = $"batch_{Guid.NewGuid()}";
+            var endpoint = "http://localhost";
+
+            Type[] controllers = new[] { typeof(BatchTestCustomersController) };
+            var server = TestServerFactory.Create(controllers, (config) =>
+            {
+                var builder = ODataConventionModelBuilderFactory.Create(config);
+                builder.EntitySet<BatchTestCustomer>("BatchTestCustomers");
+
+                config.MapODataServiceRoute("odata", null, builder.GetEdmModel(), new DefaultODataBatchHandler());
+            });
+
+            var client = TestServerFactory.CreateClient(server);
+
+            var batchRequest = new HttpRequestMessage(HttpMethod.Post, $"{endpoint}/$batch");
+            var batchContent = $@"
+--{batchRef}
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET {endpoint}/BatchTestCustomers HTTP/1.1
+Host: localhost
+
+
+--{batchRef}--
+";
+            var httpContent = new StringContent(batchContent);
+            httpContent.Headers.ContentType = MediaTypeHeaderValue.Parse($"multipart/mixed;boundary={batchRef}");
+            batchRequest.Content = httpContent;
+
+            var response = await client.SendAsync(batchRequest);
+
+            ExceptionAssert.DoesNotThrow(() => response.EnsureSuccessStatusCode());
+        }
+
+        [Fact]
+        public async Task SendAsync_Throws_WhenSubRequestPathEscapesODataRoutePrefix()
+        {
+            var batchRef = $"batch_{Guid.NewGuid()}";
+            var endpoint = "http://localhost";
+
+            Type[] controllers = new[] { typeof(BatchTestCustomersController) };
+            var server = TestServerFactory.Create(controllers, (config) =>
+            {
+                var builder = ODataConventionModelBuilderFactory.Create(config);
+                builder.EntitySet<BatchTestCustomer>("BatchTestCustomers");
+
+                // Mount the OData service under the "odata" route prefix.
+                config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel(), new DefaultODataBatchHandler());
+            });
+
+            var client = TestServerFactory.CreateClient(server);
+
+            var batchRequest = new HttpRequestMessage(HttpMethod.Post, $"{endpoint}/odata/$batch");
+            var batchContent = $@"
+--{batchRef}
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET {endpoint}/admin/diagnostics HTTP/1.1
+Host: localhost
+
+
+--{batchRef}--
+";
+            var httpContent = new StringContent(batchContent);
+            httpContent.Headers.ContentType = MediaTypeHeaderValue.Parse($"multipart/mixed;boundary={batchRef}");
+            batchRequest.Content = httpContent;
+
+            InvalidOperationException exception = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(
+                () => client.SendAsync(batchRequest));
+            Assert.Contains("not within the OData service root", exception.Message);
+        }
+
+        [Fact]
+        public async Task SendAsync_Throws_WhenContentIdTraversalEscapesODataServiceRoot()
+        {
+            // A Content-ID relative reference with dot-segment traversal inside a changeset.
+            // The reference "$1/../../../admin/control" is resolved by the .NET Uri constructor
+            // before the sub-request URL is applied: with base http://localhost/odata/ the path
+            // normalises to /admin/control, which is outside the /odata service root.
+            var batchRef = $"batch_{Guid.NewGuid()}";
+            var changesetRef = $"changeset_{Guid.NewGuid()}";
+            var endpoint = "http://localhost";
+
+            Type[] controllers = new[] { typeof(BatchTestCustomersController), typeof(BatchTestOrdersController) };
+            var server = TestServerFactory.Create(controllers, (config) =>
+            {
+                var builder = ODataConventionModelBuilderFactory.Create(config);
+                builder.EntitySet<BatchTestCustomer>("BatchTestCustomers");
+                builder.EntitySet<BatchTestOrder>("BatchTestOrders");
+
+                config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel(), new DefaultODataBatchHandler());
+            });
+
+            var client = TestServerFactory.CreateClient(server);
+
+            var createOrderPayload = @"{""@odata.type"":""Microsoft.AspNet.OData.Test.Batch.BatchTestOrder"",""Id"":3,""Amount"":10}";
+
+            var batchRequest = new HttpRequestMessage(HttpMethod.Post, $"{endpoint}/odata/$batch");
+            var batchContent = $@"
+--{batchRef}
+Content-Type: multipart/mixed; boundary={changesetRef}
+
+--{changesetRef}
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 1
+
+POST {endpoint}/odata/BatchTestOrders HTTP/1.1
+Content-Type: application/json
+
+{createOrderPayload}
+--{changesetRef}
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 2
+
+POST $1/../../../admin/control HTTP/1.1
+Content-Type: application/json
+
+{{}}
+--{changesetRef}--
+--{batchRef}--
+";
+            var httpContent = new StringContent(batchContent);
+            httpContent.Headers.ContentType = MediaTypeHeaderValue.Parse($"multipart/mixed;boundary={batchRef}");
+            batchRequest.Content = httpContent;
+
+            InvalidOperationException exception = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(
+                () => client.SendAsync(batchRequest));
+            Assert.Contains("not within the OData service root", exception.Message);
+        }
+
+        [Fact]
+        public async Task SendAsync_DoesNotCopyBlockedTrustHeadersFromSubRequest()
+        {
+            // Sub-request carries X-Forwarded-For and X-MS-Client-Principal-Id headers. Per the
+            // OData batch spec these must not be copied onto the synthetic sub-request; the
+            // sub-request must inherit the outer request's context for these values instead.
+            var batchRef = $"batch_{Guid.NewGuid()}";
+            var endpoint = "http://localhost";
+
+            Type[] controllers = new[] { typeof(BatchTestSecurityHeaderCustomersController) };
+            var server = TestServerFactory.Create(controllers, (config) =>
+            {
+                var builder = ODataConventionModelBuilderFactory.Create(config);
+                builder.EntitySet<BatchTestSecurityHeaderCustomer>("BatchTestSecurityHeaderCustomers");
+
+                config.MapODataServiceRoute("odata", null, builder.GetEdmModel(), new DefaultODataBatchHandler());
+            });
+
+            var client = TestServerFactory.CreateClient(server);
+
+            var batchRequest = new HttpRequestMessage(HttpMethod.Post, $"{endpoint}/$batch");
+            var batchContent = $@"
+--{batchRef}
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET {endpoint}/BatchTestSecurityHeaderCustomers HTTP/1.1
+Host: localhost
+X-Forwarded-For: 10.0.0.1
+X-MS-Client-Principal-Id: test-user-id
+
+
+--{batchRef}--
+";
+            var httpContent = new StringContent(batchContent);
+            httpContent.Headers.ContentType = MediaTypeHeaderValue.Parse($"multipart/mixed;boundary={batchRef}");
+            batchRequest.Content = httpContent;
+
+            var response = await client.SendAsync(batchRequest);
+
+            ExceptionAssert.DoesNotThrow(() => response.EnsureSuccessStatusCode());
+            var responseContent = await response.Content.ReadAsStringAsync();
+            Assert.Contains("XForwardedFor=,PrincipalId=", responseContent);
+        }
+
+        [Fact]
+        public async Task SendAsync_DoesNotOverrideHostFromSubRequestHostHeader()
+        {
+            // CopyAbsoluteUrl sets Request.Host from the validated sub-request URI; a Host
+            // header present in the batch body must not override that value.
+            var batchRef = $"batch_{Guid.NewGuid()}";
+            var endpoint = "http://localhost";
+
+            Type[] controllers = new[] { typeof(BatchTestSecurityHeaderCustomersController) };
+            var server = TestServerFactory.Create(controllers, (config) =>
+            {
+                var builder = ODataConventionModelBuilderFactory.Create(config);
+                builder.EntitySet<BatchTestSecurityHeaderCustomer>("BatchTestSecurityHeaderCustomers");
+
+                config.MapODataServiceRoute("odata", null, builder.GetEdmModel(), new DefaultODataBatchHandler());
+            });
+
+            var client = TestServerFactory.CreateClient(server);
+
+            var batchRequest = new HttpRequestMessage(HttpMethod.Post, $"{endpoint}/$batch");
+            var batchContent = $@"
+--{batchRef}
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET {endpoint}/BatchTestSecurityHeaderCustomers HTTP/1.1
+Host: other.example.com
+
+
+--{batchRef}--
+";
+            var httpContent = new StringContent(batchContent);
+            httpContent.Headers.ContentType = MediaTypeHeaderValue.Parse($"multipart/mixed;boundary={batchRef}");
+            batchRequest.Content = httpContent;
+
+            var response = await client.SendAsync(batchRequest);
+
+            ExceptionAssert.DoesNotThrow(() => response.EnsureSuccessStatusCode());
+            var responseContent = await response.Content.ReadAsStringAsync();
+            Assert.Contains($"Host={new Uri(endpoint).Authority}", responseContent);
+        }
 #endif
 
         [Fact]
@@ -935,6 +1278,22 @@ Prefer: return=representation
     }
 
     public class BatchTestHeadersCustomer
+    {
+        public int Id { get; set; }
+    }
+
+    public class BatchTestSecurityHeaderCustomersController : TestODataController
+    {
+        public string Get()
+        {
+            string xForwardedFor = HttpContext.Request.Headers["X-Forwarded-For"].ToString();
+            string principalId = HttpContext.Request.Headers["X-MS-Client-Principal-Id"].ToString();
+            string host = HttpContext.Request.Host.Value;
+            return $"XForwardedFor={xForwardedFor},PrincipalId={principalId},Host={host}";
+        }
+    }
+
+    public class BatchTestSecurityHeaderCustomer
     {
         public int Id { get; set; }
     }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchReaderExtensionsTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Batch/ODataBatchReaderExtensionsTest.cs
@@ -7,6 +7,7 @@
 
 #if !NETCORE // TODO #939: Enable these test on AspNetCore.
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -82,6 +83,82 @@ namespace Microsoft.AspNet.OData.Test.Batch
                 () => ODataBatchReaderExtensions.ReadChangeSetOperationRequestAsync(reader.CreateODataBatchReader(),
                     Guid.NewGuid(), Guid.NewGuid(), false, CancellationToken.None),
                 "The current batch reader state 'Initial' is invalid. The expected state is 'Operation'.");
+        }
+
+        [Fact]
+        public async Task ParseBatchRequestsAsync_DoesNotCopyBlockedHeaders()
+        {
+            string batchBoundary = "batch_" + Guid.NewGuid();
+            string batchContent = $@"
+--{batchBoundary}
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+GET http://localhost/odata/Customers HTTP/1.1
+Host: other.example.com
+Authorization: Bearer test-token
+X-Forwarded-For: 10.0.0.1
+X-MS-Client-Principal-Id: test-user-id
+X-Custom-Header: retained
+
+
+--{batchBoundary}--
+";
+            HttpRequestMessage batchRequest = new HttpRequestMessage(HttpMethod.Post, "http://localhost/$batch");
+            batchRequest.Content = new StringContent(batchContent);
+            batchRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse($"multipart/mixed;boundary={batchBoundary}");
+            batchRequest.EnableHttpDependencyInjectionSupport();
+
+            DefaultODataBatchHandler handler = new DefaultODataBatchHandler(new System.Web.Http.HttpServer());
+            IList<ODataBatchRequestItem> requests = await handler.ParseBatchRequestsAsync(batchRequest, CancellationToken.None);
+
+            HttpRequestMessage subRequest = Assert.IsType<OperationRequestItem>(Assert.Single(requests)).Request;
+            Assert.Null(subRequest.Headers.Host);
+            Assert.False(subRequest.Headers.Contains("Authorization"));
+            Assert.False(subRequest.Headers.Contains("X-Forwarded-For"));
+            Assert.False(subRequest.Headers.Contains("X-MS-Client-Principal-Id"));
+            Assert.Equal("retained", Assert.Single(subRequest.Headers.GetValues("X-Custom-Header")));
+        }
+
+        [Fact]
+        public void ValidateRequestUri_Throws_WhenAuthorityDiffers()
+        {
+            ExceptionAssert.Throws<InvalidOperationException>(
+                () => ODataBatchReaderExtensions.ValidateRequestUri(
+                    new Uri("https://other.example.com/odata/Customers"),
+                    new Uri("http://localhost/odata/")),
+                "The batch sub-request URI 'https://other.example.com/odata/Customers' has a different authority",
+                partialMatch: true);
+        }
+
+        [Fact]
+        public void ValidateRequestUri_Throws_WhenPathIsOutsideServiceRoot()
+        {
+            ExceptionAssert.Throws<InvalidOperationException>(
+                () => ODataBatchReaderExtensions.ValidateRequestUri(
+                    new Uri("http://localhost/odata-admin/Customers"),
+                    new Uri("http://localhost/odata/")),
+                "The batch sub-request URI 'http://localhost/odata-admin/Customers' targets a path that is not within the OData service root",
+                partialMatch: true);
+        }
+
+        [Fact]
+        public async Task SendMessageAsync_Throws_WhenContentIdResolutionEscapesServiceRoot()
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "$1/../../../admin/control");
+            request.SetODataBatchServiceRoot(new Uri("http://localhost/odata/"));
+            IDictionary<string, string> contentIdMapping = new Dictionary<string, string>
+            {
+                { "1", "http://localhost/odata/Orders(1)" }
+            };
+
+            using (HttpMessageInvoker invoker = new HttpMessageInvoker(new HttpClientHandler()))
+            {
+                await ExceptionAssert.ThrowsAsync<InvalidOperationException>(
+                    () => ODataBatchRequestItem.SendMessageAsync(invoker, request, CancellationToken.None, contentIdMapping),
+                    "targets a path that is not within the OData service root",
+                    partialMatch: true);
+            }
         }
 
         private static ODataMessageQuotas _odataMessageQuotas = new ODataMessageQuotas { MaxReceivedMessageSize = ODataMessageSizeOptions.DefaultMaxReceivedMessageSize };

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/DefaultSkipTokenHandlerTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/DefaultSkipTokenHandlerTests.cs
@@ -7,7 +7,12 @@
 
 #if NETCORE
 using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Microsoft.AspNet.OData.Builder;
 using Microsoft.AspNet.OData.Formatter.Serialization;
+using Microsoft.AspNet.OData.Query;
 using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
 using Microsoft.OData.Edm;
@@ -17,9 +22,13 @@ using ODataPath = Microsoft.AspNet.OData.Routing.ODataPath;
 #else
 using System;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
 using System.Web.Http.Routing;
+using Microsoft.AspNet.OData.Builder;
 using Microsoft.AspNet.OData.Formatter;
 using Microsoft.AspNet.OData.Formatter.Serialization;
+using Microsoft.AspNet.OData.Query;
 using Microsoft.AspNet.OData.Test.Abstraction;
 using Microsoft.AspNet.OData.Test.Common;
 using Microsoft.OData.Edm;
@@ -30,6 +39,34 @@ using ODataPath = Microsoft.AspNet.OData.Routing.ODataPath;
 
 namespace Microsoft.AspNet.OData.Test.Query
 {
+    [DataContract]
+    public enum SkipTokenTestAliasedGender
+    {
+        [EnumMember(Value = "M")]
+        Male,
+        [EnumMember(Value = "F")]
+        Female
+    }
+
+    // Wrapper class exists purely so SkipTokenTestGender is a nested enum: its CLR
+    // FullName contains a '+' (nested-type) separator, which reproduces the bug where
+    // the generated skiptoken value used the CLR FullName instead of the EDM type name.
+    public class SkipTokenTestGenderContainer
+    {
+        public enum SkipTokenTestGender
+        {
+            Male,
+            Female
+        }
+    }
+
+    public class SkipTokenEnumCustomer
+    {
+        public int Id { get; set; }
+        public SkipTokenTestGenderContainer.SkipTokenTestGender Gender { get; set; }
+        public SkipTokenTestAliasedGender AliasedGender { get; set; }
+    }
+
     public class DefaultSkipTokenHandlerTests
     {
         [Theory]
@@ -65,6 +102,57 @@ namespace Microsoft.AspNet.OData.Test.Query
             ResourceContext resource = new ResourceContext();
             ODataSerializerContext context = new ODataSerializerContext(resource, edmProperty, queryContext, null);
             return context;
-        }        
+        }
+
+        [Fact]
+        public void GenerateSkipTokenValue_UsesEdmEnumTypeName_NotClrFullName_ForEnumProperty()
+        {
+            // Arrange
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<SkipTokenEnumCustomer>("Customers");
+            IEdmModel model = builder.GetEdmModel();
+            IEdmEntityType customerType = model.SchemaElements.OfType<IEdmEntityType>().Single(t => t.Name == "SkipTokenEnumCustomer");
+            IEdmProperty genderProperty = customerType.FindProperty("Gender");
+
+            SkipTokenEnumCustomer instance = new SkipTokenEnumCustomer { Id = 1, Gender = SkipTokenTestGenderContainer.SkipTokenTestGender.Male };
+            OrderByPropertyNode orderByNode = new OrderByPropertyNode(genderProperty, OrderByDirection.Ascending);
+
+            // Act
+            string skipTokenValue = InvokeGenerateSkipTokenValue(instance, model, new[] { orderByNode });
+
+            // Assert: EDM type name is used (dot-separated), not the CLR FullName ('+'-separated).
+            Assert.Contains("Gender-", skipTokenValue);
+            Assert.Contains(".SkipTokenTestGender%27Male%27", skipTokenValue);
+            Assert.DoesNotContain("%2B", skipTokenValue, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void GenerateSkipTokenValue_UsesEdmMemberAlias_ForEnumMemberAnnotatedProperty()
+        {
+            // Arrange
+            ODataConventionModelBuilder builder = new ODataConventionModelBuilder();
+            builder.EntitySet<SkipTokenEnumCustomer>("Customers");
+            IEdmModel model = builder.GetEdmModel();
+            IEdmEntityType customerType = model.SchemaElements.OfType<IEdmEntityType>().Single(t => t.Name == "SkipTokenEnumCustomer");
+            IEdmProperty aliasedGenderProperty = customerType.FindProperty("AliasedGender");
+
+            SkipTokenEnumCustomer instance = new SkipTokenEnumCustomer { Id = 1, AliasedGender = SkipTokenTestAliasedGender.Male };
+            OrderByPropertyNode orderByNode = new OrderByPropertyNode(aliasedGenderProperty, OrderByDirection.Ascending);
+
+            // Act
+            string skipTokenValue = InvokeGenerateSkipTokenValue(instance, model, new[] { orderByNode });
+
+            // Assert: the EDM alias 'M' (from [EnumMember(Value = "M")]) is used, not the CLR name 'Male'.
+            Assert.Contains("AliasedGender-", skipTokenValue);
+            Assert.Contains("%27M%27", skipTokenValue);
+            Assert.DoesNotContain("%27Male%27", skipTokenValue);
+        }
+
+        private static string InvokeGenerateSkipTokenValue(object lastMember, IEdmModel model, OrderByNode[] orderByNodes)
+        {
+            MethodInfo method = typeof(DefaultSkipTokenHandler).GetMethod(
+                "GenerateSkipTokenValue", BindingFlags.NonPublic | BindingFlags.Static);
+            return (string)method.Invoke(null, new object[] { lastMember, model, orderByNodes });
+        }
     }
 }

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/FilterBinderTests.cs
@@ -3022,6 +3022,77 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Theory]
+        [InlineData("BoolProp gt false", true)]
+        [InlineData("BoolProp gt true", false)]
+        [InlineData("BoolProp lt true", false)]
+        [InlineData("BoolProp ge true", true)]
+        [InlineData("BoolProp le false", false)]
+        public void FilterWithOrderingOperators_OnNonNullableBoolProperty_DoesNotThrow(string filter, bool expectedResult)
+        {
+            // .NET expression trees do not define gt/ge/lt/le operators for bool. Before the fix,
+            // CreateBinaryExpression would let these reach Expression.MakeBinary unconverted, which
+            // throws InvalidOperationException("The binary operator GreaterThan is not defined for
+            // the types 'System.Boolean' and 'System.Boolean'.").
+            var filters = VerifyQueryDeserialization<DataTypes>(filter);
+
+            RunFilters(
+                filters,
+                new DataTypes { BoolProp = true },
+                new { WithNullPropagation = expectedResult, WithoutNullPropagation = expectedResult });
+        }
+
+        [Theory]
+        [InlineData("NullableBoolProp gt false", true)]
+        [InlineData("NullableBoolProp lt true", false)]
+        public void FilterWithOrderingOperators_OnNullableBoolProperty_DoesNotThrow(string filter, bool expectedResult)
+        {
+            var filters = VerifyQueryDeserialization<DataTypes>(filter);
+
+            RunFilters(
+                filters,
+                new DataTypes { NullableBoolProp = true },
+                new { WithNullPropagation = expectedResult, WithoutNullPropagation = expectedResult });
+        }
+
+        [Theory]
+        [InlineData(BinaryOperatorKind.GreaterThan, true, false, true)]
+        [InlineData(BinaryOperatorKind.GreaterThan, false, true, false)]
+        [InlineData(BinaryOperatorKind.LessThan, false, true, true)]
+        [InlineData(BinaryOperatorKind.LessThan, true, false, false)]
+        [InlineData(BinaryOperatorKind.GreaterThanOrEqual, true, true, true)]
+        [InlineData(BinaryOperatorKind.LessThanOrEqual, false, false, true)]
+        public void CreateBinaryExpression_WithLiftToNullTrue_OnNonNullableBoolOperands_DoesNotProduceNullableBoolResult(
+            BinaryOperatorKind binaryOperator, bool leftValue, bool rightValue, bool expectedResult)
+        {
+            // This is the exact scenario flagged in review: DefaultSkipTokenHandler.ApplyToCore
+            // passes liftToNull: !propertyIsNullable, so a non-nullable bool ordering property is
+            // compared with liftToNull: true. If BoolToIntExpression unconditionally widened both
+            // operands to int?, the GreaterThan/LessThan comparison would be *lifted* (since both
+            // operands would then be nullable), producing a bool? result. A bool?-typed expression
+            // cannot be used as the body of a Func<T, bool> predicate (e.g. for LINQ's Where, as
+            // DefaultSkipTokenHandler does via Expression.Lambda(where, param)).
+            //
+            // Verified independently that Expression.MakeBinary(GreaterThan, int, int, liftToNull:
+            // true) => type Boolean, while (int?, int?) => type Nullable<Boolean>, and mismatched
+            // (int, int?) throws - which is why only-nullable-when-needed widening is required.
+            FilterBinder binder = new FilterBinder(
+                new ODataQuerySettings { HandleNullPropagation = HandleNullPropagationOption.False },
+                WebApiAssembliesResolverFactory.Create(),
+                GetModel<DataTypes>());
+
+            Expression left = Expression.Constant(leftValue, typeof(bool));
+            Expression right = Expression.Constant(rightValue, typeof(bool));
+
+            // Act
+            Expression result = binder.CreateBinaryExpression(binaryOperator, left, right, liftToNull: true);
+
+            // Assert
+            Assert.Equal(typeof(bool), result.Type);
+            Expression<Func<bool>> lambda = Expression.Lambda<Func<bool>>(result);
+            Assert.Equal(expectedResult, lambda.Compile().Invoke());
+        }
+
+        [Theory]
         [InlineData(new[] { 1, 2, 42 }, true)]
         [InlineData(new[] { 1, 2 }, false)]
         public void InOnPrimitiveCollectionPropertyOnRHS(int[] alternateIds, bool withNullPropagation)

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandWrapperTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/SelectExpandWrapperTest.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Microsoft.AspNet.OData.Builder;
 using Microsoft.AspNet.OData.Query;
 using Microsoft.AspNet.OData.Query.Expressions;
 using Microsoft.AspNet.OData.Test.Common;
@@ -166,6 +167,133 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             bool result = wrapper.TryGetPropertyValue("SampleNotPresentProperty", out value);
 
             Assert.False(result);
+        }
+
+        [Fact]
+        public void TryGetValue_ReturnsFalse_ForClrPropertyNotDeclaredInEdmModel()
+        {
+            // Arrange: an open entity type that declares "Id" and "Name" but intentionally omits
+            // "PasswordHash", even though the backing CLR class has it.
+            EdmModel model = new EdmModel();
+            EdmEntityType entityType = new EdmEntityType("NS", "AccountEntity", null, false, isOpen: true);
+            entityType.AddKeys(entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            entityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            model.AddElement(entityType);
+            model.SetAnnotationValue(entityType, new ClrTypeAnnotation(typeof(AccountEntity)));
+
+            SelectExpandWrapper<AccountEntity> wrapper = new SelectExpandWrapper<AccountEntity>
+            {
+                ModelID = ModelContainer.GetModelID(model),
+                InstanceType = "NS.AccountEntity",
+                Instance = new AccountEntity { Id = 1, Name = "Alice", PasswordHash = "clr-only-value" },
+                UseInstanceForProperties = true,
+            };
+
+            // Act: request the CLR-only property that is not declared in the EDM model.
+            object value;
+            bool result = wrapper.TryGetPropertyValue("PasswordHash", out value);
+
+            // Assert: the CLR fallback must not resolve the undeclared property.
+            Assert.False(result);
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void TryGetValue_ReturnsTrue_ForClrPropertyDeclaredInEdmModel_OnOpenType()
+        {
+            // Arrange: same open entity type as above, but requesting the declared "Name" property
+            // must continue to work via the CLR instance fallback.
+            EdmModel model = new EdmModel();
+            EdmEntityType entityType = new EdmEntityType("NS", "AccountEntity", null, false, isOpen: true);
+            entityType.AddKeys(entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            entityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            model.AddElement(entityType);
+            model.SetAnnotationValue(entityType, new ClrTypeAnnotation(typeof(AccountEntity)));
+
+            SelectExpandWrapper<AccountEntity> wrapper = new SelectExpandWrapper<AccountEntity>
+            {
+                ModelID = ModelContainer.GetModelID(model),
+                InstanceType = "NS.AccountEntity",
+                Instance = new AccountEntity { Id = 1, Name = "Alice", PasswordHash = "clr-only-value" },
+                UseInstanceForProperties = true,
+            };
+
+            // Act
+            object value;
+            bool result = wrapper.TryGetPropertyValue("Name", out value);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("Alice", value);
+        }
+
+        [Fact]
+        public void TryGetValue_ReturnsTrue_ForDynamicPropertyDictionary_OnOpenType()
+        {
+            // Arrange: an open entity type whose dynamic-property container ("DynamicProperties")
+            // is annotated on the model. Undeclared property names stored inside this bag must
+            // still be reachable through the container/dictionary lookup, not through CLR reflection
+            // of the "PasswordHash" property.
+            EdmModel model = new EdmModel();
+            EdmEntityType entityType = new EdmEntityType("NS", "AccountEntity", null, false, isOpen: true);
+            entityType.AddKeys(entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            entityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            model.AddElement(entityType);
+            model.SetAnnotationValue(entityType, new ClrTypeAnnotation(typeof(AccountEntity)));
+            model.SetAnnotationValue(
+                entityType,
+                new DynamicPropertyDictionaryAnnotation(typeof(AccountEntity).GetProperty("DynamicProperties")));
+
+            SelectExpandWrapper<AccountEntity> wrapper = new SelectExpandWrapper<AccountEntity>
+            {
+                ModelID = ModelContainer.GetModelID(model),
+                InstanceType = "NS.AccountEntity",
+                Instance = new AccountEntity { Id = 1, Name = "Alice", PasswordHash = "clr-only-value" },
+                UseInstanceForProperties = true,
+            };
+
+            // Act: request the container property itself (not an arbitrary undeclared name).
+            object value;
+            bool result = wrapper.TryGetPropertyValue("DynamicProperties", out value);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void TryGetValue_ReturnsFalse_ForNavigationPropertyNotInContainer_OnOpenType()
+        {
+            // Arrange: an open entity type that declares "Manager" as a *navigation* property.
+            // Navigation properties are not structural, so a declared navigation property that is
+            // absent from the container must not reach the CLR reflection fallback.
+            EdmModel model = new EdmModel();
+            EdmEntityType entityType = new EdmEntityType("NS", "AccountEntity", null, false, isOpen: true);
+            entityType.AddKeys(entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            entityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            entityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+            {
+                Name = "Manager",
+                TargetMultiplicity = EdmMultiplicity.ZeroOrOne,
+                Target = entityType,
+            });
+            model.AddElement(entityType);
+            model.SetAnnotationValue(entityType, new ClrTypeAnnotation(typeof(AccountEntity)));
+
+            SelectExpandWrapper<AccountEntity> wrapper = new SelectExpandWrapper<AccountEntity>
+            {
+                ModelID = ModelContainer.GetModelID(model),
+                InstanceType = "NS.AccountEntity",
+                Instance = new AccountEntity { Id = 1, Name = "Alice", Manager = new AccountEntity { Id = 2, Name = "Bob" } },
+                UseInstanceForProperties = true,
+            };
+
+            // Act: request the declared navigation property that is not present in the container.
+            object value;
+            bool result = wrapper.TryGetPropertyValue("Manager", out value);
+
+            // Assert: the CLR fallback must not resolve the navigation property.
+            Assert.False(result);
+            Assert.Null(value);
         }
 
         [Fact]
@@ -342,6 +470,22 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
 
         private class DerivedEntity : TestEntity
         {
+        }
+
+        // CLR class backing an open EDM entity type used to verify that CLR properties
+        // excluded from the EDM model (e.g. via [NotMapped] or .Ignore()) are not resolved
+        // through the SelectExpandWrapper CLR reflection fallback.
+        private class AccountEntity
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public IDictionary<string, object> DynamicProperties { get; set; }
+
+            // Declared as a navigation property in the EDM model (not a structural property).
+            public AccountEntity Manager { get; set; }
+
+            // Intentionally omitted from the EDM model in the tests above.
+            public string PasswordHash { get; set; }
         }
 
         [DataContract(Namespace = "NS", Name = "Customer")]


### PR DESCRIPTION
## Summary

- align property lookup with EDM model definitions across ASP.NET and ASP.NET Core
- improve OData batch sub-request URI and header handling across both frameworks
- correct skip-token enum serialization and Boolean ordering behavior across both frameworks
- add regression coverage for the updated scenarios

## Testing

- ASP.NET solution build completed successfully with code analysis
- ASP.NET: 9,070 passed, 4 skipped
- ASP.NET Core `netcoreapp2.1`: 8,469 passed, 4 skipped
- ASP.NET Core `netcoreapp3.1`: 8,531 passed, 4 skipped