### PR TITLE
Add opt-in diagnostic logging for OData query validation failures

### DIFF
--- a/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
@@ -23,6 +23,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
@@ -44,6 +46,26 @@ namespace Microsoft.AspNet.OData
         // and those of the v3 assembly.  Concern is reduced here due to addition of user type name but prefix
         // also clearly ties the property to code in this assembly.
         private const string ModelKeyPrefix = "Microsoft.AspNet.OData.Model+";
+
+        private bool? _enableQueryValidationErrorLogging;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether diagnostic details are recorded when an incoming query
+        /// fails validation. When enabled, the endpoint's route template, the queried type, the attempted
+        /// <c>$select</c> and <c>$expand</c> options, and the failure reason are written, together with the
+        /// validation exception, to an <see cref="ILogger{TCategoryName}"/> resolved from the request services
+        /// and categorized for <see cref="EnableQueryAttribute"/>. This information is captured from the request
+        /// even when the query options cannot be fully parsed. When this property is not set on the attribute,
+        /// the value of <see cref="ODataOptions.EnableQueryValidationErrorLogging"/> is used, so the behavior can be
+        /// configured once for all actions; setting it here overrides that global value for this action. The
+        /// diagnostic is written at the level from <see cref="ODataOptions.QueryValidationErrorLogLevel"/>
+        /// (default <see cref="LogLevel.Warning"/>). The default value is <c>false</c>.
+        /// </summary>
+        public bool EnableQueryValidationErrorLogging
+        {
+            get => _enableQueryValidationErrorLogging ?? false;
+            set => _enableQueryValidationErrorLogging = value;
+        }
 
         /// <summary>
         /// Performs query validations before action is executed.
@@ -199,18 +221,21 @@ namespace Microsoft.AspNet.OData
             catch (ArgumentOutOfRangeException e)
             {
                 context.Result = CreateBadRequestResult(
+                    context.HttpContext,
                     Error.Format(SRResources.QueryParameterNotSupported, e.Message),
                     e);
             }
             catch (NotImplementedException e)
             {
                 context.Result = CreateBadRequestResult(
+                    context.HttpContext,
                     Error.Format(SRResources.UriQueryStringInvalid, e.Message),
                     e);
             }
             catch (NotSupportedException e)
             {
                 context.Result = CreateBadRequestResult(
+                    context.HttpContext,
                     Error.Format(SRResources.UriQueryStringInvalid, e.Message),
                     e);
             }
@@ -218,6 +243,7 @@ namespace Microsoft.AspNet.OData
             {
                 // Will also catch ODataException here because ODataException derives from InvalidOperationException.
                 context.Result = CreateBadRequestResult(
+                    context.HttpContext,
                     Error.Format(SRResources.UriQueryStringInvalid, e.Message),
                     e);
             }
@@ -290,7 +316,7 @@ namespace Microsoft.AspNet.OData
                         (elementClrType) => GetModel(elementClrType, request, actionDescriptor),
                         (queryContext) => CreateAndValidateQueryOptions(request, queryContext),
                         (statusCode) => actionExecutedContext.Result = new StatusCodeResult((int)statusCode),
-                        (statusCode, message, exception) => actionExecutedContext.Result = CreateBadRequestResult(message, exception));
+                        (statusCode, message, exception) => actionExecutedContext.Result = CreateBadRequestResult(actionExecutedContext.HttpContext, message, exception));
 
                     if (queryResult != null)
                     {
@@ -341,6 +367,13 @@ namespace Microsoft.AspNet.OData
 
             ODataQueryOptions queryOptions = new ODataQueryOptions(queryContext, request);
 
+            if (requestQueryData != null)
+            {
+                // Capture the options so diagnostics on the post-action validation path can report the element
+                // type and the attempted query, consistent with the pre-action path.
+                requestQueryData.ProcessedQueryOptions = queryOptions;
+            }
+
             ValidateQuery(request, queryOptions);
 
             return queryOptions;
@@ -390,13 +423,65 @@ namespace Microsoft.AspNet.OData
         /// <summary>
         /// Create a BadRequestObjectResult.
         /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
         /// <param name="message">The error message.</param>
         /// <param name="exception">The exception.</param>
         /// <returns>A BadRequestObjectResult.</returns>
-        private static BadRequestObjectResult CreateBadRequestResult(string message, Exception exception)
+        private BadRequestObjectResult CreateBadRequestResult(HttpContext httpContext, string message, Exception exception)
         {
+            LogQueryValidationError(httpContext, exception);
+
             SerializableError error = CreateErrorResponse(message, exception);
             return new BadRequestObjectResult(error);
+        }
+
+        /// <summary>
+        /// Records diagnostic details about a query that failed validation, using the request state that is
+        /// available even when the query options could not be fully parsed. Does nothing unless logging is
+        /// enabled for the action — either on the attribute or through the global
+        /// <see cref="ODataOptions.EnableQueryValidationErrorLogging"/> value — and a logger is available. The
+        /// diagnostic is written at the level from the global <see cref="ODataOptions.QueryValidationErrorLogLevel"/>
+        /// (default <see cref="LogLevel.Warning"/>). This never changes the response produced for the failed query.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+        /// <param name="exception">The exception raised while validating the query.</param>
+        private void LogQueryValidationError(HttpContext httpContext, Exception exception)
+        {
+            if (httpContext == null)
+            {
+                return;
+            }
+
+            // When the attribute does not set the flag, fall back to the global value from ODataOptions so the
+            // behavior can be configured once for all actions. An explicit value on the attribute takes precedence.
+            ODataOptions odataOptions = httpContext.RequestServices?.GetService<ODataOptions>();
+            bool loggingEnabled = _enableQueryValidationErrorLogging ?? odataOptions?.EnableQueryValidationErrorLogging ?? false;
+            if (!loggingEnabled)
+            {
+                return;
+            }
+
+            ILogger logger = httpContext.RequestServices?.GetService<ILogger<EnableQueryAttribute>>();
+            if (logger == null)
+            {
+                return;
+            }
+
+            // The global level from ODataOptions applies, defaulting to Warning when it is not configured.
+            LogLevel logLevel = odataOptions?.QueryValidationErrorLogLevel ?? LogLevel.Warning;
+
+            // The processed query options are captured before validation runs; they carry the raw values that were
+            // normalized during parsing, so the requested set is reported regardless of whether the request used the
+            // '$' prefix. They may be null when the query options could not be built, in which case the element type
+            // and requested options are omitted.
+            ODataQueryOptions processedQueryOptions = null;
+            if (httpContext.Items.TryGetValue(nameof(RequestQueryData), out object item) &&
+                item is RequestQueryData requestQueryData)
+            {
+                processedQueryOptions = requestQueryData.ProcessedQueryOptions;
+            }
+
+            QueryValidationErrorLogger.LogQueryValidationFailure(logger, logLevel, httpContext, processedQueryOptions, exception);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
@@ -50,16 +50,9 @@ namespace Microsoft.AspNet.OData
         private bool? _enableQueryValidationErrorLogging;
 
         /// <summary>
-        /// Gets or sets a value indicating whether diagnostic details are recorded when an incoming query
-        /// fails validation. When enabled, the endpoint's route template, the queried type, the attempted
-        /// <c>$select</c> and <c>$expand</c> options, and the failure reason are written, together with the
-        /// validation exception, to an <see cref="ILogger{TCategoryName}"/> resolved from the request services
-        /// and categorized for <see cref="EnableQueryAttribute"/>. This information is captured from the request
-        /// even when the query options cannot be fully parsed. When this property is not set on the attribute,
-        /// the value of <see cref="ODataOptions.EnableQueryValidationErrorLogging"/> is used, so the behavior can be
-        /// configured once for all actions; setting it here overrides that global value for this action. The
-        /// diagnostic is written at the level from <see cref="ODataOptions.QueryValidationErrorLogLevel"/>
-        /// (default <see cref="LogLevel.Warning"/>). The default value is <c>false</c>.
+        /// Gets or sets a value indicating whether diagnostic details are logged when a query fails validation.
+        /// When not set on the attribute, <see cref="ODataOptions.EnableQueryValidationErrorLogging"/> is used;
+        /// setting it here overrides that global value for this action. The default value is <c>false</c>.
         /// </summary>
         public bool EnableQueryValidationErrorLogging
         {
@@ -436,12 +429,9 @@ namespace Microsoft.AspNet.OData
         }
 
         /// <summary>
-        /// Records diagnostic details about a query that failed validation, using the request state that is
-        /// available even when the query options could not be fully parsed. Does nothing unless logging is
-        /// enabled for the action — either on the attribute or through the global
-        /// <see cref="ODataOptions.EnableQueryValidationErrorLogging"/> value — and a logger is available. The
-        /// diagnostic is written at the level from the global <see cref="ODataOptions.QueryValidationErrorLogLevel"/>
-        /// (default <see cref="LogLevel.Warning"/>). This never changes the response produced for the failed query.
+        /// Logs diagnostic details about a query that failed validation. Does nothing unless logging is enabled
+        /// (on the attribute or via <see cref="ODataOptions.EnableQueryValidationErrorLogging"/>) and a logger is
+        /// available. Never changes the response produced for the failed query.
         /// </summary>
         /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
         /// <param name="exception">The exception raised while validating the query.</param>

--- a/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
+++ b/src/Microsoft.AspNetCore.OData/EnableQueryAttribute.cs
@@ -360,12 +360,9 @@ namespace Microsoft.AspNet.OData
 
             ODataQueryOptions queryOptions = new ODataQueryOptions(queryContext, request);
 
-            if (requestQueryData != null)
-            {
-                // Capture the options so diagnostics on the post-action validation path can report the element
-                // type and the attempted query, consistent with the pre-action path.
-                requestQueryData.ProcessedQueryOptions = queryOptions;
-            }
+            // Capture the options so diagnostics on the post-action validation path can report the element
+            // type and the attempted query, consistent with the pre-action path.
+            requestQueryData.ProcessedQueryOptions = queryOptions;
 
             ValidateQuery(request, queryOptions);
 

--- a/src/Microsoft.AspNetCore.OData/ODataOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataOptions.cs
@@ -7,6 +7,7 @@
 
 using Microsoft.AspNet.OData.Batch;
 using Microsoft.AspNet.OData.Common;
+using Microsoft.Extensions.Logging;
 using Microsoft.OData;
 
 namespace Microsoft.AspNet.OData
@@ -47,6 +48,25 @@ namespace Microsoft.AspNet.OData
             get => _messageSizeOptions.MaxReceivedMessageSize;
             set => _messageSizeOptions.MaxReceivedMessageSize = value;
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether diagnostic details are recorded when an incoming query
+        /// fails validation for actions annotated with <see cref="EnableQueryAttribute"/>. When enabled, the
+        /// endpoint's route template, the queried type, the requested <c>$select</c> and <c>$expand</c>, and the failure
+        /// reason are written. This value provides the default for every such action, allowing the behavior to be
+        /// configured once instead of on each attribute; an individual <see cref="EnableQueryAttribute"/> overrides it
+        /// by setting <see cref="EnableQueryAttribute.EnableQueryValidationErrorLogging"/> explicitly. The default
+        /// value is <c>false</c>.
+        /// </summary>
+        public bool EnableQueryValidationErrorLogging { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="LogLevel"/> at which query validation diagnostics are written for actions
+        /// annotated with <see cref="EnableQueryAttribute"/> when <see cref="EnableQueryValidationErrorLogging"/> is
+        /// enabled. This value applies to every such action, so the level can be configured once. The default value is
+        /// <see cref="LogLevel.Warning"/>.
+        /// </summary>
+        public LogLevel QueryValidationErrorLogLevel { get; set; } = LogLevel.Warning;
 
         private readonly ODataMessageSizeOptions _messageSizeOptions = new ODataMessageSizeOptions();
     }

--- a/src/Microsoft.AspNetCore.OData/ODataOptions.cs
+++ b/src/Microsoft.AspNetCore.OData/ODataOptions.cs
@@ -50,21 +50,16 @@ namespace Microsoft.AspNet.OData
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether diagnostic details are recorded when an incoming query
-        /// fails validation for actions annotated with <see cref="EnableQueryAttribute"/>. When enabled, the
-        /// endpoint's route template, the queried type, the requested <c>$select</c> and <c>$expand</c>, and the failure
-        /// reason are written. This value provides the default for every such action, allowing the behavior to be
-        /// configured once instead of on each attribute; an individual <see cref="EnableQueryAttribute"/> overrides it
-        /// by setting <see cref="EnableQueryAttribute.EnableQueryValidationErrorLogging"/> explicitly. The default
-        /// value is <c>false</c>.
+        /// Gets or sets a value indicating whether diagnostic details are logged when a query fails validation,
+        /// for actions annotated with <see cref="EnableQueryAttribute"/>. Provides the default for every such
+        /// action; an individual <see cref="EnableQueryAttribute.EnableQueryValidationErrorLogging"/> overrides it.
+        /// The default value is <c>false</c>.
         /// </summary>
         public bool EnableQueryValidationErrorLogging { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="LogLevel"/> at which query validation diagnostics are written for actions
-        /// annotated with <see cref="EnableQueryAttribute"/> when <see cref="EnableQueryValidationErrorLogging"/> is
-        /// enabled. This value applies to every such action, so the level can be configured once. The default value is
-        /// <see cref="LogLevel.Warning"/>.
+        /// Gets or sets the <see cref="LogLevel"/> at which query validation diagnostics are written when
+        /// <see cref="EnableQueryValidationErrorLogging"/> is enabled. The default value is <see cref="LogLevel.Warning"/>.
         /// </summary>
         public LogLevel QueryValidationErrorLogLevel { get; set; } = LogLevel.Warning;
 

--- a/src/Microsoft.AspNetCore.OData/QueryValidationErrorLogger.cs
+++ b/src/Microsoft.AspNetCore.OData/QueryValidationErrorLogger.cs
@@ -12,6 +12,10 @@ using Microsoft.Extensions.Logging;
 using Microsoft.OData.Edm;
 #if !NETSTANDARD2_0
 using Microsoft.AspNetCore.Routing;
+#else
+using System.Collections.Generic;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.OData.UriParser;
 #endif
 
 namespace Microsoft.AspNet.OData
@@ -51,7 +55,9 @@ namespace Microsoft.AspNet.OData
                 // requests. It is null when the request is not served by a routed endpoint, in which case it is
                 // omitted.
                 string endpoint = null;
-#if !NETSTANDARD2_0
+#if NETSTANDARD2_0
+                endpoint = BuildRoutedEndpointTemplate(httpContext);
+#else
                 endpoint = (httpContext.GetEndpoint() as RouteEndpoint)?.RoutePattern?.RawText;
 #endif
 
@@ -76,6 +82,57 @@ namespace Microsoft.AspNet.OData
                 // the exception raised for the failed query are preserved unchanged.
             }
         }
+
+#if NETSTANDARD2_0
+        /// <summary>
+        /// Builds a route-template-like identifier for the matched OData endpoint on targets that predate ASP.NET
+        /// Core endpoint routing. Reconstructs the template from the parsed OData path segments, preserving entity
+        /// set, singleton, navigation, and property names while representing entity keys as the "{key}" placeholder,
+        /// so the same endpoint is reported consistently regardless of the concrete key value. This mirrors the value
+        /// produced from the endpoint's route pattern on endpoint-routing targets (for example, "odata/Customers({key})").
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+        /// <returns>
+        /// The endpoint template, or <c>null</c> when the request is not served by a routed OData endpoint.
+        /// </returns>
+        private static string BuildRoutedEndpointTemplate(HttpContext httpContext)
+        {
+            var odataFeature = httpContext.ODataFeature();
+            var path = odataFeature?.Path;
+            if (path == null || path.Segments.Count == 0)
+            {
+                return null;
+            }
+
+            List<string> parts = new List<string>(path.Segments.Count);
+            foreach (ODataPathSegment segment in path.Segments)
+            {
+                if (segment is KeySegment)
+                {
+                    // Represent the key as a placeholder and, matching the endpoint-routing template shape,
+                    // attach it to the preceding segment (for example, "Customers({key})").
+                    if (parts.Count > 0)
+                    {
+                        parts[parts.Count - 1] = parts[parts.Count - 1] + "({key})";
+                    }
+                    else
+                    {
+                        parts.Add("{key}");
+                    }
+                }
+                else
+                {
+                    // ODataPathSegment.Identifier is the segment's name (entity set, singleton, navigation
+                    // property, property, operation, $count, $value, ...), so the framework's own naming is reused.
+                    parts.Add(segment.Identifier);
+                }
+            }
+
+            string template = string.Join("/", parts);
+            string prefix = odataFeature.RoutePrefix;
+            return string.IsNullOrEmpty(prefix) ? template : string.Concat(prefix, "/", template);
+        }
+#endif
 
         /// <summary>
         /// Builds a compact description of the supplied <c>$select</c>/<c>$expand</c> options, omitting empty ones.

--- a/src/Microsoft.AspNetCore.OData/QueryValidationErrorLogger.cs
+++ b/src/Microsoft.AspNetCore.OData/QueryValidationErrorLogger.cs
@@ -13,16 +13,17 @@ using Microsoft.OData.Edm;
 #if !NETSTANDARD2_0
 using Microsoft.AspNetCore.Routing;
 #else
-using System.Collections.Generic;
+using System.Text;
 using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Interfaces;
 using Microsoft.OData.UriParser;
+using ODataPath = Microsoft.AspNet.OData.Routing.ODataPath;
 #endif
 
 namespace Microsoft.AspNet.OData
 {
     /// <summary>
-    /// Writes structured diagnostics about a query that failed validation. Shared by the
-    /// <see cref="EnableQueryAttribute"/> validation paths, and never changes the response produced for the query.
+    /// Writes structured diagnostics for a query that failed validation, without changing the response.
     /// </summary>
     internal static class QueryValidationErrorLogger
     {
@@ -30,8 +31,7 @@ namespace Microsoft.AspNet.OData
             "OData query validation failed. Endpoint: {Endpoint}, Type: {QueryType}, Query options: {QueryOptions}. {Reason}";
 
         /// <summary>
-        /// Writes the diagnostic entry for a failed query validation at the specified level. Does nothing when no
-        /// logger is available or the level is not enabled.
+        /// Writes the diagnostic for a failed query validation, or does nothing when the logger or level is disabled.
         /// </summary>
         /// <param name="logger">The logger to write to, or <c>null</c> when none is available.</param>
         /// <param name="logLevel">The level at which the diagnostic is written.</param>
@@ -50,10 +50,7 @@ namespace Microsoft.AspNet.OData
             try
             {
                 // Record the matched endpoint's route template (for example, "odata/Customers({key})") rather than
-                // the concrete request path. The template identifies the endpoint and keeps the route prefix while
-                // representing entity keys as placeholders, so the same endpoint is reported consistently across
-                // requests. It is null when the request is not served by a routed endpoint, in which case it is
-                // omitted.
+                // the concrete request path, so the same endpoint is reported consistently. Null when not routed.
                 string endpoint = null;
 #if NETSTANDARD2_0
                 endpoint = BuildRoutedEndpointTemplate(httpContext);
@@ -85,52 +82,49 @@ namespace Microsoft.AspNet.OData
 
 #if NETSTANDARD2_0
         /// <summary>
-        /// Builds a route-template-like identifier for the matched OData endpoint on targets that predate ASP.NET
-        /// Core endpoint routing. Reconstructs the template from the parsed OData path segments, preserving entity
-        /// set, singleton, navigation, and property names while representing entity keys as the "{key}" placeholder,
-        /// so the same endpoint is reported consistently regardless of the concrete key value. This mirrors the value
-        /// produced from the endpoint's route pattern on endpoint-routing targets (for example, "odata/Customers({key})").
+        /// Reconstructs the matched OData endpoint's route template from the parsed path on targets without endpoint
+        /// routing, using "{key}" placeholders for entity keys (for example, "odata/Customers({key})").
         /// </summary>
         /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
-        /// <returns>
-        /// The endpoint template, or <c>null</c> when the request is not served by a routed OData endpoint.
-        /// </returns>
+        /// <returns>The endpoint template, or <c>null</c> when the request is not served by a routed OData endpoint.</returns>
         private static string BuildRoutedEndpointTemplate(HttpContext httpContext)
         {
-            var odataFeature = httpContext.ODataFeature();
-            var path = odataFeature?.Path;
+            IODataFeature odataFeature = httpContext.ODataFeature();
+            ODataPath path = odataFeature?.Path;
             if (path == null || path.Segments.Count == 0)
             {
                 return null;
             }
 
-            List<string> parts = new List<string>(path.Segments.Count);
+            StringBuilder template = new StringBuilder();
             foreach (ODataPathSegment segment in path.Segments)
             {
                 if (segment is KeySegment)
                 {
-                    // Represent the key as a placeholder and, matching the endpoint-routing template shape,
-                    // attach it to the preceding segment (for example, "Customers({key})").
-                    if (parts.Count > 0)
-                    {
-                        parts[parts.Count - 1] = parts[parts.Count - 1] + "({key})";
-                    }
-                    else
-                    {
-                        parts.Add("{key}");
-                    }
+                    // Attach the key placeholder to the preceding segment (for example, "Customers({key})"). A
+                    // routed OData path never starts with a key; the bare placeholder is a defensive fallback.
+                    template.Append(template.Length == 0 ? "{key}" : "({key})");
                 }
                 else
                 {
-                    // ODataPathSegment.Identifier is the segment's name (entity set, singleton, navigation
-                    // property, property, operation, $count, $value, ...), so the framework's own naming is reused.
-                    parts.Add(segment.Identifier);
+                    // ODataPathSegment.Identifier is the segment's own name (entity set, navigation property, etc.).
+                    if (template.Length != 0)
+                    {
+                        template.Append('/');
+                    }
+
+                    template.Append(segment.Identifier);
                 }
             }
 
-            string template = string.Join("/", parts);
             string prefix = odataFeature.RoutePrefix;
-            return string.IsNullOrEmpty(prefix) ? template : string.Concat(prefix, "/", template);
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                // The route prefix precedes the first segment (for example, "odata/Customers({key})").
+                template.Insert(0, '/').Insert(0, prefix);
+            }
+
+            return template.ToString();
         }
 #endif
 

--- a/src/Microsoft.AspNetCore.OData/QueryValidationErrorLogger.cs
+++ b/src/Microsoft.AspNetCore.OData/QueryValidationErrorLogger.cs
@@ -17,10 +17,8 @@ using Microsoft.AspNetCore.Routing;
 namespace Microsoft.AspNet.OData
 {
     /// <summary>
-    /// Writes structured diagnostics about a query that failed validation, using request state that is available
-    /// even when the query options could not be fully parsed. This is shared by the controller
-    /// (<see cref="EnableQueryAttribute"/>) validation paths so they report the same information. It never changes
-    /// the response produced for the failed query.
+    /// Writes structured diagnostics about a query that failed validation. Shared by the
+    /// <see cref="EnableQueryAttribute"/> validation paths, and never changes the response produced for the query.
     /// </summary>
     internal static class QueryValidationErrorLogger
     {
@@ -80,8 +78,7 @@ namespace Microsoft.AspNet.OData
         }
 
         /// <summary>
-        /// Builds a compact description of the requested query options that reference properties, including only
-        /// the options that were supplied so empty options are not reported.
+        /// Builds a compact description of the supplied <c>$select</c>/<c>$expand</c> options, omitting empty ones.
         /// </summary>
         /// <param name="rawValues">The raw query option values, or <c>null</c> when unavailable.</param>
         /// <returns>The requested query options, or an empty string when none apply.</returns>

--- a/src/Microsoft.AspNetCore.OData/QueryValidationErrorLogger.cs
+++ b/src/Microsoft.AspNetCore.OData/QueryValidationErrorLogger.cs
@@ -1,0 +1,116 @@
+//-----------------------------------------------------------------------------
+// <copyright file="QueryValidationErrorLogger.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.AspNet.OData.Query;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.OData.Edm;
+#if !NETSTANDARD2_0
+using Microsoft.AspNetCore.Routing;
+#endif
+
+namespace Microsoft.AspNet.OData
+{
+    /// <summary>
+    /// Writes structured diagnostics about a query that failed validation, using request state that is available
+    /// even when the query options could not be fully parsed. This is shared by the controller
+    /// (<see cref="EnableQueryAttribute"/>) validation paths so they report the same information. It never changes
+    /// the response produced for the failed query.
+    /// </summary>
+    internal static class QueryValidationErrorLogger
+    {
+        private const string MessageTemplate =
+            "OData query validation failed. Endpoint: {Endpoint}, Type: {QueryType}, Query options: {QueryOptions}. {Reason}";
+
+        /// <summary>
+        /// Writes the diagnostic entry for a failed query validation at the specified level. Does nothing when no
+        /// logger is available or the level is not enabled.
+        /// </summary>
+        /// <param name="logger">The logger to write to, or <c>null</c> when none is available.</param>
+        /// <param name="logLevel">The level at which the diagnostic is written.</param>
+        /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+        /// <param name="processedQueryOptions">
+        /// The query options captured before validation ran, or <c>null</c> when they could not be built.
+        /// </param>
+        /// <param name="exception">The exception raised while validating the query.</param>
+        internal static void LogQueryValidationFailure(ILogger logger, LogLevel logLevel, HttpContext httpContext, ODataQueryOptions processedQueryOptions, Exception exception)
+        {
+            if (logger == null || httpContext == null || !logger.IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            try
+            {
+                // Record the matched endpoint's route template (for example, "odata/Customers({key})") rather than
+                // the concrete request path. The template identifies the endpoint and keeps the route prefix while
+                // representing entity keys as placeholders, so the same endpoint is reported consistently across
+                // requests. It is null when the request is not served by a routed endpoint, in which case it is
+                // omitted.
+                string endpoint = null;
+#if !NETSTANDARD2_0
+                endpoint = (httpContext.GetEndpoint() as RouteEndpoint)?.RoutePattern?.RawText;
+#endif
+
+                // Use LoggerMessage.Define so the diagnostic is written with named, structured values on every
+                // supported target (the generic ILogger.Log overloads are not available on all of them). The
+                // dynamic level from configuration is baked into the delegate here.
+                Action<ILogger, string, string, string, string, Exception> log =
+                    LoggerMessage.Define<string, string, string, string>(logLevel, default(EventId), MessageTemplate);
+
+                log(
+                    logger,
+                    endpoint,
+                    processedQueryOptions?.Context?.ElementType?.FullTypeName(),
+                    FormatRequestedQueryOptions(processedQueryOptions?.RawValues),
+                    exception?.Message,
+                    exception);
+            }
+            catch (Exception)
+            {
+                // Recording the diagnostic must never change the request outcome. If the configured logging
+                // provider throws while writing this entry, suppress it so the original validation response and
+                // the exception raised for the failed query are preserved unchanged.
+            }
+        }
+
+        /// <summary>
+        /// Builds a compact description of the requested query options that reference properties, including only
+        /// the options that were supplied so empty options are not reported.
+        /// </summary>
+        /// <param name="rawValues">The raw query option values, or <c>null</c> when unavailable.</param>
+        /// <returns>The requested query options, or an empty string when none apply.</returns>
+        private static string FormatRequestedQueryOptions(ODataRawQueryOptions rawValues)
+        {
+            if (rawValues == null)
+            {
+                return string.Empty;
+            }
+
+            bool hasSelect = !string.IsNullOrEmpty(rawValues.Select);
+            bool hasExpand = !string.IsNullOrEmpty(rawValues.Expand);
+
+            if (hasSelect && hasExpand)
+            {
+                return string.Concat("$select=", rawValues.Select, "&$expand=", rawValues.Expand);
+            }
+
+            if (hasSelect)
+            {
+                return string.Concat("$select=", rawValues.Select);
+            }
+
+            if (hasExpand)
+            {
+                return string.Concat("$expand=", rawValues.Expand);
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Microsoft.AspNet.OData.Test.Shared.projitems
@@ -340,6 +340,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Routing\ODataSingletonRoutingTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Routing\ODataValueProviderFactoryTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Routing\ODataVersionConstraintTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestCommon\CapturingLoggerProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestCommon\ThrowingLoggerProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestCommon\CustomersModelWithInheritance.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestCommon\Models\SampleEdmModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestCommon\TestControllerBase.cs" />

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/EnableQueryAttributeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/EnableQueryAttributeTest.cs
@@ -433,6 +433,101 @@ namespace Microsoft.AspNet.OData.Test.Query
             Assert.Contains("NoSuchNavigation", entry.GetFieldValue("Reason"));
         }
 
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_NestedExpandSelect_UnknownProperty_WritesDiagnostic()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$expand=Orders($select=NoSuchOrderProperty)",
+                BuildLoggerServices(loggerProvider),
+                collectionEndpoint: true,
+                model: GetLoggingCustomerOrdersModel());
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal(LogLevel.Warning, entry.Level);
+            Assert.Equal("odata/Customers", entry.GetFieldValue("Endpoint"));
+            Assert.Equal("$expand=Orders($select=NoSuchOrderProperty)", entry.GetFieldValue("QueryOptions"));
+            Assert.Contains("NoSuchOrderProperty", entry.GetFieldValue("Reason"));
+            Assert.NotNull(entry.Exception);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_NestedExpandFilter_UnknownProperty_WritesDiagnostic()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$expand=Orders($filter=NoSuchOrderProperty eq 1)",
+                BuildLoggerServices(loggerProvider),
+                collectionEndpoint: true,
+                model: GetLoggingCustomerOrdersModel());
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal("odata/Customers", entry.GetFieldValue("Endpoint"));
+            Assert.Equal("$expand=Orders($filter=NoSuchOrderProperty eq 1)", entry.GetFieldValue("QueryOptions"));
+            Assert.Contains("NoSuchOrderProperty", entry.GetFieldValue("Reason"));
+            Assert.NotNull(entry.Exception);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_AnyLambdaFilter_UnknownProperty_WritesDiagnostic()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$filter=Orders/any(o: o/NoSuchOrderProperty eq 1)",
+                BuildLoggerServices(loggerProvider),
+                collectionEndpoint: true,
+                model: GetLoggingCustomerOrdersModel());
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal("odata/Customers", entry.GetFieldValue("Endpoint"));
+            Assert.Contains("NoSuchOrderProperty", entry.GetFieldValue("Reason"));
+            Assert.NotNull(entry.Exception);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_AllLambdaFilter_UnknownProperty_WritesDiagnostic()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$filter=Orders/all(o: o/NoSuchOrderProperty eq 1)",
+                BuildLoggerServices(loggerProvider),
+                collectionEndpoint: true,
+                model: GetLoggingCustomerOrdersModel());
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal("odata/Customers", entry.GetFieldValue("Endpoint"));
+            Assert.Contains("NoSuchOrderProperty", entry.GetFieldValue("Reason"));
+            Assert.NotNull(entry.Exception);
+        }
+
 #if !NETCOREAPP2_1
         [Fact]
         public void OnActionExecuting_LoggingEnabled_RoutedEndpoint_ReportsRouteTemplate()
@@ -447,6 +542,25 @@ namespace Microsoft.AspNet.OData.Test.Query
                 metadata: EndpointMetadataCollection.Empty,
                 displayName: "Customers");
             var context = CreateQueryValidationActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider), endpoint);
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal("odata/Customers({key})", entry.GetFieldValue("Endpoint"));
+        }
+#endif
+
+#if NETCOREAPP2_1
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_RoutedEndpoint_ReportsRouteTemplate()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider), routedEndpoint: true);
 
             // Act
             attribute.OnActionExecuting(context);
@@ -754,6 +868,20 @@ namespace Microsoft.AspNet.OData.Test.Query
             return new ODataModelBuilder().Add_Customers_EntitySet().GetEdmModel();
         }
 
+        private static IEdmModel GetLoggingCustomerOrdersModel()
+        {
+            // A model where Customer.Orders is a valid, bound navigation property to the Orders entity set. This lets
+            // the outer $expand/$filter clause bind successfully so that only the nested clause (a $select/$filter on
+            // Order, or an any/all lambda over Orders) is what fails validation, exercising the nested query paths.
+            return new ODataModelBuilder()
+                .Add_Order_EntityType()
+                .Add_Customers_EntitySet()
+                .Add_Orders_EntitySet()
+                .Add_CustomerOrders_Relationship()
+                .Add_CustomerOrders_Binding()
+                .GetEdmModel();
+        }
+
         private static IServiceProvider BuildLoggerServices(CapturingLoggerProvider loggerProvider)
         {
             return BuildLoggerServices(loggerProvider, LogLevel.Trace, null);
@@ -803,13 +931,13 @@ namespace Microsoft.AspNet.OData.Test.Query
         }
 
 #if NETCOREAPP2_1
-        private ActionExecutingContext CreateQueryValidationActionExecutingContext(string queryString, IServiceProvider requestServices)
+        private ActionExecutingContext CreateQueryValidationActionExecutingContext(string queryString, IServiceProvider requestServices, bool routedEndpoint = false, bool collectionEndpoint = false, IEdmModel model = null)
 #else
-        private ActionExecutingContext CreateQueryValidationActionExecutingContext(string queryString, IServiceProvider requestServices, Endpoint routeEndpoint = null)
+        private ActionExecutingContext CreateQueryValidationActionExecutingContext(string queryString, IServiceProvider requestServices, Endpoint routeEndpoint = null, bool collectionEndpoint = false, IEdmModel model = null)
 #endif
         {
             var routeName = "querylogging";
-            IEdmModel model = GetLoggingCustomerModel();
+            model = model ?? GetLoggingCustomerModel();
 
             var customers = model.EntityContainer.FindEntitySet("Customers");
             var path = new ODataPath(new Microsoft.OData.UriParser.EntitySetSegment(customers));
@@ -830,6 +958,37 @@ namespace Microsoft.AspNet.OData.Test.Query
             if (routeEndpoint != null)
             {
                 httpContext.SetEndpoint(routeEndpoint);
+            }
+            else if (collectionEndpoint)
+            {
+                // Collection endpoint (no key). Attach a routed endpoint whose route pattern is the collection
+                // template so the diagnostic reports "odata/Customers" for a query over the Customers collection.
+                httpContext.SetEndpoint(new RouteEndpoint(
+                    ctx => System.Threading.Tasks.Task.CompletedTask,
+                    Microsoft.AspNetCore.Routing.Patterns.RoutePatternFactory.Parse("odata/Customers"),
+                    order: 0,
+                    metadata: EndpointMetadataCollection.Empty,
+                    displayName: "Customers"));
+            }
+#else
+            if (routedEndpoint)
+            {
+                // Targets that predate endpoint routing expose the matched OData endpoint through the request's
+                // ODataFeature rather than an Endpoint object. Populate the parsed path (entity set + key) and the
+                // route prefix the way the classic OData router does, so the diagnostic reconstructs the same
+                // "odata/Customers({key})" template produced from the endpoint route pattern on later targets.
+                var keySegment = new Microsoft.OData.UriParser.KeySegment(
+                    new[] { new KeyValuePair<string, object>("CustomerId", 1) },
+                    customers.EntityType(),
+                    customers);
+                request.ODataFeature().Path = new ODataPath(new Microsoft.OData.UriParser.EntitySetSegment(customers), keySegment);
+                request.ODataFeature().RoutePrefix = "odata";
+            }
+            else if (collectionEndpoint)
+            {
+                // Collection endpoint (no key). Keep the entity-set (keyless) path and just set the route prefix, so
+                // the diagnostic reconstructs the collection template "odata/Customers" for the same request.
+                request.ODataFeature().RoutePrefix = "odata";
             }
 #endif
 

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/EnableQueryAttributeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/EnableQueryAttributeTest.cs
@@ -697,6 +697,56 @@ namespace Microsoft.AspNet.OData.Test.Query
             Assert.IsType<BadRequestObjectResult>(context.Result);
         }
 
+        [Fact]
+        public void OnActionExecuted_LoggingEnabled_PostActionValidationFailure_WritesDiagnostic()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+
+            // Seed the per-request state, but clear the OData path so the pre-action validation is skipped and the
+            // query is instead validated after the action runs - the path taken for IActionResult/SingleResult
+            // actions whose element type is only known once the result is produced.
+            var executingContext = CreateQueryValidationActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider));
+            executingContext.HttpContext.Request.ODataFeature().Path = null;
+            attribute.OnActionExecuting(executingContext);
+            Assert.Null(executingContext.Result);
+            Assert.Empty(loggerProvider.Entries);
+
+            // The controller result whose element type (Customer) becomes known only now drives post-action
+            // validation. The element type must match the model registered on the request (the logging model is
+            // built from the TestModels Customer), so the query is validated against that type instead of falling
+            // back to a model built from the action descriptor.
+            HttpContext httpContext = executingContext.HttpContext;
+            ActionDescriptor actionDescriptor = ControllerDescriptorFactory
+                .Create(RoutingConfigurationFactory.Create(), "CustomersController", typeof(CustomersController))
+                .First(descriptor => descriptor.ActionName.StartsWith("Get", StringComparison.OrdinalIgnoreCase));
+            var customers = new List<Microsoft.AspNet.OData.Test.Builder.TestModels.Customer>
+            {
+                new Microsoft.AspNet.OData.Test.Builder.TestModels.Customer { Name = "Anne" }
+            }.AsQueryable();
+            var executedContext = new ActionExecutedContext(
+                new ActionContext(httpContext, new RouteData(), actionDescriptor),
+                new List<IFilterMetadata>(),
+                new CustomersController())
+            {
+                Result = new ObjectResult(customers) { StatusCode = 200 }
+            };
+
+            // Act
+            attribute.OnActionExecuted(executedContext);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(executedContext.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal(LogLevel.Warning, entry.Level);
+            Assert.Equal(typeof(EnableQueryAttribute).FullName, entry.Category);
+            Assert.Contains("Customer", entry.GetFieldValue("QueryType"));
+            Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+            Assert.Contains("NoSuchProperty", entry.GetFieldValue("Reason"));
+            Assert.NotNull(entry.Exception);
+        }
+
         private static IEdmModel GetLoggingCustomerModel()
         {
             return new ODataModelBuilder().Add_Customers_EntitySet().GetEdmModel();

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/EnableQueryAttributeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/EnableQueryAttributeTest.cs
@@ -433,6 +433,7 @@ namespace Microsoft.AspNet.OData.Test.Query
             Assert.Contains("NoSuchNavigation", entry.GetFieldValue("Reason"));
         }
 
+#if !NETCOREAPP2_1
         [Fact]
         public void OnActionExecuting_LoggingEnabled_RoutedEndpoint_ReportsRouteTemplate()
         {
@@ -455,6 +456,7 @@ namespace Microsoft.AspNet.OData.Test.Query
             var entry = Assert.Single(loggerProvider.Entries);
             Assert.Equal("odata/Customers({key})", entry.GetFieldValue("Endpoint"));
         }
+#endif
 
         [Fact]
         public void OnActionExecuting_DefaultConfiguration_WritesNothing()
@@ -800,7 +802,11 @@ namespace Microsoft.AspNet.OData.Test.Query
             return services.BuildServiceProvider();
         }
 
+#if NETCOREAPP2_1
+        private ActionExecutingContext CreateQueryValidationActionExecutingContext(string queryString, IServiceProvider requestServices)
+#else
         private ActionExecutingContext CreateQueryValidationActionExecutingContext(string queryString, IServiceProvider requestServices, Endpoint routeEndpoint = null)
+#endif
         {
             var routeName = "querylogging";
             IEdmModel model = GetLoggingCustomerModel();
@@ -820,10 +826,12 @@ namespace Microsoft.AspNet.OData.Test.Query
             HttpContext httpContext = request.HttpContext;
             httpContext.RequestServices = requestServices;
 
+#if !NETCOREAPP2_1
             if (routeEndpoint != null)
             {
                 httpContext.SetEndpoint(routeEndpoint);
             }
+#endif
 
             var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
             return new ActionExecutingContext(actionContext, new List<IFilterMetadata>(), new Dictionary<string, object>(), controller: new object());

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/EnableQueryAttributeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/EnableQueryAttributeTest.cs
@@ -572,6 +572,96 @@ namespace Microsoft.AspNet.OData.Test.Query
         }
 #endif
 
+#if !NETCOREAPP2_1
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_NavigationAfterKey_ReportsRouteTemplate()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var endpoint = new RouteEndpoint(
+                ctx => System.Threading.Tasks.Task.CompletedTask,
+                Microsoft.AspNetCore.Routing.Patterns.RoutePatternFactory.Parse("odata/Customers({key})/Orders"),
+                order: 0,
+                metadata: EndpointMetadataCollection.Empty,
+                displayName: "CustomerOrders");
+            var context = CreateQueryValidationActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider), endpoint);
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal("odata/Customers({key})/Orders", entry.GetFieldValue("Endpoint"));
+        }
+#endif
+
+#if NETCOREAPP2_1
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_NavigationAfterKey_ReportsRouteTemplate()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var model = GetLoggingCustomerOrdersModel();
+            var context = CreateQueryValidationActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider), model: model);
+            var odataFeature = context.HttpContext.ODataFeature();
+            odataFeature.Path = BuildCustomersOrdersPath(model, includeOrderKey: false);
+            odataFeature.RoutePrefix = "odata";
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal("odata/Customers({key})/Orders", entry.GetFieldValue("Endpoint"));
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_KeyOnNavigation_ReportsRouteTemplate()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var model = GetLoggingCustomerOrdersModel();
+            var context = CreateQueryValidationActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider), model: model);
+            var odataFeature = context.HttpContext.ODataFeature();
+            odataFeature.Path = BuildCustomersOrdersPath(model, includeOrderKey: true);
+            odataFeature.RoutePrefix = "odata";
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal("odata/Customers({key})/Orders({key})", entry.GetFieldValue("Endpoint"));
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_NoRoutePrefix_ReportsRouteTemplate()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var model = GetLoggingCustomerOrdersModel();
+            var context = CreateQueryValidationActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider), model: model);
+            var odataFeature = context.HttpContext.ODataFeature();
+            odataFeature.Path = BuildCustomersOrdersPath(model, includeOrderKey: false);
+            odataFeature.RoutePrefix = null;
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal("Customers({key})/Orders", entry.GetFieldValue("Endpoint"));
+        }
+#endif
+
         [Fact]
         public void OnActionExecuting_DefaultConfiguration_WritesNothing()
         {
@@ -870,9 +960,8 @@ namespace Microsoft.AspNet.OData.Test.Query
 
         private static IEdmModel GetLoggingCustomerOrdersModel()
         {
-            // A model where Customer.Orders is a valid, bound navigation property to the Orders entity set. This lets
-            // the outer $expand/$filter clause bind successfully so that only the nested clause (a $select/$filter on
-            // Order, or an any/all lambda over Orders) is what fails validation, exercising the nested query paths.
+            // Customer.Orders is a bound navigation to the Orders set, so the outer clause binds and only the nested
+            // clause (a $select/$filter on Order, or an any/all lambda over Orders) fails validation.
             return new ODataModelBuilder()
                 .Add_Order_EntityType()
                 .Add_Customers_EntitySet()
@@ -881,6 +970,34 @@ namespace Microsoft.AspNet.OData.Test.Query
                 .Add_CustomerOrders_Binding()
                 .GetEdmModel();
         }
+
+#if NETCOREAPP2_1
+        // Builds a multi-segment OData path (Customers(1)/Orders[(5)]) for endpoint-template reconstruction tests.
+        private static ODataPath BuildCustomersOrdersPath(IEdmModel model, bool includeOrderKey)
+        {
+            var customers = model.EntityContainer.FindEntitySet("Customers");
+            var orders = model.EntityContainer.FindEntitySet("Orders");
+            var ordersProperty = customers.EntityType().FindProperty("Orders") as IEdmNavigationProperty;
+
+            var entitySetSegment = new Microsoft.OData.UriParser.EntitySetSegment(customers);
+            var customerKeySegment = new Microsoft.OData.UriParser.KeySegment(
+                new[] { new KeyValuePair<string, object>("CustomerId", 1) },
+                customers.EntityType(),
+                customers);
+            var ordersSegment = new Microsoft.OData.UriParser.NavigationPropertySegment(ordersProperty, orders);
+
+            if (includeOrderKey)
+            {
+                var orderKeySegment = new Microsoft.OData.UriParser.KeySegment(
+                    new[] { new KeyValuePair<string, object>("OrderId", 5) },
+                    orders.EntityType(),
+                    orders);
+                return new ODataPath(entitySetSegment, customerKeySegment, ordersSegment, orderKeySegment);
+            }
+
+            return new ODataPath(entitySetSegment, customerKeySegment, ordersSegment);
+        }
+#endif
 
         private static IServiceProvider BuildLoggerServices(CapturingLoggerProvider loggerProvider)
         {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/EnableQueryAttributeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/EnableQueryAttributeTest.cs
@@ -416,6 +416,47 @@ namespace Microsoft.AspNet.OData.Test.Query
         }
 
         [Fact]
+        public void OnActionExecuting_LoggingEnabled_UnknownExpandWithSelect_ReportsCombinedQueryOptions()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext("?$select=Name&$expand=NoSuchNavigation", BuildLoggerServices(loggerProvider));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal("$select=Name&$expand=NoSuchNavigation", entry.GetFieldValue("QueryOptions"));
+            Assert.Contains("NoSuchNavigation", entry.GetFieldValue("Reason"));
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_RoutedEndpoint_ReportsRouteTemplate()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var endpoint = new RouteEndpoint(
+                ctx => System.Threading.Tasks.Task.CompletedTask,
+                Microsoft.AspNetCore.Routing.Patterns.RoutePatternFactory.Parse("odata/Customers({key})"),
+                order: 0,
+                metadata: EndpointMetadataCollection.Empty,
+                displayName: "Customers");
+            var context = CreateQueryValidationActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider), endpoint);
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal("odata/Customers({key})", entry.GetFieldValue("Endpoint"));
+        }
+
+        [Fact]
         public void OnActionExecuting_DefaultConfiguration_WritesNothing()
         {
             // Arrange
@@ -709,7 +750,7 @@ namespace Microsoft.AspNet.OData.Test.Query
             return services.BuildServiceProvider();
         }
 
-        private ActionExecutingContext CreateQueryValidationActionExecutingContext(string queryString, IServiceProvider requestServices)
+        private ActionExecutingContext CreateQueryValidationActionExecutingContext(string queryString, IServiceProvider requestServices, Endpoint routeEndpoint = null)
         {
             var routeName = "querylogging";
             IEdmModel model = GetLoggingCustomerModel();
@@ -728,6 +769,11 @@ namespace Microsoft.AspNet.OData.Test.Query
 
             HttpContext httpContext = request.HttpContext;
             httpContext.RequestServices = requestServices;
+
+            if (routeEndpoint != null)
+            {
+                httpContext.SetEndpoint(routeEndpoint);
+            }
 
             var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
             return new ActionExecutingContext(actionContext, new List<IFilterMetadata>(), new Dictionary<string, object>(), controller: new object());

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/EnableQueryAttributeTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/EnableQueryAttributeTest.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Microsoft.AspNet.OData.Builder;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Query;
 using Microsoft.AspNet.OData.Routing;
@@ -23,6 +24,7 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Xunit;
@@ -340,6 +342,398 @@ namespace Microsoft.AspNet.OData.Test.Query
         {
             ExceptionAssert.ThrowsArgumentNull(() => new EnableQueryAttribute().OnActionExecuting(null), "context");
         }
+
+        #region Query validation error logging (opt-in diagnostics)
+
+        [Fact]
+        public void EnableQueryValidationErrorLogging_DefaultsToFalse()
+        {
+            // Arrange & Act
+            var attribute = new EnableQueryAttribute();
+
+            // Assert
+            Assert.False(attribute.EnableQueryValidationErrorLogging);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_UnknownSelect_WritesDiagnostic()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal(LogLevel.Warning, entry.Level);
+            Assert.Equal(typeof(EnableQueryAttribute).FullName, entry.Category);
+            Assert.Contains("Customer", entry.GetFieldValue("QueryType"));
+            Assert.Equal("$select=NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+            Assert.Contains("NoSuchProperty", entry.GetFieldValue("Reason"));
+            Assert.NotNull(entry.Exception);
+            Assert.Contains("NoSuchProperty", entry.Exception.Message);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_UnknownExpand_WritesDiagnostic()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext("?$expand=NoSuchNavigation", BuildLoggerServices(loggerProvider));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal(LogLevel.Warning, entry.Level);
+            Assert.Equal("$expand=NoSuchNavigation", entry.GetFieldValue("QueryOptions"));
+            Assert.Contains("NoSuchNavigation", entry.GetFieldValue("Reason"));
+            Assert.NotNull(entry.Exception);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_ReportsFullRequestedSelectSet()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext("?$select=Name,NoSuchProperty", BuildLoggerServices(loggerProvider));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal("$select=Name,NoSuchProperty", entry.GetFieldValue("QueryOptions"));
+        }
+
+        [Fact]
+        public void OnActionExecuting_DefaultConfiguration_WritesNothing()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute();
+            var context = CreateQueryValidationActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            Assert.Empty(loggerProvider.Entries);
+        }
+
+        [Fact]
+        public void OnActionExecuting_GlobalOptionEnabled_WritesDiagnostic()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute();
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$select=NoSuchProperty",
+                BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnable: true));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal(LogLevel.Warning, entry.Level);
+            Assert.Contains("NoSuchProperty", entry.GetFieldValue("Reason"));
+        }
+
+        [Fact]
+        public void OnActionExecuting_GlobalEnabled_AttributeOptOut_WritesNothing()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = false };
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$select=NoSuchProperty",
+                BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnable: true));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            Assert.Empty(loggerProvider.Entries);
+        }
+
+        [Fact]
+        public void OnActionExecuting_GlobalDisabled_AttributeEnabled_WritesDiagnostic()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$select=NoSuchProperty",
+                BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnable: false));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            Assert.Single(loggerProvider.Entries);
+        }
+
+        [Fact]
+        public void OnActionExecuting_AttributeDisabled_WritesNothing()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = false };
+            var context = CreateQueryValidationActionExecutingContext("?$select=NoSuchProperty", BuildLoggerServices(loggerProvider));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            Assert.Empty(loggerProvider.Entries);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_ValidSelect_WritesNothing()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext("?$select=Name", BuildLoggerServices(loggerProvider));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.Null(context.Result);
+            Assert.Empty(loggerProvider.Entries);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_NoQueryOptions_WritesNothing()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext(string.Empty, BuildLoggerServices(loggerProvider));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.Null(context.Result);
+            Assert.Empty(loggerProvider.Entries);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_NoLoggerRegistered_DoesNotThrow_AndReturnsBadRequest()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddSingleton(new ODataOptions());
+            IServiceProvider requestServices = services.BuildServiceProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext("?$select=NoSuchProperty", requestServices);
+
+            // Act & Assert
+            ExceptionAssert.DoesNotThrow(() => attribute.OnActionExecuting(context));
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_WarningLevelDisabled_WritesNothing()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$select=NoSuchProperty",
+                BuildLoggerServices(loggerProvider, minimumLevel: LogLevel.Error));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            Assert.Empty(loggerProvider.Entries);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_CustomLogLevel_WritesAtConfiguredLevel()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$select=NoSuchProperty",
+                BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnable: false, globalLevel: LogLevel.Error));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal(LogLevel.Error, entry.Level);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_InformationLevel_WritesAtInformation()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$select=NoSuchProperty",
+                BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnable: false, globalLevel: LogLevel.Information));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal(LogLevel.Information, entry.Level);
+        }
+
+        [Fact]
+        public void OnActionExecuting_GlobalEnabled_UsesGlobalLogLevel()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute();
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$select=NoSuchProperty",
+                BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnable: true, globalLevel: LogLevel.Debug));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            var entry = Assert.Single(loggerProvider.Entries);
+            Assert.Equal(LogLevel.Debug, entry.Level);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_CustomLevelDisabled_WritesNothing()
+        {
+            // Arrange
+            var loggerProvider = new CapturingLoggerProvider();
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$select=NoSuchProperty",
+                BuildLoggerServicesWithGlobalOption(loggerProvider, globalEnable: false, globalLevel: LogLevel.Information, minimumLevel: LogLevel.Warning));
+
+            // Act
+            attribute.OnActionExecuting(context);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+            Assert.Empty(loggerProvider.Entries);
+        }
+
+        [Fact]
+        public void OnActionExecuting_LoggingEnabled_LoggerThrows_ResponseUnchanged()
+        {
+            // Arrange
+            var throwingProvider = new ThrowingLoggerProvider(typeof(EnableQueryAttribute).FullName);
+            var attribute = new EnableQueryAttribute { EnableQueryValidationErrorLogging = true };
+            var context = CreateQueryValidationActionExecutingContext(
+                "?$select=NoSuchProperty",
+                BuildThrowingLoggerServices(throwingProvider));
+
+            // Act & Assert
+            ExceptionAssert.DoesNotThrow(() => attribute.OnActionExecuting(context));
+            Assert.IsType<BadRequestObjectResult>(context.Result);
+        }
+
+        private static IEdmModel GetLoggingCustomerModel()
+        {
+            return new ODataModelBuilder().Add_Customers_EntitySet().GetEdmModel();
+        }
+
+        private static IServiceProvider BuildLoggerServices(CapturingLoggerProvider loggerProvider)
+        {
+            return BuildLoggerServices(loggerProvider, LogLevel.Trace, null);
+        }
+
+        private static IServiceProvider BuildLoggerServices(CapturingLoggerProvider loggerProvider, LogLevel minimumLevel)
+        {
+            return BuildLoggerServices(loggerProvider, minimumLevel, null);
+        }
+
+        private static IServiceProvider BuildLoggerServices(CapturingLoggerProvider loggerProvider, LogLevel minimumLevel, ODataOptions odataOptions)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging(builder =>
+            {
+                builder.SetMinimumLevel(minimumLevel);
+                builder.AddProvider(loggerProvider);
+            });
+            services.AddSingleton(odataOptions ?? new ODataOptions());
+            return services.BuildServiceProvider();
+        }
+
+        private static IServiceProvider BuildLoggerServicesWithGlobalOption(CapturingLoggerProvider loggerProvider, bool globalEnable, LogLevel? globalLevel = null, LogLevel minimumLevel = LogLevel.Trace)
+        {
+            var odataOptions = new ODataOptions
+            {
+                EnableQueryValidationErrorLogging = globalEnable
+            };
+            if (globalLevel.HasValue)
+            {
+                odataOptions.QueryValidationErrorLogLevel = globalLevel.Value;
+            }
+
+            return BuildLoggerServices(loggerProvider, minimumLevel, odataOptions);
+        }
+
+        private static IServiceProvider BuildThrowingLoggerServices(ThrowingLoggerProvider loggerProvider)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging(builder =>
+            {
+                builder.SetMinimumLevel(LogLevel.Trace);
+                builder.AddProvider(loggerProvider);
+            });
+            services.AddSingleton(new ODataOptions());
+            return services.BuildServiceProvider();
+        }
+
+        private ActionExecutingContext CreateQueryValidationActionExecutingContext(string queryString, IServiceProvider requestServices)
+        {
+            var routeName = "querylogging";
+            IEdmModel model = GetLoggingCustomerModel();
+
+            var customers = model.EntityContainer.FindEntitySet("Customers");
+            var path = new ODataPath(new Microsoft.OData.UriParser.EntitySetSegment(customers));
+
+            var request = RequestFactory.CreateFromModel(model, "http://localhost/odata/Customers" + queryString, routeName, path);
+
+            // Enable $select and $expand so the requested clause is bound during validation (which then reports the
+            // unknown property) instead of being rejected outright as a disallowed option.
+            var configuration = RoutingConfigurationFactory.Create();
+            configuration.Select().Expand().Filter().OrderBy().Count();
+            IServiceProvider odataContainer = GetServiceProvider(configuration, model, routeName);
+            request.ODataFeature().RequestContainer = odataContainer;
+
+            HttpContext httpContext = request.HttpContext;
+            httpContext.RequestServices = requestServices;
+
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+            return new ActionExecutingContext(actionContext, new List<IFilterMetadata>(), new Dictionary<string, object>(), controller: new object());
+        }
+
+        #endregion
 #endif
 
 #if !NETCORE // TODO #939: Enable these test on AspNetCore.

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/TestCommon/CapturingLoggerProvider.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/TestCommon/CapturingLoggerProvider.cs
@@ -1,0 +1,152 @@
+//-----------------------------------------------------------------------------
+// <copyright file="CapturingLoggerProvider.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+#if NETCORE
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNet.OData.Test.Common
+{
+    /// <summary>
+    /// An <see cref="ILoggerProvider"/> that captures every log entry it receives so tests can assert on the
+    /// category, level, formatted message, and the individual structured fields that were logged.
+    /// </summary>
+    public sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<CapturedLogEntry> _entries = new ConcurrentQueue<CapturedLogEntry>();
+
+        /// <summary>
+        /// Gets a snapshot of the log entries captured so far.
+        /// </summary>
+        public IReadOnlyList<CapturedLogEntry> Entries => _entries.ToArray();
+
+        /// <summary>
+        /// Removes all captured entries.
+        /// </summary>
+        public void Clear()
+        {
+            while (_entries.TryDequeue(out _))
+            {
+            }
+        }
+
+        /// <inheritdoc/>
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new CapturingLogger(categoryName, _entries);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+        }
+
+        private sealed class CapturingLogger : ILogger
+        {
+            private readonly string _categoryName;
+            private readonly ConcurrentQueue<CapturedLogEntry> _entries;
+
+            public CapturingLogger(string categoryName, ConcurrentQueue<CapturedLogEntry> entries)
+            {
+                _categoryName = categoryName;
+                _entries = entries;
+            }
+
+            public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                Dictionary<string, object> fields = new Dictionary<string, object>();
+                if (state is IReadOnlyList<KeyValuePair<string, object>> structuredState)
+                {
+                    foreach (KeyValuePair<string, object> pair in structuredState)
+                    {
+                        fields[pair.Key] = pair.Value;
+                    }
+                }
+
+                CapturedLogEntry entry = new CapturedLogEntry
+                {
+                    Category = _categoryName,
+                    Level = logLevel,
+                    EventId = eventId,
+                    Message = formatter != null ? formatter(state, exception) : null,
+                    Exception = exception,
+                    Fields = fields
+                };
+
+                _entries.Enqueue(entry);
+            }
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+
+                public void Dispose()
+                {
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// A single captured log entry.
+    /// </summary>
+    public sealed class CapturedLogEntry
+    {
+        /// <summary>
+        /// Gets or sets the logger category name.
+        /// </summary>
+        public string Category { get; set; }
+
+        /// <summary>
+        /// Gets or sets the log level.
+        /// </summary>
+        public LogLevel Level { get; set; }
+
+        /// <summary>
+        /// Gets or sets the event id.
+        /// </summary>
+        public EventId EventId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the formatted message.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the exception associated with the entry, if any.
+        /// </summary>
+        public Exception Exception { get; set; }
+
+        /// <summary>
+        /// Gets or sets the structured fields captured from the log state.
+        /// </summary>
+        public IReadOnlyDictionary<string, object> Fields { get; set; }
+
+        /// <summary>
+        /// Gets the string value of a structured field, or <c>null</c> when the field is not present.
+        /// </summary>
+        /// <param name="name">The field name.</param>
+        /// <returns>The field value as a string, or <c>null</c>.</returns>
+        public string GetFieldValue(string name)
+        {
+            if (Fields != null && Fields.TryGetValue(name, out object value))
+            {
+                return value?.ToString();
+            }
+
+            return null;
+        }
+    }
+}
+#endif

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/TestCommon/ThrowingLoggerProvider.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/TestCommon/ThrowingLoggerProvider.cs
@@ -1,0 +1,84 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ThrowingLoggerProvider.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+#if NETCORE
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNet.OData.Test.Common
+{
+    /// <summary>
+    /// An <see cref="ILoggerProvider"/> whose logger throws when it writes an entry, so tests can verify that a
+    /// misbehaving logging sink never changes the outcome of the request. By default it throws for every category;
+    /// pass a category name to throw only for that category and act as a no-op for all others, which keeps the rest
+    /// of the framework's logging working while still failing the write under test.
+    /// </summary>
+    public sealed class ThrowingLoggerProvider : ILoggerProvider
+    {
+        private readonly string _throwForCategory;
+        private readonly string _message;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThrowingLoggerProvider"/> class.
+        /// </summary>
+        /// <param name="throwForCategory">
+        /// The category the logger throws for, or <c>null</c> to throw for every category.
+        /// </param>
+        /// <param name="message">The message of the thrown exception.</param>
+        public ThrowingLoggerProvider(string throwForCategory = null, string message = "Simulated logging sink failure.")
+        {
+            _throwForCategory = throwForCategory;
+            _message = message;
+        }
+
+        /// <inheritdoc/>
+        public ILogger CreateLogger(string categoryName)
+        {
+            bool shouldThrow = _throwForCategory == null || string.Equals(categoryName, _throwForCategory, StringComparison.Ordinal);
+            return new ThrowingLogger(_message, shouldThrow);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+        }
+
+        private sealed class ThrowingLogger : ILogger
+        {
+            private readonly string _message;
+            private readonly bool _shouldThrow;
+
+            public ThrowingLogger(string message, bool shouldThrow)
+            {
+                _message = message;
+                _shouldThrow = shouldThrow;
+            }
+
+            public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                if (_shouldThrow)
+                {
+                    throw new InvalidOperationException(_message);
+                }
+            }
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+
+                public void Dispose()
+                {
+                }
+            }
+        }
+    }
+}
+#endif

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore.OData.PublicApi.bsl
@@ -574,6 +574,7 @@ public class Microsoft.AspNet.OData.EnableQueryAttribute : Microsoft.AspNetCore.
 	AllowedQueryOptions AllowedQueryOptions  { public get; public set; }
 	bool EnableConstantParameterization  { public get; public set; }
 	bool EnableCorrelatedSubqueryBuffering  { public get; public set; }
+	bool EnableQueryValidationErrorLogging  { public get; public set; }
 	bool EnsureStableOrdering  { public get; public set; }
 	HandleNullPropagationOption HandleNullPropagation  { public get; public set; }
 	bool HandleReferenceNavigationPropertyExpandFilter  { public get; public set; }
@@ -703,8 +704,10 @@ public class Microsoft.AspNet.OData.ODataOptions {
 
 	CompatibilityOptions CompatibilityOptions  { public get; public set; }
 	bool EnableContinueOnErrorHeader  { public get; public set; }
+	bool EnableQueryValidationErrorLogging  { public get; public set; }
 	long MaxReceivedMessageSize  { public get; public set; }
 	bool NullDynamicPropertyIsEnabled  { public get; public set; }
+	Microsoft.Extensions.Logging.LogLevel QueryValidationErrorLogLevel  { public get; public set; }
 	Microsoft.OData.ODataUrlKeyDelimiter UrlKeyDelimiter  { public get; public set; }
 }
 

--- a/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
+++ b/test/UnitTest/Microsoft.AspNetCore.OData.Test/PublicApi/Microsoft.AspNetCore3x.OData.PublicApi.bsl
@@ -578,6 +578,7 @@ public class Microsoft.AspNet.OData.EnableQueryAttribute : Microsoft.AspNetCore.
 	AllowedQueryOptions AllowedQueryOptions  { public get; public set; }
 	bool EnableConstantParameterization  { public get; public set; }
 	bool EnableCorrelatedSubqueryBuffering  { public get; public set; }
+	bool EnableQueryValidationErrorLogging  { public get; public set; }
 	bool EnsureStableOrdering  { public get; public set; }
 	HandleNullPropagationOption HandleNullPropagation  { public get; public set; }
 	bool HandleReferenceNavigationPropertyExpandFilter  { public get; public set; }
@@ -707,8 +708,10 @@ public class Microsoft.AspNet.OData.ODataOptions {
 
 	CompatibilityOptions CompatibilityOptions  { public get; public set; }
 	bool EnableContinueOnErrorHeader  { public get; public set; }
+	bool EnableQueryValidationErrorLogging  { public get; public set; }
 	long MaxReceivedMessageSize  { public get; public set; }
 	bool NullDynamicPropertyIsEnabled  { public get; public set; }
+	Microsoft.Extensions.Logging.LogLevel QueryValidationErrorLogLevel  { public get; public set; }
 	Microsoft.OData.ODataUrlKeyDelimiter UrlKeyDelimiter  { public get; public set; }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Ports the query-validation diagnostic logging feature [OData/AspNetCoreOData#1592](https://github.com/OData/AspNetCoreOData/pull/1592) to the ASP.NET Core WebApi stack.

### What's included
- `EnableQueryAttribute.EnableQueryValidationErrorLogging` to opt in per action.
- Global `ODataOptions.EnableQueryValidationErrorLogging` + `ODataOptions.QueryValidationErrorLogLevel` (default `Warning`); an explicit value on the attribute overrides the global value.
- New internal `QueryValidationErrorLogger` that emits the endpoint route template, queried type, attempted `$select`/`$expand`, and the failure reason together with the validation exception, categorized for `EnableQueryAttribute`.
- Diagnostics never change the response produced for the failed query.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
